### PR TITLE
Prevent dungeon controls from triggering while editing math expressions

### DIFF
--- a/main.js
+++ b/main.js
@@ -6093,6 +6093,13 @@ let playerTurn = true;
 document.addEventListener('keydown', (event) => {
     if (!playerTurn || isGameOver) return;
     if (isAnyModalOpen()) return; // モーダル中はゲーム入力を無効化
+    const target = event.target;
+    if (target instanceof HTMLElement) {
+        if (target.closest('input, textarea, select')) return;
+        const editableAncestor = target.closest('[contenteditable]');
+        if (editableAncestor instanceof HTMLElement && editableAncestor.isContentEditable) return;
+        if (target.isContentEditable) return;
+    }
     ensureAudio(); // 初回入力でオーディオ解放
 
     let acted = false;


### PR DESCRIPTION
## Summary
- ensure dungeon movement shortcuts ignore events originating from focused text and editable inputs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d77d5f7024832bad0ef1e974abe24d