### PR TITLE
Fix bubble shooter minigame registration

### DIFF
--- a/games/bubble_shooter.js
+++ b/games/bubble_shooter.js
@@ -621,4 +621,12 @@
 
   if (!window.MiniGameMods) window.MiniGameMods = {};
   window.MiniGameMods.bubbleShooter = { create };
+  if (window.registerMiniGame) {
+    window.registerMiniGame({
+      id: 'bubble_shooter',
+      name: 'バブルシューター',
+      description: 'バブルを撃って3つ揃えで消すカジュアルパズル。浮いたバブルはまとめて落下！',
+      create
+    });
+  }
 })();


### PR DESCRIPTION
## Summary
- register the Bubble Shooter mod with the mini game loader so it resolves correctly
- provide metadata so the loader can start the game from the manifest entry

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d7628239b0832bb65dd241cb1f1279