### PR TITLE
Manage shortcuts during pseudo3d race lifecycle

### DIFF
--- a/games/pseudo3d_race.js
+++ b/games/pseudo3d_race.js
@@ -81,6 +81,20 @@
     const xpPass = 4 * (cfg.xpScale || 1);
     const xpDistanceUnit = 0.5 * (cfg.xpScale || 1);
     const xpPerfect = 100 * (cfg.xpScale || 1.1);
+    const shortcuts = opts?.shortcuts;
+    let shortcutsLocked = false;
+
+    function setShortcutsLocked(nextLocked){
+      if (!shortcuts || shortcutsLocked === nextLocked) return;
+      if (nextLocked){
+        shortcuts.disableKey?.('p');
+        shortcuts.disableKey?.('r');
+      } else {
+        shortcuts.enableKey?.('p');
+        shortcuts.enableKey?.('r');
+      }
+      shortcutsLocked = nextLocked;
+    }
 
     const canvas = document.createElement('canvas');
     const W = Math.max(560, Math.min(800, root.clientWidth||640));
@@ -466,6 +480,7 @@
       if (ended) return;
       ended=true;
       running=false;
+      setShortcutsLocked(false);
       if (playerSpeed>0) playerSpeed=0;
       cancelAnimationFrame(raf);
       if (crashes === 0 && awardXp){
@@ -485,9 +500,9 @@
       }
     }
 
-    function start(){ if(running) return; running=true; ended=false; paused=false; lastTs=0; raf=requestAnimationFrame(loop); }
-    function stop(){ if(!running) return; running=false; cancelAnimationFrame(raf); }
-    function destroy(){ try{ stop(); canvas.remove(); removeControls(); document.removeEventListener('keydown', onKeyDown); document.removeEventListener('keyup', onKeyUp); }catch{} }
+    function start(){ if(running) return; running=true; ended=false; paused=false; lastTs=0; setShortcutsLocked(true); raf=requestAnimationFrame(loop); }
+    function stop(){ if(running){ running=false; cancelAnimationFrame(raf); } setShortcutsLocked(false); }
+    function destroy(){ try{ stop(); setShortcutsLocked(false); canvas.remove(); removeControls(); document.removeEventListener('keydown', onKeyDown); document.removeEventListener('keyup', onKeyUp); }catch{} }
     function getScore(){ return Math.floor(totalDistance); }
 
     function reset(){
@@ -497,7 +512,7 @@
       ended=false; paused=false; draw();
     }
 
-    function togglePause(){ if(ended) return; paused=!paused; if(running && paused){ cancelAnimationFrame(raf); draw(); } else if(running){ lastTs=0; raf=requestAnimationFrame(loop); } }
+    function togglePause(){ if(ended) return; paused=!paused; if(running && paused){ cancelAnimationFrame(raf); draw(); } else if(running){ lastTs=0; setShortcutsLocked(true); raf=requestAnimationFrame(loop); } }
 
     function triggerNitro(){
       if (paused || ended) return;


### PR DESCRIPTION
## Summary
- capture the shortcuts controller when creating the pseudo3d race mini-game
- disable pause/reset shortcuts while the race is running or resuming and re-enable them when it stops or ends
- guard shortcut toggling to avoid redundant enable/disable calls across lifecycle transitions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d73f1aeed0832babfb7b496bd6c560