### PR TITLE
Render sandbox map preview on canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -506,7 +506,10 @@
                                     <div class="sandbox-map-header">
                                         <h4>マッププレビュー</h4>
                                     </div>
-                                    <div id="sandbox-grid" class="sandbox-grid" role="grid" aria-label="サンドボックスマップ"></div>
+                                    <div id="sandbox-grid" class="sandbox-grid" role="grid" aria-label="サンドボックスマップ">
+                                        <canvas id="sandbox-grid-canvas" role="presentation" aria-hidden="true"></canvas>
+                                        <div id="sandbox-grid-aria" class="visually-hidden" aria-live="polite"></div>
+                                    </div>
                                     <dl class="sandbox-legend">
                                         <div><dt>■</dt><dd>壁</dd></div>
                                         <div><dt>□</dt><dd>床</dd></div>

--- a/style.css
+++ b/style.css
@@ -9,6 +9,18 @@ body {
     padding: 20px;
 }
 
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 /* 探索画面レイアウト（全画面・スクロール抑止） */
 body.in-game {
     overflow: hidden; /* ページの縦横スクロールを無効化 */
@@ -1646,12 +1658,16 @@ h1 {
     border: 1px solid rgba(102,126,234,0.2);
     border-radius: 12px;
     padding: 12px;
-    display: grid;
-    gap: 4px;
     max-height: 480px;
     overflow: auto;
     user-select: none;
     touch-action: none;
+}
+
+.sandbox-grid canvas {
+    display: block;
+    cursor: pointer;
+    image-rendering: pixelated;
 }
 
 .sandbox-cell {


### PR DESCRIPTION
## Summary
- replace the sandbox map preview markup with a canvas element and hidden live region for announcements
- draw the sandbox grid on the canvas with tile metadata colors, icons, and updated pointer handling for painting
- add supporting canvas styling and a reusable visually hidden helper class

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d77fc35114832b8e9644fa11d39a5e