### PR TITLE
Ensure BlockDim specs prefer concrete type when unanimous

### DIFF
--- a/main.js
+++ b/main.js
@@ -449,7 +449,7 @@ function composeSpec(dim, b1, b2, b3, nested = 1) {
     // 新仕様: タイプはブロック由来の組み合わせで混合させる
     const pool = [b1.type, b2.type, b3.type].filter(t => !!t);
     const uniquePool = Array.from(new Set(pool));
-    const type = uniquePool.length > 0 ? 'mixed' : 'mixed';
+    const type = uniquePool.length === 1 ? uniquePool[0] : 'mixed';
     const bossFloors = unionNormalize([b1.bossFloors, b2.bossFloors, b3.bossFloors]).filter(n => n>=1 && n<=depth);
     // typePool を追加して混合対象を明示（空ならデフォルト混合）
     return { level, sizeFactor, depth, chestBias, type, bossFloors, typePool: uniquePool };


### PR DESCRIPTION
## Summary
- update the BlockDim spec composer to emit the single available type while still tracking the pool
- keep mixed rendering for pools while allowing concrete type display when only one remains

## Testing
- node - <<'NODE' ...

------
https://chatgpt.com/codex/tasks/task_e_68d2a25aca30832bab8470452e5d9bc1