### PR TITLE
Fix Highway Chaser load failure

### DIFF
--- a/games/pseudo3d_race.js
+++ b/games/pseudo3d_race.js
@@ -82,7 +82,6 @@
     const xpPass = 4 * (cfg.xpScale || 1);
     const xpDistanceUnit = 0.5 * (cfg.xpScale || 1);
     const xpPerfect = 100 * (cfg.xpScale || 1.1);
-    const shortcuts = opts?.shortcuts;
     let shortcutsLocked = false;
 
     function setShortcutsLocked(nextLocked){


### PR DESCRIPTION
## Summary
- remove the duplicate `shortcuts` declaration in the Highway Chaser mini-game to prevent load failures

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d75c030a64832b86b1ddd608fc664e