### PR TITLE
Fix ensureTileMeta declaration typo

### DIFF
--- a/main.js
+++ b/main.js
@@ -318,7 +318,7 @@ function resetTileMetadata() {
     tileMeta = Array.from({ length: MAP_HEIGHT }, () => Array(MAP_WIDTH).fill(null));
 }
 
-ffunction ensureTileMeta(x, y) {
+function ensureTileMeta(x, y) {
     if (y < 0 || y >= MAP_HEIGHT || x < 0 || x >= MAP_WIDTH) return null;
     if (!tileMeta[y]) tileMeta[y] = Array(MAP_WIDTH).fill(null);
     if (!tileMeta[y][x]) tileMeta[y][x] = {};


### PR DESCRIPTION
## Summary
- fix a typo in the ensureTileMeta function declaration that caused a syntax error in main.js

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3ecf27984832bb5c9c3c95a9b8fdd