### PR TITLE
Format best score display to two decimals

### DIFF
--- a/main.js
+++ b/main.js
@@ -6494,7 +6494,8 @@ function renderMiniExpRecords() {
     const totalExpRaw = rec?.totalExpEarned ?? 0;
     const totalExp = Math.floor(totalExpRaw);
     const totalExpText = totalExp > 0 ? `+${totalExp}` : String(totalExp);
-    box.appendChild(mk('ベストスコア', String(best)));
+    const formattedBest = Number.isFinite(best) ? best.toFixed(2) : String(best);
+    box.appendChild(mk('ベストスコア', formattedBest));
     box.appendChild(mk('通算プレイ', String(plays)));
     box.appendChild(mk('通算獲得EXP', totalExpText));
 }


### PR DESCRIPTION
## Summary
- format the mini game record card best score value to show two decimal places when numeric

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d53e8e68ac832b8016b9d98e5d4b91