### PR TITLE
Preserve sandbox editor focus during rerenders

### DIFF
--- a/js/tools/sandbox.js
+++ b/js/tools/sandbox.js
@@ -18,6 +18,37 @@
     let state = null;
     let enemySeq = 1;
 
+    function captureActiveInput() {
+        const active = document.activeElement;
+        if (!active || !refs.panel?.contains(active)) return null;
+        if (!(active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement)) return null;
+        const key = active.dataset.preserveKey;
+        if (!key) return null;
+        return {
+            key,
+            selectionStart: typeof active.selectionStart === 'number' ? active.selectionStart : null,
+            selectionEnd: typeof active.selectionEnd === 'number' ? active.selectionEnd : null
+        };
+    }
+
+    function restoreActiveInput(snapshot) {
+        if (!snapshot?.key) return;
+        const target = refs.panel?.querySelector(`[data-preserve-key="${snapshot.key}"]`);
+        if (!target || typeof target.focus !== 'function') return;
+        try {
+            target.focus({ preventScroll: true });
+        } catch (err) {
+            target.focus();
+        }
+        if (typeof snapshot.selectionStart === 'number' && typeof snapshot.selectionEnd === 'number' && typeof target.setSelectionRange === 'function') {
+            try {
+                target.setSelectionRange(snapshot.selectionStart, snapshot.selectionEnd);
+            } catch (err) {
+                // Ignore selection errors for input types that do not support setSelectionRange.
+            }
+        }
+    }
+
     function createEmptyGrid(width, height, fill = 0) {
         return Array.from({ length: height }, () => Array.from({ length: width }, () => fill));
     }
@@ -227,12 +258,14 @@
 
             const fields = [
                 {
+                    key: 'name',
                     label: '名前',
                     type: 'text',
                     value: enemy.name || '',
                     handler: (val) => { enemy.name = val; render(); }
                 },
                 {
+                    key: 'level',
                     label: 'レベル',
                     type: 'number',
                     value: enemy.level,
@@ -243,6 +276,7 @@
                     }
                 },
                 {
+                    key: 'hp',
                     label: 'HP',
                     type: 'number',
                     value: enemy.hp,
@@ -253,6 +287,7 @@
                     }
                 },
                 {
+                    key: 'attack',
                     label: '攻撃',
                     type: 'number',
                     value: enemy.attack,
@@ -263,6 +298,7 @@
                     }
                 },
                 {
+                    key: 'defense',
                     label: '防御',
                     type: 'number',
                     value: enemy.defense,
@@ -273,6 +309,7 @@
                     }
                 },
                 {
+                    key: 'x',
                     label: 'X座標',
                     type: 'number',
                     value: Number.isFinite(enemy.x) ? enemy.x : '',
@@ -289,6 +326,7 @@
                     }
                 },
                 {
+                    key: 'y',
                     label: 'Y座標',
                     type: 'number',
                     value: Number.isFinite(enemy.y) ? enemy.y : '',
@@ -312,6 +350,7 @@
                 const input = document.createElement('input');
                 input.type = field.type;
                 input.value = field.value;
+                input.dataset.preserveKey = `enemy-${enemy.id}-${field.key}`;
                 if (field.attrs) {
                     Object.keys(field.attrs).forEach(key => {
                         input.setAttribute(key, field.attrs[key]);
@@ -394,6 +433,7 @@
 
     function render() {
         if (!Bridge) return;
+        const focusSnapshot = captureActiveInput();
         const validation = Bridge.validate(buildConfigFromState()) || { errors: [], warnings: [], config: buildConfigFromState() };
         state.validation = { errors: validation.errors || [], warnings: validation.warnings || [] };
         state.compiledConfig = validation.config || buildConfigFromState();
@@ -404,6 +444,7 @@
         renderPlayerPreview();
         renderEnemies();
         renderValidation();
+        restoreActiveInput(focusSnapshot);
     }
 
     function handleGridClick(event) {


### PR DESCRIPTION
## Summary
- capture the active sandbox input before rerendering and restore focus afterward so caret position survives live updates
- tag enemy form inputs with stable identifiers to keep values intact while editing

## Testing
- browser_container.run_playwright_script (Playwright focus retention check)


------
https://chatgpt.com/codex/tasks/task_e_68d7440880d4832b9c83eaed2b8bcb74