### PR TITLE
Limit sandbox enemy additions to Bridge maximum

### DIFF
--- a/js/tools/sandbox.js
+++ b/js/tools/sandbox.js
@@ -344,7 +344,21 @@
 
     function renderValidation() {
         if (!refs.validation) return;
-        const { errors, warnings } = state.validation;
+        const baseErrors = state.validation?.errors || [];
+        const baseWarnings = state.validation?.warnings || [];
+        const errors = baseErrors.slice();
+        const warnings = baseWarnings.slice();
+        const maxEnemies = Number.isFinite(Bridge?.maxEnemies) ? Bridge.maxEnemies : null;
+        if (maxEnemies !== null && state.enemies.length >= maxEnemies) {
+            const limitMsg = state.enemies.length > maxEnemies
+                ? `敵の上限（${maxEnemies}体）を超えています。敵を減らしてください。`
+                : `敵の上限（${maxEnemies}体）に達しています。新たに追加するには既存の敵を削除してください。`;
+            if (state.enemies.length > maxEnemies) {
+                errors.push(limitMsg);
+            } else {
+                warnings.push(limitMsg);
+            }
+        }
         const tempMsg = state.tempMessage;
         refs.validation.innerHTML = '';
         const list = document.createElement('ul');
@@ -450,6 +464,12 @@
     }
 
     function addEnemy() {
+        const maxEnemies = Number.isFinite(Bridge?.maxEnemies) ? Bridge.maxEnemies : null;
+        if (maxEnemies !== null && state.enemies.length >= maxEnemies) {
+            state.tempMessage = `敵の上限（${maxEnemies}体）に達しています。新たに追加するには既存の敵を削除してください。`;
+            renderValidation();
+            return;
+        }
         const id = `enemy-${enemySeq++}`;
         const stats = defaultEnemyStats(state.playerLevel);
         const enemy = {


### PR DESCRIPTION
## Summary
- stop adding sandbox enemies once SandboxBridge.maxEnemies is reached and notify the user
- show a validation warning when the enemy list reaches or exceeds the configured cap

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d7440f4074832bb6417d6003d90e1d