### PR TITLE
Fix clock hub timer continuing after quit

### DIFF
--- a/games/clock_hub.js
+++ b/games/clock_hub.js
@@ -851,18 +851,33 @@
       lastSegments = segments;
     }
 
-    timer = setInterval(update, UPDATE_INTERVAL);
-    state.running = true;
-    update();
-
-    function quit(){
-      if (!state.running) return;
-      clearInterval(timer);
-      state.running = false;
-      wrapper.remove();
+    function start(){
+      if (state.running) return;
+      state.running = true;
+      timer = setInterval(update, UPDATE_INTERVAL);
+      lastSegments = null;
+      update();
     }
 
-    return { quit };
+    function stop(){
+      if (!state.running) return;
+      state.running = false;
+      if (timer){
+        clearInterval(timer);
+        timer = null;
+      }
+    }
+
+    function destroy(){
+      stop();
+      try { wrapper.remove(); } catch {}
+    }
+
+    function quit(){
+      destroy();
+    }
+
+    return { start, stop, destroy, quit };
   }
 
   window.registerMiniGame({


### PR DESCRIPTION
## Summary
- add explicit start/stop/destroy lifecycle handlers to the clock hub mini-game
- ensure the internal timer is cleared when the mini-game stops or is destroyed
- reset XP tracking state when restarting so the timer does not keep running after exit

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3f1ead2b0832bb91f897708b3a35a