### PR TITLE
Add shortcut control API for mini games and disable typing shortcut conflicts

### DIFF
--- a/games/typing.js
+++ b/games/typing.js
@@ -397,6 +397,20 @@
     if (!root) throw new Error('MiniExp Typing requires a container');
     ensureStyles();
 
+    const shortcutController = opts?.shortcuts;
+    if (shortcutController){
+      if (typeof shortcutController.disableKey === 'function'){
+        shortcutController.disableKey('r');
+        shortcutController.disableKey('p');
+      } else if (typeof shortcutController.setKeyEnabled === 'function'){
+        shortcutController.setKeyEnabled('r', false);
+        shortcutController.setKeyEnabled('p', false);
+      } else if (typeof shortcutController.setAll === 'function' || typeof shortcutController.setGlobal === 'function'){
+        const setter = shortcutController.setAll || shortcutController.setGlobal;
+        try { setter.call(shortcutController, false); } catch {}
+      }
+    }
+
     const initialDifficulty = pickDifficulty(opts?.difficulty);
     const state = {
       difficulty: initialDifficulty,


### PR DESCRIPTION
## Summary
- expose a shortcut controller to MiniExp mods so they can enable or disable host shortcuts
- reset and honor shortcut state when starting or quitting a mini game before handling key presses
- disable the default pause/restart shortcuts while the Typing Challenge mod is active

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d73acbd6b8832b9f047d13a554a634