### PR TITLE
Fix Blockcode worker broadcast message

### DIFF
--- a/games/blockcode.js
+++ b/games/blockcode.js
@@ -1484,7 +1484,8 @@
           }
           case 'broadcast': {
             const channel = block.inputs?.channel ?? '';
-            send({ type: 'log', level: 'info', message: `ブロードキャスト: ${channel}` });
+            const message = 'ブロードキャスト: ' + String(channel ?? '');
+            send({ type: 'log', level: 'info', message });
             break;
           }
           case 'stopAll': {


### PR DESCRIPTION
## Summary
- prevent the Blockcode sandbox worker template from interpolating the broadcast channel on creation
- ensure the broadcast log message is built inside the worker so the script loads correctly

## Testing
- not run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d75f1071c4832bbb28484631d68265