### PR TITLE
Move image viewer styles into tool script

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,6 +187,8 @@
                         <aside class="tools-sidebar" aria-label="ツール一覧">
                             <button id="tool-button-modmaker" class="tool-item active" type="button" data-tool-target="mod-maker">ダンジョンタイプMod作成</button>
                             <p class="tool-hint">構造や生成アルゴリズムを組み立てて `registerDungeonAddon` ファイルを出力します。</p>
+                            <button id="tool-button-image-viewer" class="tool-item" type="button" data-tool-target="image-viewer">画像ビューア</button>
+                            <p class="tool-hint">スクリーンショットなどを拡大・回転・遠近表示しながらメタ情報を確認できます。</p>
                         </aside>
                         <section id="tool-mod-maker" class="tool-panel active" data-tool-panel="mod-maker" aria-label="ダンジョンタイプMod作成ツール">
                             <header class="tool-panel-header">
@@ -392,6 +394,112 @@
                                     </div>
                                 </div>
                             </section>
+                        </section>
+                        <section id="tool-image-viewer" class="tool-panel" data-tool-panel="image-viewer" aria-label="画像ビューア">
+                            <header class="tool-panel-header">
+                                <h3>画像ビューア</h3>
+                                <p>ユーティリティカテゴリ向けのプレビュー。画像を読み込み、パン・ズーム・回転・伸縮・遠近変換を組み合わせて確認できます（変換はプレビューのみ）。</p>
+                            </header>
+                            <div class="image-viewer-body">
+                                <div class="image-viewer-stage-wrapper">
+                                    <div id="image-viewer-stage" class="image-viewer-stage" tabindex="0" aria-label="画像プレビュー領域">
+                                        <div id="image-viewer-placeholder" class="image-viewer-placeholder">画像ファイルを選択するか、ここにドラッグ＆ドロップしてください。</div>
+                                        <img id="image-viewer-image" alt="選択した画像のプレビュー" draggable="false" />
+                                    </div>
+                                    <p class="image-viewer-stage-hint">ホイールでズーム、ドラッグでパン、ダブルクリックでビューをリセットします。</p>
+                                    <div id="image-viewer-message" class="image-viewer-message" role="status" aria-live="polite"></div>
+                                </div>
+                                <div class="image-viewer-controls">
+                                    <div class="image-viewer-upload">
+                                        <label class="image-viewer-file-label">
+                                            <span>画像ファイルを選択</span>
+                                            <input type="file" id="image-viewer-file" accept="image/*" />
+                                        </label>
+                                        <div class="image-viewer-upload-actions">
+                                            <button type="button" id="image-viewer-reset-view">ビューリセット</button>
+                                            <button type="button" id="image-viewer-reset-all">全てリセット</button>
+                                        </div>
+                                    </div>
+                                    <div class="image-viewer-control-group">
+                                        <label for="image-viewer-zoom">ズーム</label>
+                                        <div class="image-viewer-control">
+                                            <input type="range" id="image-viewer-zoom" min="0.1" max="8" step="0.01" value="1">
+                                            <span id="image-viewer-zoom-value" class="image-viewer-value">100%</span>
+                                        </div>
+                                    </div>
+                                    <div class="image-viewer-control-group">
+                                        <label for="image-viewer-rotation">回転</label>
+                                        <div class="image-viewer-control">
+                                            <input type="range" id="image-viewer-rotation" min="-180" max="180" step="1" value="0">
+                                            <span id="image-viewer-rotation-value" class="image-viewer-value">0°</span>
+                                        </div>
+                                    </div>
+                                    <div class="image-viewer-control-row">
+                                        <div class="image-viewer-control-group">
+                                            <label for="image-viewer-stretch-x">横伸縮</label>
+                                            <div class="image-viewer-control">
+                                                <input type="range" id="image-viewer-stretch-x" min="0.2" max="4" step="0.01" value="1">
+                                                <span id="image-viewer-stretch-x-value" class="image-viewer-value">100%</span>
+                                            </div>
+                                        </div>
+                                        <div class="image-viewer-control-group">
+                                            <label for="image-viewer-stretch-y">縦伸縮</label>
+                                            <div class="image-viewer-control">
+                                                <input type="range" id="image-viewer-stretch-y" min="0.2" max="4" step="0.01" value="1">
+                                                <span id="image-viewer-stretch-y-value" class="image-viewer-value">100%</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="image-viewer-control-group">
+                                        <label for="image-viewer-perspective">遠近距離</label>
+                                        <div class="image-viewer-control">
+                                            <input type="range" id="image-viewer-perspective" min="200" max="2000" step="10" value="800">
+                                            <span id="image-viewer-perspective-value" class="image-viewer-value">800px</span>
+                                        </div>
+                                    </div>
+                                    <div class="image-viewer-control-row">
+                                        <div class="image-viewer-control-group">
+                                            <label for="image-viewer-rotate-x">遠近X回転</label>
+                                            <div class="image-viewer-control">
+                                                <input type="range" id="image-viewer-rotate-x" min="-75" max="75" step="1" value="0">
+                                                <span id="image-viewer-rotate-x-value" class="image-viewer-value">0°</span>
+                                            </div>
+                                        </div>
+                                        <div class="image-viewer-control-group">
+                                            <label for="image-viewer-rotate-y">遠近Y回転</label>
+                                            <div class="image-viewer-control">
+                                                <input type="range" id="image-viewer-rotate-y" min="-75" max="75" step="1" value="0">
+                                                <span id="image-viewer-rotate-y-value" class="image-viewer-value">0°</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="image-viewer-meta" aria-live="polite">
+                                        <h4>メタ情報</h4>
+                                        <dl class="image-viewer-meta-grid">
+                                            <div class="image-viewer-meta-row">
+                                                <dt>ファイル名</dt>
+                                                <dd id="image-viewer-meta-name">-</dd>
+                                            </div>
+                                            <div class="image-viewer-meta-row">
+                                                <dt>種類</dt>
+                                                <dd id="image-viewer-meta-type">-</dd>
+                                            </div>
+                                            <div class="image-viewer-meta-row">
+                                                <dt>サイズ</dt>
+                                                <dd id="image-viewer-meta-size">-</dd>
+                                            </div>
+                                            <div class="image-viewer-meta-row">
+                                                <dt>画像解像度</dt>
+                                                <dd id="image-viewer-meta-dimensions">-</dd>
+                                            </div>
+                                            <div class="image-viewer-meta-row">
+                                                <dt>最終更新日</dt>
+                                                <dd id="image-viewer-meta-modified">-</dd>
+                                            </div>
+                                        </dl>
+                                    </div>
+                                </div>
+                            </div>
                         </section>
                     </div>
                 </div>
@@ -618,6 +726,7 @@
     </div>
     <script src="js/tools/tools-tab.js"></script>
     <script src="js/tools/modmaker.js"></script>
+    <script src="js/tools/image-viewer.js"></script>
     <script src="main.js"></script>
 </body>
 </html>

--- a/js/tools/image-viewer.js
+++ b/js/tools/image-viewer.js
@@ -1,0 +1,673 @@
+(function (global) {
+    'use strict';
+
+    const TOOL_ID = 'image-viewer';
+    const STYLE_ID = 'tool-image-viewer-styles';
+    const ZOOM_MIN = 0.1;
+    const ZOOM_MAX = 8;
+    const STRETCH_MIN = 0.2;
+    const STRETCH_MAX = 4;
+    const PERSPECTIVE_MIN = 200;
+    const PERSPECTIVE_MAX = 2000;
+    const DEFAULT_PERSPECTIVE = 800;
+    const ROTATE_LIMIT = 180;
+    const ROTATE_3D_LIMIT = 75;
+
+    const dateFormatter = new Intl.DateTimeFormat('ja-JP', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit'
+    });
+
+    const defaultState = () => ({
+        zoom: 1,
+        rotation: 0,
+        stretchX: 1,
+        stretchY: 1,
+        panX: 0,
+        panY: 0,
+        rotateX: 0,
+        rotateY: 0,
+        perspective: DEFAULT_PERSPECTIVE
+    });
+
+    let state = defaultState();
+    let refs = null;
+    let dragging = null;
+    let currentFile = null;
+    let objectUrl = null;
+    let naturalSize = { width: 0, height: 0 };
+
+    function ensureStylesInjected() {
+        if (document.getElementById(STYLE_ID)) {
+            return;
+        }
+
+        const style = document.createElement('style');
+        style.id = STYLE_ID;
+        style.textContent = `#tool-image-viewer .image-viewer-body {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+}
+
+#tool-image-viewer .image-viewer-stage-wrapper {
+    flex: 1 1 360px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+#tool-image-viewer .image-viewer-stage {
+    position: relative;
+    border: 1px solid rgba(102,126,234,0.35);
+    border-radius: 12px;
+    background: rgba(238,242,255,0.85);
+    min-height: 340px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    cursor: grab;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+#tool-image-viewer .image-viewer-stage:focus-visible {
+    outline: 3px solid rgba(102,126,234,0.6);
+    outline-offset: 2px;
+}
+
+#tool-image-viewer .image-viewer-stage.dragging {
+    cursor: grabbing;
+    border-color: rgba(102,126,234,0.65);
+    box-shadow: inset 0 0 0 2px rgba(102,126,234,0.15);
+}
+
+#tool-image-viewer .image-viewer-stage.drag-over {
+    border-color: #60a5fa;
+    box-shadow: 0 0 0 3px rgba(96,165,250,0.35);
+}
+
+#tool-image-viewer .image-viewer-stage img {
+    max-width: none;
+    max-height: none;
+    transform-origin: center center;
+    user-select: none;
+    pointer-events: none;
+    display: none;
+}
+
+#tool-image-viewer .image-viewer-stage.has-image img {
+    display: block;
+}
+
+#tool-image-viewer .image-viewer-placeholder {
+    position: absolute;
+    inset: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    color: #64748b;
+    font-size: 14px;
+    line-height: 1.5;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+}
+
+#tool-image-viewer .image-viewer-stage.has-image .image-viewer-placeholder {
+    opacity: 0;
+}
+
+#tool-image-viewer .image-viewer-stage-hint {
+    margin: 0;
+    font-size: 12px;
+    color: #475569;
+}
+
+#tool-image-viewer .image-viewer-message {
+    min-height: 1em;
+    font-size: 12px;
+    color: #475569;
+}
+
+#tool-image-viewer .image-viewer-message.error {
+    color: #b91c1c;
+}
+
+#tool-image-viewer .image-viewer-message.success {
+    color: #166534;
+}
+
+#tool-image-viewer .image-viewer-controls {
+    flex: 1 1 280px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+#tool-image-viewer .image-viewer-upload {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+#tool-image-viewer .image-viewer-file-label {
+    appearance: none;
+    border: 2px dashed rgba(102,126,234,0.5);
+    border-radius: 12px;
+    padding: 16px;
+    background: rgba(238,242,255,0.6);
+    text-align: center;
+    color: #475569;
+    font-size: 14px;
+    line-height: 1.6;
+    cursor: pointer;
+    transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+#tool-image-viewer .image-viewer-file-label strong {
+    display: block;
+    font-size: 16px;
+    color: #1f2937;
+}
+
+#tool-image-viewer .image-viewer-file-label span {
+    display: block;
+    margin-top: 4px;
+    font-size: 12px;
+    color: #64748b;
+}
+
+#tool-image-viewer .image-viewer-file-label:hover {
+    border-color: rgba(102,126,234,0.8);
+    background: rgba(238,242,255,0.9);
+}
+
+#tool-image-viewer .image-viewer-file-label input[type="file"] {
+    display: none;
+}
+
+#tool-image-viewer .image-viewer-upload-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+#tool-image-viewer .image-viewer-upload-actions button {
+    appearance: none;
+    border: none;
+    border-radius: 8px;
+    padding: 8px 12px;
+    background: linear-gradient(135deg,#667eea,#764ba2);
+    color: #fff;
+    font-weight: 700;
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgba(102,126,234,0.35);
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+#tool-image-viewer .image-viewer-upload-actions button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(102,126,234,0.45);
+}
+
+#tool-image-viewer .image-viewer-control-group {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+#tool-image-viewer .image-viewer-control-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+#tool-image-viewer .image-viewer-control {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+#tool-image-viewer .image-viewer-control input[type="range"] {
+    flex: 1 1 auto;
+}
+
+#tool-image-viewer .image-viewer-value {
+    min-width: 52px;
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    color: #1f2937;
+    font-weight: 600;
+}
+
+#tool-image-viewer .image-viewer-meta {
+    background: #f8f9ff;
+    border: 1px solid rgba(102,126,234,0.2);
+    border-radius: 12px;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+#tool-image-viewer .image-viewer-meta h4 {
+    margin: 0;
+    font-size: 16px;
+    color: #1f2937;
+}
+
+#tool-image-viewer .image-viewer-meta-grid {
+    margin: 0;
+    display: grid;
+    grid-template-columns: 120px 1fr;
+    gap: 6px 12px;
+}
+
+#tool-image-viewer .image-viewer-meta-grid dt {
+    margin: 0;
+    font-size: 13px;
+    color: #475569;
+}
+
+#tool-image-viewer .image-viewer-meta-grid dd {
+    margin: 0;
+    font-size: 13px;
+    color: #1f2937;
+    word-break: break-all;
+}
+
+@media (max-width: 980px) {
+    #tool-image-viewer .image-viewer-stage-wrapper,
+    #tool-image-viewer .image-viewer-controls { flex: 1 1 100%; }
+}
+
+@media (max-width: 600px) {
+    #tool-image-viewer .image-viewer-stage { min-height: 260px; }
+}`;
+        document.head.appendChild(style);
+    }
+
+    function clamp(value, min, max) {
+        return Math.min(max, Math.max(min, value));
+    }
+
+    function formatPercent(value) {
+        return `${Math.round(value * 100)}%`;
+    }
+
+    function formatDegrees(value) {
+        return `${Math.round(value)}°`;
+    }
+
+    function formatPerspective(value) {
+        return `${Math.round(value)}px`;
+    }
+
+    function formatFileSize(bytes) {
+        if (!Number.isFinite(bytes) || bytes < 0) return '-';
+        if (bytes < 1024) return `${bytes} B`;
+        const kb = bytes / 1024;
+        if (kb < 1024) return `${kb.toFixed(1)} KB`;
+        const mb = kb / 1024;
+        if (mb < 1024) return `${mb.toFixed(1)} MB`;
+        const gb = mb / 1024;
+        return `${gb.toFixed(2)} GB`;
+    }
+
+    function setMessage(text, type = 'info') {
+        if (!refs?.message) return;
+        refs.message.textContent = text || '';
+        refs.message.classList.remove('error', 'success');
+        if (type === 'error') refs.message.classList.add('error');
+        if (type === 'success') refs.message.classList.add('success');
+    }
+
+    function clearMessage() {
+        setMessage('');
+    }
+
+    function setStageHasImage(hasImage) {
+        if (!refs?.stage) return;
+        const active = !!hasImage;
+        refs.stage.classList.toggle('has-image', active);
+        if (refs.placeholder) {
+            refs.placeholder.hidden = active;
+            refs.placeholder.setAttribute('aria-hidden', active ? 'true' : 'false');
+        }
+    }
+
+    function syncInputsFromState() {
+        if (!refs) return;
+        refs.zoom.value = state.zoom;
+        refs.rotation.value = state.rotation;
+        refs.stretchX.value = state.stretchX;
+        refs.stretchY.value = state.stretchY;
+        refs.perspective.value = state.perspective;
+        refs.rotateX.value = state.rotateX;
+        refs.rotateY.value = state.rotateY;
+    }
+
+    function updateValueLabels() {
+        if (!refs) return;
+        refs.zoomValue.textContent = formatPercent(state.zoom);
+        refs.rotationValue.textContent = formatDegrees(state.rotation);
+        refs.stretchXValue.textContent = formatPercent(state.stretchX);
+        refs.stretchYValue.textContent = formatPercent(state.stretchY);
+        refs.perspectiveValue.textContent = formatPerspective(state.perspective);
+        refs.rotateXValue.textContent = formatDegrees(state.rotateX);
+        refs.rotateYValue.textContent = formatDegrees(state.rotateY);
+    }
+
+    function updateTransform() {
+        if (!refs?.image) return;
+        const scaleX = clamp(state.zoom * state.stretchX, ZOOM_MIN * STRETCH_MIN, ZOOM_MAX * STRETCH_MAX);
+        const scaleY = clamp(state.zoom * state.stretchY, ZOOM_MIN * STRETCH_MIN, ZOOM_MAX * STRETCH_MAX);
+        const transforms = [
+            `perspective(${clamp(state.perspective, PERSPECTIVE_MIN, PERSPECTIVE_MAX)}px)`,
+            `rotateX(${clamp(state.rotateX, -ROTATE_3D_LIMIT, ROTATE_3D_LIMIT)}deg)`,
+            `rotateY(${clamp(state.rotateY, -ROTATE_3D_LIMIT, ROTATE_3D_LIMIT)}deg)`,
+            `translate(${state.panX}px, ${state.panY}px)`,
+            `rotate(${clamp(state.rotation, -ROTATE_LIMIT, ROTATE_LIMIT)}deg)`,
+            `scale(${scaleX}, ${scaleY})`
+        ];
+        refs.image.style.transform = transforms.join(' ');
+    }
+
+    function updateMeta() {
+        if (!refs) return;
+        if (!currentFile) {
+            refs.metaName.textContent = '-';
+            refs.metaType.textContent = '-';
+            refs.metaSize.textContent = '-';
+            refs.metaDimensions.textContent = '-';
+            refs.metaModified.textContent = '-';
+            return;
+        }
+        refs.metaName.textContent = currentFile.name || '(名称未設定)';
+        refs.metaType.textContent = currentFile.type || '不明';
+        refs.metaSize.textContent = formatFileSize(currentFile.size);
+        refs.metaDimensions.textContent = (naturalSize.width && naturalSize.height)
+            ? `${naturalSize.width} × ${naturalSize.height} px`
+            : '-';
+        if (typeof currentFile.lastModified === 'number') {
+            refs.metaModified.textContent = dateFormatter.format(new Date(currentFile.lastModified));
+        } else {
+            refs.metaModified.textContent = '-';
+        }
+    }
+
+    function resetTransformState() {
+        state = defaultState();
+        endPointerDrag();
+        syncInputsFromState();
+        updateValueLabels();
+        updateTransform();
+    }
+
+    function resetAllState() {
+        if (objectUrl) {
+            URL.revokeObjectURL(objectUrl);
+            objectUrl = null;
+        }
+        if (refs?.file) refs.file.value = '';
+        currentFile = null;
+        naturalSize = { width: 0, height: 0 };
+        setStageHasImage(false);
+        if (refs?.image) {
+            refs.image.removeAttribute('src');
+            refs.image.style.transform = 'none';
+        }
+        resetTransformState();
+        updateMeta();
+    }
+
+    function handleImageLoad() {
+        naturalSize = {
+            width: refs.image.naturalWidth || 0,
+            height: refs.image.naturalHeight || 0
+        };
+        setStageHasImage(true);
+        updateMeta();
+        updateTransform();
+        updateValueLabels();
+        setMessage('画像を読み込みました。', 'success');
+    }
+
+    function handleImageError() {
+        setMessage('画像の読み込みに失敗しました。', 'error');
+        resetAllState();
+    }
+
+    function loadFile(file) {
+        if (!file) return;
+        if (!file.type || !file.type.startsWith('image/')) {
+            setMessage('画像ファイルのみ読み込み可能です。', 'error');
+            return;
+        }
+        if (objectUrl) {
+            URL.revokeObjectURL(objectUrl);
+            objectUrl = null;
+        }
+        currentFile = file;
+        naturalSize = { width: 0, height: 0 };
+        setStageHasImage(false);
+        resetTransformState();
+        updateMeta();
+        setMessage('画像を読み込み中...', 'info');
+        objectUrl = URL.createObjectURL(file);
+        refs.image.src = objectUrl;
+    }
+
+    function onPointerDown(ev) {
+        if (!refs?.stage || !currentFile) return;
+        if (ev.button !== 0) return;
+        refs.stage.setPointerCapture(ev.pointerId);
+        dragging = {
+            id: ev.pointerId,
+            startX: ev.clientX,
+            startY: ev.clientY,
+            panX: state.panX,
+            panY: state.panY
+        };
+        refs.stage.classList.add('dragging');
+        ev.preventDefault();
+    }
+
+    function onPointerMove(ev) {
+        if (!dragging || dragging.id !== ev.pointerId) return;
+        const dx = ev.clientX - dragging.startX;
+        const dy = ev.clientY - dragging.startY;
+        state.panX = dragging.panX + dx;
+        state.panY = dragging.panY + dy;
+        updateTransform();
+    }
+
+    function endPointerDrag(ev) {
+        if (!dragging) return;
+        const pointerId = ev?.pointerId ?? dragging.id ?? null;
+        if (refs?.stage) {
+            refs.stage.classList.remove('dragging');
+            if (pointerId != null && refs.stage.hasPointerCapture(pointerId)) {
+                refs.stage.releasePointerCapture(pointerId);
+            }
+        }
+        dragging = null;
+    }
+
+    function onWheel(ev) {
+        if (!currentFile) return;
+        ev.preventDefault();
+        const direction = ev.deltaY < 0 ? 1 : -1;
+        const factor = direction > 0 ? 1.1 : 0.9;
+        const nextZoom = clamp(state.zoom * factor, ZOOM_MIN, ZOOM_MAX);
+        state.zoom = nextZoom;
+        refs.zoom.value = state.zoom;
+        updateTransform();
+        updateValueLabels();
+    }
+
+    function onDoubleClick(ev) {
+        if (!currentFile) return;
+        ev.preventDefault();
+        resetTransformState();
+        setMessage('ビュー設定をリセットしました。', 'info');
+    }
+
+    function onDragOver(ev) {
+        ev.preventDefault();
+        if (!refs?.stage) return;
+        refs.stage.classList.add('drag-over');
+    }
+
+    function onDragLeave(ev) {
+        ev.preventDefault();
+        if (!refs?.stage) return;
+        refs.stage.classList.remove('drag-over');
+    }
+
+    function onDrop(ev) {
+        ev.preventDefault();
+        if (!refs?.stage) return;
+        refs.stage.classList.remove('drag-over');
+        const file = ev.dataTransfer?.files?.[0] || null;
+        if (file) loadFile(file);
+    }
+
+    function bindControlEvents() {
+        if (!refs) return;
+        refs.file.addEventListener('change', (ev) => {
+            const file = ev.target.files?.[0] || null;
+            if (file) {
+                loadFile(file);
+            }
+        });
+
+        refs.resetView.addEventListener('click', () => {
+            if (!refs.image?.src) {
+                resetTransformState();
+                clearMessage();
+                return;
+            }
+            resetTransformState();
+            setMessage('ビュー設定をリセットしました。', 'info');
+        });
+
+        refs.resetAll.addEventListener('click', () => {
+            resetAllState();
+            setMessage('画像ビューアを初期化しました。', 'info');
+        });
+
+        refs.zoom.addEventListener('input', () => {
+            state.zoom = clamp(parseFloat(refs.zoom.value) || 1, ZOOM_MIN, ZOOM_MAX);
+            updateTransform();
+            updateValueLabels();
+        });
+
+        refs.rotation.addEventListener('input', () => {
+            state.rotation = clamp(parseFloat(refs.rotation.value) || 0, -ROTATE_LIMIT, ROTATE_LIMIT);
+            updateTransform();
+            updateValueLabels();
+        });
+
+        refs.stretchX.addEventListener('input', () => {
+            state.stretchX = clamp(parseFloat(refs.stretchX.value) || 1, STRETCH_MIN, STRETCH_MAX);
+            updateTransform();
+            updateValueLabels();
+        });
+
+        refs.stretchY.addEventListener('input', () => {
+            state.stretchY = clamp(parseFloat(refs.stretchY.value) || 1, STRETCH_MIN, STRETCH_MAX);
+            updateTransform();
+            updateValueLabels();
+        });
+
+        refs.perspective.addEventListener('input', () => {
+            state.perspective = clamp(parseFloat(refs.perspective.value) || DEFAULT_PERSPECTIVE, PERSPECTIVE_MIN, PERSPECTIVE_MAX);
+            updateTransform();
+            updateValueLabels();
+        });
+
+        refs.rotateX.addEventListener('input', () => {
+            state.rotateX = clamp(parseFloat(refs.rotateX.value) || 0, -ROTATE_3D_LIMIT, ROTATE_3D_LIMIT);
+            updateTransform();
+            updateValueLabels();
+        });
+
+        refs.rotateY.addEventListener('input', () => {
+            state.rotateY = clamp(parseFloat(refs.rotateY.value) || 0, -ROTATE_3D_LIMIT, ROTATE_3D_LIMIT);
+            updateTransform();
+            updateValueLabels();
+        });
+
+        refs.stage.addEventListener('pointerdown', onPointerDown);
+        refs.stage.addEventListener('pointermove', onPointerMove);
+        refs.stage.addEventListener('pointerup', endPointerDrag);
+        refs.stage.addEventListener('pointercancel', endPointerDrag);
+        refs.stage.addEventListener('pointerleave', endPointerDrag);
+        refs.stage.addEventListener('wheel', onWheel, { passive: false });
+        refs.stage.addEventListener('dblclick', onDoubleClick);
+        refs.stage.addEventListener('dragover', onDragOver);
+        refs.stage.addEventListener('dragenter', onDragOver);
+        refs.stage.addEventListener('dragleave', onDragLeave);
+        refs.stage.addEventListener('drop', onDrop);
+    }
+
+    function initImageViewerTool(context) {
+        if (!context?.panel || context.panel.__imageViewerInited) return;
+        context.panel.__imageViewerInited = true;
+
+        ensureStylesInjected();
+
+        refs = {
+            panel: context.panel,
+            stage: context.panel.querySelector('#image-viewer-stage'),
+            image: context.panel.querySelector('#image-viewer-image'),
+            placeholder: context.panel.querySelector('#image-viewer-placeholder'),
+            message: context.panel.querySelector('#image-viewer-message'),
+            file: context.panel.querySelector('#image-viewer-file'),
+            resetView: context.panel.querySelector('#image-viewer-reset-view'),
+            resetAll: context.panel.querySelector('#image-viewer-reset-all'),
+            zoom: context.panel.querySelector('#image-viewer-zoom'),
+            zoomValue: context.panel.querySelector('#image-viewer-zoom-value'),
+            rotation: context.panel.querySelector('#image-viewer-rotation'),
+            rotationValue: context.panel.querySelector('#image-viewer-rotation-value'),
+            stretchX: context.panel.querySelector('#image-viewer-stretch-x'),
+            stretchXValue: context.panel.querySelector('#image-viewer-stretch-x-value'),
+            stretchY: context.panel.querySelector('#image-viewer-stretch-y'),
+            stretchYValue: context.panel.querySelector('#image-viewer-stretch-y-value'),
+            perspective: context.panel.querySelector('#image-viewer-perspective'),
+            perspectiveValue: context.panel.querySelector('#image-viewer-perspective-value'),
+            rotateX: context.panel.querySelector('#image-viewer-rotate-x'),
+            rotateXValue: context.panel.querySelector('#image-viewer-rotate-x-value'),
+            rotateY: context.panel.querySelector('#image-viewer-rotate-y'),
+            rotateYValue: context.panel.querySelector('#image-viewer-rotate-y-value'),
+            metaName: context.panel.querySelector('#image-viewer-meta-name'),
+            metaType: context.panel.querySelector('#image-viewer-meta-type'),
+            metaSize: context.panel.querySelector('#image-viewer-meta-size'),
+            metaDimensions: context.panel.querySelector('#image-viewer-meta-dimensions'),
+            metaModified: context.panel.querySelector('#image-viewer-meta-modified')
+        };
+
+        if (!refs.stage || !refs.image || !refs.file) {
+            console.warn('[ImageViewer] 必須要素が見つかりません。');
+            return;
+        }
+
+        refs.image.addEventListener('load', handleImageLoad);
+        refs.image.addEventListener('error', handleImageError);
+
+        resetAllState();
+        bindControlEvents();
+        updateMeta();
+        clearMessage();
+    }
+
+    if (global.ToolsTab?.registerTool) {
+        global.ToolsTab.registerTool(TOOL_ID, initImageViewerTool);
+    }
+})(window);


### PR DESCRIPTION
## Summary
- add a new image viewer utility to the tools tab with zoom, pan, rotation, stretch, and perspective controls
- implement metadata display and drag-and-drop loading for the viewer
- style the viewer panel directly from the tool script by injecting the required CSS inline

## Testing
- Not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d543b274ec832ba1ddd825d48672af