### PR TITLE
Fix floating puyos splitting on lock

### DIFF
--- a/games/puyo.js
+++ b/games/puyo.js
@@ -135,6 +135,7 @@
 
     function lockPiece(){
       placeCurrent();
+      applyGravity();
       current = null;
       fallTimer = 0;
       lockTimer = 0;


### PR DESCRIPTION
## Summary
- ensure gravity is applied immediately after locking a puyo pair so floating halves fall apart as expected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d29c87f7dc832b9a808ae0c25fbefe