### PR TITLE
Preserve active Tools tab selection across tab switches

### DIFF
--- a/js/tools/tools-tab.js
+++ b/js/tools/tools-tab.js
@@ -93,6 +93,10 @@
         }
     }
 
+    function getCurrentTool() {
+        return moduleState.currentTool;
+    }
+
     function show(toolId) {
         if (!toolId || !moduleState.activateTool) return;
         moduleState.activateTool(toolId);
@@ -101,6 +105,7 @@
     global.ToolsTab = {
         init,
         registerTool,
-        show
+        show,
+        getCurrentTool
     };
 })(window);

--- a/main.js
+++ b/main.js
@@ -1419,7 +1419,8 @@ function setupTabs() {
                 }
                 __toolsTabInitialized = true;
             } else if (window.ToolsTab?.show) {
-                window.ToolsTab.show('mod-maker');
+                const currentTool = window.ToolsTab.getCurrentTool?.();
+                window.ToolsTab.show(currentTool || 'mod-maker');
             }
         });
     }


### PR DESCRIPTION
## Summary
- add a `ToolsTab.getCurrentTool` helper that returns the active tool id
- reuse the stored tool id when re-opening the Tools tab so the previous selection remains active

## Testing
- Manual verification: switch to another tool, change tabs, and reopen the Tools tab to confirm the selection persists


------
https://chatgpt.com/codex/tasks/task_e_68d74435b3c8832b8da7c6c0341c15e4