### PR TITLE
Handle shortcut disablement in editors

### DIFF
--- a/games/notepad.js
+++ b/games/notepad.js
@@ -35,8 +35,10 @@
     } catch {}
   }
 
-  function create(root, awardXp){
+  function create(root, awardXp, opts){
     if (!root) throw new Error('MiniExp Notepad requires a container');
+
+    const shortcuts = opts?.shortcuts;
 
     const persisted = loadPersistentState();
     const state = {
@@ -58,6 +60,7 @@
     let settingsPanel = null;
     let settingsControls = null;
     let isRunning = false;
+    let shortcutsDisabled = false;
 
     const wrapper = document.createElement('div');
     wrapper.style.width = '100%';
@@ -1049,6 +1052,10 @@
     function start(){
       if (isRunning) return;
       isRunning = true;
+      if (!shortcutsDisabled) {
+        shortcuts?.disableKey('p');
+        shortcutsDisabled = true;
+      }
       listeners.forEach(l => l.target.addEventListener(l.type, l.handler, l.capture || false));
       textarea.focus();
     }
@@ -1057,10 +1064,18 @@
       if (!isRunning) return;
       isRunning = false;
       listeners.forEach(l => l.target.removeEventListener(l.type, l.handler, l.capture || false));
+      if (shortcutsDisabled) {
+        shortcuts?.enableKey('p');
+        shortcutsDisabled = false;
+      }
     }
 
     function destroy(){
       stop();
+      if (shortcutsDisabled) {
+        shortcuts?.enableKey('p');
+        shortcutsDisabled = false;
+      }
       closeMenu();
       closeSettingsPanel();
       if (persistTimer) {

--- a/games/wording.js
+++ b/games/wording.js
@@ -55,8 +55,10 @@
 
   const FONT_SIZE_OPTIONS = [8,9,10,11,12,14,16,18,20,22,24,26,28,36,48,72];
 
-  function create(root, awardXp){
+  function create(root, awardXp, opts){
     if (!root) throw new Error('MiniExp Wording requires a container');
+
+    const shortcuts = opts?.shortcuts;
 
     const persisted = loadPersistentState();
     const state = {
@@ -86,6 +88,7 @@
     const xpCooldowns = new Map();
     let persistTimer = null;
     const skipFormatXpCommands = new Set(['insertText', 'insertHTML']);
+    let shortcutsDisabled = false;
 
     const wrapper = document.createElement('div');
     wrapper.style.width = '100%';
@@ -1456,6 +1459,11 @@
     function start(){
       if (state.isRunning) return;
       state.isRunning = true;
+      if (!shortcutsDisabled) {
+        shortcuts?.disableKey('p');
+        shortcuts?.disableKey('r');
+        shortcutsDisabled = true;
+      }
       document.addEventListener('keydown', onKeydown);
       grantXp('launch', LAUNCH_BONUS, 0);
       renderRibbon();
@@ -1469,10 +1477,20 @@
       if (!state.isRunning) return;
       state.isRunning = false;
       document.removeEventListener('keydown', onKeydown);
+      if (shortcutsDisabled) {
+        shortcuts?.enableKey('p');
+        shortcuts?.enableKey('r');
+        shortcutsDisabled = false;
+      }
     }
 
     function destroy(){
       stop();
+      if (shortcutsDisabled) {
+        shortcuts?.enableKey('p');
+        shortcuts?.enableKey('r');
+        shortcutsDisabled = false;
+      }
       flushPersist();
       document.removeEventListener('selectionchange', handleSelectionChange);
       window.removeEventListener('resize', handleResize);


### PR DESCRIPTION
## Summary
- accept optional shortcut controls when creating the Notepad and Wording runtimes
- disable conflicting host shortcuts while the editors are active and restore them when stopped

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d73f16ebc4832b9d00b0ea53b36f0f