### PR TITLE
Fix electro instrument keyboard alignment and hover behavior

### DIFF
--- a/games/electro_instrument.js
+++ b/games/electro_instrument.js
@@ -470,7 +470,7 @@
         const leftWhite = noteDef.between ? noteDef.between[0] : null;
         let leftIndex = leftWhite ? whiteNotes.findIndex(n => n.note === leftWhite) : 0;
         if (leftIndex < 0) leftIndex = 0;
-        const position = (leftIndex * WHITE_KEY_STEP) + (WHITE_KEY_STEP / 2) - (BLACK_KEY_WIDTH / 2);
+        const position = (leftIndex * WHITE_KEY_STEP) + WHITE_KEY_WIDTH + (WHITE_KEY_SPACING / 2);
         el.style.left = `${position}px`;
         el.style.zIndex = '5';
         blackLayer.appendChild(el);


### PR DESCRIPTION
## Summary
- align the electro instrument keyboard by layering white and black key containers with consistent spacing so keys no longer drift
- add hover-only glow styling for keys so the keyboard stays steady while pointing

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d73a6ae6f0832ba14d108217a234cb