### PR TITLE
Fix paint helper scope, adjust puyo sizing, and collapse ToDo lists

### DIFF
--- a/games/paint.js
+++ b/games/paint.js
@@ -74,6 +74,11 @@
     } catch {}
   }
 
+  function setImportantColor(element, color){
+    if (!element) return;
+    element.style.setProperty('color', color, 'important');
+  }
+
   function create(root, awardXp){
     if (!root) throw new Error('MiniExp Paint requires a container');
 
@@ -128,11 +133,6 @@
     let secondarySwatch;
     let primaryInput;
     let secondaryInput;
-
-    function setImportantColor(element, color){
-      if (!element) return;
-      element.style.setProperty('color', color, 'important');
-    }
 
     const wrapper = document.createElement('div');
     wrapper.style.width = '100%';

--- a/games/puyo.js
+++ b/games/puyo.js
@@ -246,7 +246,8 @@
       ctx.fillStyle = '#0b1120';
       ctx.fillRect(0,0,W,H);
       const margin = 24;
-      const cell = Math.floor((W - margin*2 - 140) / COLS);
+      const baseCell = Math.floor((W - margin*2 - 140) / COLS);
+      const cell = Math.max(12, Math.floor(baseCell * 0.5));
       const gridW = cell * COLS;
       const gridH = cell * ROWS;
       const ox = margin;

--- a/games/todo_list.js
+++ b/games/todo_list.js
@@ -68,6 +68,10 @@
       editingTaskId: null,
       sessionXp: 0
     };
+    const collapseState = {
+      pending: false,
+      completed: false
+    };
 
     const today = (() => {
       try {
@@ -268,6 +272,7 @@
     pendingTitle.style.fontSize = '18px';
     pendingTitle.style.color = '#b91c1c';
     const pendingList = document.createElement('div');
+    pendingList.id = 'todo_pending_list';
     pendingList.style.display = 'flex';
     pendingList.style.flexDirection = 'column';
     pendingList.style.gap = '12px';
@@ -282,12 +287,16 @@
     completedTitle.style.fontSize = '18px';
     completedTitle.style.color = '#6b7280';
     const completedList = document.createElement('div');
+    completedList.id = 'todo_completed_list';
     completedList.style.display = 'flex';
     completedList.style.flexDirection = 'column';
     completedList.style.gap = '12px';
 
     completedSection.appendChild(completedTitle);
     completedSection.appendChild(completedList);
+
+    const updatePendingVisibility = makeCollapsibleSection(pendingTitle, pendingList, 'pending');
+    const updateCompletedVisibility = makeCollapsibleSection(completedTitle, completedList, 'completed');
 
     listsWrap.appendChild(pendingSection);
     listsWrap.appendChild(completedSection);
@@ -353,6 +362,62 @@
       } else {
         done.forEach(task => completedList.appendChild(renderTaskCard(task)));
       }
+
+      updatePendingVisibility();
+      updateCompletedVisibility();
+    }
+
+    function makeCollapsibleSection(titleEl, listEl, key){
+      const labelText = titleEl.textContent;
+      const icon = document.createElement('span');
+      icon.textContent = '▼';
+      icon.style.display = 'inline-flex';
+      icon.style.alignItems = 'center';
+      icon.style.justifyContent = 'center';
+      icon.style.width = '18px';
+      icon.style.fontSize = '12px';
+      icon.style.color = titleEl.style.color || '#111827';
+
+      const label = document.createElement('span');
+      label.textContent = labelText;
+
+      titleEl.textContent = '';
+      titleEl.appendChild(icon);
+      titleEl.appendChild(label);
+      titleEl.style.display = 'flex';
+      titleEl.style.alignItems = 'center';
+      titleEl.style.gap = '6px';
+      titleEl.style.cursor = 'pointer';
+      titleEl.style.userSelect = 'none';
+      titleEl.tabIndex = 0;
+      titleEl.setAttribute('role', 'button');
+      if (!listEl.id){
+        listEl.id = `todo_section_${key}`;
+      }
+      titleEl.setAttribute('aria-controls', listEl.id);
+
+      function update(){
+        const collapsed = !!collapseState[key];
+        icon.textContent = collapsed ? '▶' : '▼';
+        listEl.style.display = collapsed ? 'none' : 'flex';
+        titleEl.setAttribute('aria-expanded', String(!collapsed));
+      }
+
+      function toggle(){
+        collapseState[key] = !collapseState[key];
+        update();
+      }
+
+      titleEl.addEventListener('click', toggle);
+      titleEl.addEventListener('keydown', event => {
+        if (event.key === 'Enter' || event.key === ' '){
+          event.preventDefault();
+          toggle();
+        }
+      });
+
+      update();
+      return update;
     }
 
     function renderTaskCard(task){


### PR DESCRIPTION
## Summary
- ensure the paint helper for important text colors is defined where toolbar buttons can use it
- shrink each puyo board cell so the playfield stays within the canvas frame
- allow ToDo list pending and completed sections to be collapsed from their headers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d292914c60832bb26dac85e58cde65