### PR TITLE
Adjust popup coordinates for steady wire game

### DIFF
--- a/games/steady_wire.js
+++ b/games/steady_wire.js
@@ -276,7 +276,10 @@
       if (window.showTransientPopupAt){
         try {
           const rect = canvas.getBoundingClientRect();
-          window.showTransientPopupAt(rect.left + player.x, rect.top + player.y, '+' + amount, { variant: 'combo', level: Math.min(5, checkpointsAwarded + 1) });
+          const wrapperRect = wrapper.getBoundingClientRect();
+          const x = rect.left + player.x - wrapperRect.left;
+          const y = rect.top + player.y - wrapperRect.top;
+          window.showTransientPopupAt(x, y, '+' + amount, { variant: 'combo', level: Math.min(5, checkpointsAwarded + 1) });
         } catch {}
       }
     }
@@ -292,7 +295,10 @@
       if (window.showTransientPopupAt){
         try {
           const rect = canvas.getBoundingClientRect();
-          window.showTransientPopupAt(rect.left + finishPoint.x, rect.top + finishPoint.y, '+' + amount, { variant: 'win' });
+          const wrapperRect = wrapper.getBoundingClientRect();
+          const x = rect.left + finishPoint.x - wrapperRect.left;
+          const y = rect.top + finishPoint.y - wrapperRect.top;
+          window.showTransientPopupAt(x, y, '+' + amount, { variant: 'win' });
         } catch {}
       }
     }


### PR DESCRIPTION
## Summary
- adjust transient popup coordinates in Steady Wire award handlers to account for the wrapper element

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d342f169e8832bb5c4015a996a88e7