### PR TITLE
Add mini game selection display mode options

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,6 +152,7 @@
                 <div class="row">
                     <div class="miniexp-layout">
                         <div id="miniexp-cat-list" class="miniexp-cat-list" role="listbox" aria-label="カテゴリ一覧" tabindex="0"></div>
+                        <div id="miniexp-display-modes" class="miniexp-display-toolbar" role="group" aria-label="表示形式"></div>
                         <div id="miniexp-list" class="miniexp-list" role="listbox" aria-label="ミニゲーム一覧" tabindex="0"></div>
                         <div class="miniexp-panel">
                             <div class="miniexp-toolbar">

--- a/main.js
+++ b/main.js
@@ -67,6 +67,7 @@ const miniexpPauseBtn = document.getElementById('miniexp-pause');
 const miniexpRestartBtn = document.getElementById('miniexp-restart');
 const miniexpDifficulty = document.getElementById('miniexp-difficulty');
 const miniexpContainer = document.getElementById('miniexp-container');
+const miniexpDisplayModes = document.getElementById('miniexp-display-modes');
 // BlockDim UI elements
 // BlockDim listbox UI elements
 const bdimDimList = document.getElementById('bdim-list-dimension');
@@ -116,7 +117,13 @@ const VIEWPORT_HEIGHT = 15;
 let currentMode = 'normal';
 // MiniExp state (mods)
 const MINI_ALL_CATEGORY = '__ALL__';
-let miniExpState = { selected: null, difficulty: 'NORMAL', records: {}, category: MINI_ALL_CATEGORY };
+const MINI_EXP_DISPLAY_MODES = [
+    { id: 'tile', label: 'タイル' },
+    { id: 'list', label: 'リスト' },
+    { id: 'wrap', label: '羅列' },
+    { id: 'detail', label: '詳細' }
+];
+let miniExpState = { selected: null, difficulty: 'NORMAL', records: {}, category: MINI_ALL_CATEGORY, displayMode: 'detail' };
 let __miniExpInited = false;
 let __miniManifest = null; // [{id,name,entry,version,author,icon,description}]
 let __miniGameRegistry = {}; // id -> def
@@ -5725,7 +5732,10 @@ importFileInput && importFileInput.addEventListener('change', async (e) => {
         __lastSavedBlockDimSelectionKey = snapshotBlockDimSelection(blockDimState);
         if (Array.isArray(data.blockDimHistory)) blockDimHistory = data.blockDimHistory;
         if (Array.isArray(data.blockDimBookmarks)) blockDimBookmarks = data.blockDimBookmarks;
-        if (data.miniExp) miniExpState = { selected: null, difficulty: 'NORMAL', records: {}, category: MINI_ALL_CATEGORY, ...data.miniExp };
+        if (data.miniExp) {
+            miniExpState = { selected: null, difficulty: 'NORMAL', records: {}, category: MINI_ALL_CATEGORY, displayMode: 'detail', ...data.miniExp };
+            miniExpState.displayMode = normalizeMiniExpDisplayMode(miniExpState.displayMode);
+        }
         buildSelection();
         renderHistoryAndBookmarks();
         // インポート後は選択画面に戻す（モードは保存値を尊重）
@@ -5820,7 +5830,11 @@ try {
         __lastSavedBlockDimSelectionKey = snapshotBlockDimSelection(blockDimState);
         if (Array.isArray(data.blockDimHistory)) blockDimHistory = data.blockDimHistory;
         if (Array.isArray(data.blockDimBookmarks)) blockDimBookmarks = data.blockDimBookmarks;
-        
+        if (data.miniExp) {
+            miniExpState = { selected: null, difficulty: 'NORMAL', records: {}, category: MINI_ALL_CATEGORY, displayMode: 'detail', ...data.miniExp };
+            miniExpState.displayMode = normalizeMiniExpDisplayMode(miniExpState.displayMode);
+        }
+
         // Initialize previous values to current values to prevent false change indicators
         prevHp = player.hp || 100;
         prevExp = player.exp || 0;
@@ -6132,6 +6146,39 @@ function buildCategoryMap(manifest) {
     return map;
 }
 
+function normalizeMiniExpDisplayMode(mode) {
+    const fallback = 'detail';
+    if (!mode) return fallback;
+    return MINI_EXP_DISPLAY_MODES.some(opt => opt.id === mode) ? mode : fallback;
+}
+
+function getMiniExpDisplayMode() {
+    const normalized = normalizeMiniExpDisplayMode(miniExpState.displayMode);
+    if (miniExpState.displayMode !== normalized) miniExpState.displayMode = normalized;
+    return normalized;
+}
+
+function renderMiniExpDisplayModes(manifest) {
+    if (!miniexpDisplayModes) return;
+    const list = manifest || __miniManifest || [];
+    const current = getMiniExpDisplayMode();
+    miniexpDisplayModes.innerHTML = '';
+    MINI_EXP_DISPLAY_MODES.forEach(opt => {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'display-btn' + (current === opt.id ? ' active' : '');
+        btn.textContent = opt.label;
+        btn.addEventListener('click', () => {
+            if (miniExpState.displayMode === opt.id) return;
+            miniExpState.displayMode = opt.id;
+            renderMiniExpDisplayModes(list);
+            renderMiniExpList(list);
+            saveAll();
+        });
+        miniexpDisplayModes.appendChild(btn);
+    });
+}
+
 function renderMiniExpCategories(manifest) {
     if (!miniexpCatList) return;
     miniexpCatList.innerHTML = '';
@@ -6171,8 +6218,12 @@ function getFilteredManifest(manifest) {
 
 function renderMiniExpList(manifest) {
     if (!miniexpList) return;
+    const list = manifest || __miniManifest || [];
+    const mode = getMiniExpDisplayMode();
     miniexpList.innerHTML = '';
-    const filtered = getFilteredManifest(manifest);
+    miniexpList.classList.remove('mode-detail', 'mode-tile', 'mode-list', 'mode-wrap');
+    miniexpList.classList.add(`mode-${mode}`);
+    const filtered = getFilteredManifest(list);
     if (!filtered || filtered.length === 0) {
         const p = document.createElement('div');
         p.textContent = '該当カテゴリのミニゲームが見つかりません。games/ にミニゲームを追加してください。';
@@ -6180,22 +6231,39 @@ function renderMiniExpList(manifest) {
         return;
     }
     filtered.forEach(def => {
-        const card = document.createElement('div');
-        card.className = 'miniexp-card';
-        const h = document.createElement('h4'); h.textContent = def.name || def.id;
-        const d = document.createElement('div'); d.className = 'desc'; d.textContent = def.description || '';
-        const m = document.createElement('div'); m.className = 'meta'; m.textContent = `v${def.version||'0.0.0'} ${def.author?(' / '+def.author):''}`;
-        const btn = document.createElement('button');
-        btn.textContent = miniExpState.selected === def.id ? '選択中' : '選択';
-        btn.addEventListener('click', () => {
+        const isSelected = miniExpState.selected === def.id;
+        const name = def.name || def.id;
+        const selectGame = () => {
             miniExpState.selected = def.id;
-            renderMiniExpList(manifest);
-            if (miniexpPlaceholder) miniexpPlaceholder.textContent = `${def.name||def.id} を選択しました。`;
+            renderMiniExpList(list);
+            if (miniexpPlaceholder) miniexpPlaceholder.textContent = `${name} を選択しました。`;
             renderMiniExpRecords();
             saveAll();
-        });
-        card.appendChild(h); card.appendChild(d); card.appendChild(m); card.appendChild(btn);
-        miniexpList.appendChild(card);
+        };
+        if (mode === 'detail') {
+            const card = document.createElement('div');
+            card.className = 'miniexp-card' + (isSelected ? ' selected' : '');
+            const h = document.createElement('h4'); h.textContent = name;
+            const d = document.createElement('div'); d.className = 'desc'; d.textContent = def.description || '';
+            const m = document.createElement('div'); m.className = 'meta'; m.textContent = `v${def.version||'0.0.0'} ${def.author?(' / '+def.author):''}`;
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.textContent = isSelected ? '選択中' : '選択';
+            btn.addEventListener('click', selectGame);
+            card.appendChild(h);
+            card.appendChild(d);
+            card.appendChild(m);
+            card.appendChild(btn);
+            miniexpList.appendChild(card);
+        } else {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'miniexp-entry' + (isSelected ? ' selected' : '');
+            btn.textContent = name;
+            if (def.description) btn.title = def.description;
+            btn.addEventListener('click', selectGame);
+            miniexpList.appendChild(btn);
+        }
     });
 }
 
@@ -6205,6 +6273,8 @@ async function initMiniExpUI() {
         const list = await loadMiniManifestOnce();
         // 初回表示時にカテゴリ→ゲームの順で描画
         renderMiniExpCategories(list);
+        miniExpState.displayMode = normalizeMiniExpDisplayMode(miniExpState.displayMode);
+        renderMiniExpDisplayModes(list);
         renderMiniExpList(list);
         if (miniexpPlaceholder && miniExpState.selected) {
             const sel = list.find(x=>x.id===miniExpState.selected);

--- a/style.css
+++ b/style.css
@@ -194,17 +194,24 @@ body.in-game #game-container {
 }
 
 /* MiniExp UI */
-.miniexp-layout { display: grid; grid-template-columns: 260px 1fr; gap: 12px; width: 100%; }
+.miniexp-layout {
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    grid-template-rows: auto auto 1fr;
+    gap: 12px;
+    width: 100%;
+    align-items: start;
+}
 .miniexp-cat-list { grid-column: 1; grid-row: 1; }
-.miniexp-list { grid-column: 1; grid-row: 2; }
-.miniexp-panel { grid-column: 2; grid-row: 1 / span 2; width: 100%; }
+.miniexp-display-toolbar { grid-column: 1; grid-row: 2; }
+.miniexp-list { grid-column: 1; grid-row: 3; }
+.miniexp-panel { grid-column: 2; grid-row: 1 / span 3; width: 100%; }
 .miniexp-cat-list {
     width: 100%;
     padding: 6px;
     border: 2px solid #667eea;
     border-radius: 8px;
     background: white;
-    margin-bottom: 8px;
     display: flex;
     flex-wrap: wrap;
     gap: 6px;
@@ -223,6 +230,38 @@ body.in-game #game-container {
     color: #fff;
     border-color: transparent;
 }
+.miniexp-display-toolbar {
+    width: 100%;
+    padding: 6px;
+    border: 2px solid #667eea;
+    border-radius: 8px;
+    background: white;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+}
+.miniexp-display-toolbar .display-btn {
+    padding: 6px 12px;
+    border-radius: 999px;
+    border: 1px solid rgba(102,126,234,0.45);
+    background: #f5f7ff;
+    color: #1f2937;
+    font-weight: 700;
+    cursor: pointer;
+    transition: transform 0.1s ease, box-shadow 0.2s ease;
+}
+.miniexp-display-toolbar .display-btn:hover {
+    background: #e0e7ff;
+    transform: translateY(-1px);
+    box-shadow: 0 6px 16px rgba(102,126,234,0.25);
+}
+.miniexp-display-toolbar .display-btn.active {
+    background: linear-gradient(135deg,#4338ca,#6366f1);
+    color: #fff;
+    border-color: transparent;
+    box-shadow: 0 6px 18px rgba(99,102,241,0.35);
+}
 .miniexp-list {
     width: 100%;
     max-height: 420px;
@@ -232,10 +271,78 @@ body.in-game #game-container {
     border-radius: 8px;
     background: white;
 }
+.miniexp-list.mode-detail {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+.miniexp-list.mode-tile {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 8px;
+}
+.miniexp-list.mode-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+.miniexp-list.mode-wrap {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: flex-start;
+}
+.miniexp-entry {
+    appearance: none;
+    border: 1px solid rgba(102,126,234,0.45);
+    border-radius: 12px;
+    background: #eef2ff;
+    color: #1f2937;
+    font-weight: 700;
+    padding: 10px 12px;
+    cursor: pointer;
+    transition: transform 0.1s ease, box-shadow 0.2s ease, background 0.2s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    text-decoration: none;
+}
+.miniexp-entry:hover {
+    background: #e0e7ff;
+    transform: translateY(-1px);
+    box-shadow: 0 6px 16px rgba(102,126,234,0.25);
+}
+.miniexp-entry.selected {
+    background: linear-gradient(135deg,#4338ca,#6366f1);
+    color: #fff;
+    border-color: transparent;
+    box-shadow: 0 8px 20px rgba(79,70,229,0.35);
+}
+.miniexp-list.mode-tile .miniexp-entry { min-height: 72px; }
+.miniexp-list.mode-list .miniexp-entry {
+    width: 100%;
+    justify-content: flex-start;
+    text-align: left;
+    padding-left: 16px;
+}
+.miniexp-list.mode-wrap .miniexp-entry {
+    flex: 0 1 auto;
+    min-width: 120px;
+}
 .miniexp-card {
-    display: flex; flex-direction: column; gap: 4px;
-    padding: 8px; margin: 6px 0; border: 1px solid rgba(102,126,234,0.35);
-    border-radius: 8px; background: #f8f9ff;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 8px;
+    border: 1px solid rgba(102,126,234,0.35);
+    border-radius: 8px;
+    background: #f8f9ff;
+}
+.miniexp-card.selected {
+    border-color: rgba(99,102,241,0.9);
+    background: #eef2ff;
+    box-shadow: 0 6px 18px rgba(99,102,241,0.25);
 }
 .miniexp-card h4 { margin: 0; font-size: 14px; color: #2c3e50; }
 .miniexp-card .desc { font-size: 12px; color: #4b5563; }


### PR DESCRIPTION
## Summary
- add a display mode toolbar to the mini-game experience selector so the manifest can be browsed as tiles, lists, wrapped buttons, or detailed cards
- persist the chosen display layout and update the renderer to work across all modes while keeping placeholder/status messaging intact
- style the new layouts so name-only tiles, lists, and wraps share consistent hover/selected visuals alongside the existing detailed cards

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d545da4acc832b974893eb49c4b9a1