### PR TITLE
Add canvas-based editing to mod maker tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,7 +268,10 @@
                                                 <button id="modmaker-fill-wall" type="button">全て壁</button>
                                             </div>
                                         </div>
-                                        <div id="modmaker-grid" class="modmaker-grid" role="grid" aria-label="構造パターン"></div>
+                                        <div id="modmaker-grid" class="modmaker-grid" role="application" aria-label="構造パターン">
+                                            <canvas id="modmaker-grid-canvas" aria-hidden="true"></canvas>
+                                            <div class="modmaker-grid-placeholder" data-placeholder></div>
+                                        </div>
                                         <label class="full">パターンプレビュー
                                             <textarea id="modmaker-pattern-preview" class="code" rows="4" readonly></textarea>
                                         </label>
@@ -312,7 +315,10 @@
                                                     <button id="modmaker-fixed-fill-void" type="button">全て空白</button>
                                                 </div>
                                             </div>
-                                            <div id="modmaker-fixed-grid" class="modmaker-grid" role="grid" aria-label="固定マップパターン"></div>
+                                            <div id="modmaker-fixed-grid" class="modmaker-grid" role="application" aria-label="固定マップパターン">
+                                                <canvas id="modmaker-fixed-grid-canvas" aria-hidden="true"></canvas>
+                                                <div class="modmaker-grid-placeholder" data-placeholder></div>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>

--- a/style.css
+++ b/style.css
@@ -2431,31 +2431,44 @@ h1 {
 }
 
 .modmaker-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(22px, 22px));
-    gap: 2px;
-    justify-content: start;
+    position: relative;
     background: #fff;
     border: 1px solid rgba(102,126,234,0.3);
     border-radius: 10px;
     padding: 8px;
     overflow: auto;
     max-width: 100%;
+    min-height: 140px;
 }
 
-.modmaker-grid.placeholder {
-    display: flex;
+.modmaker-grid canvas {
+    display: block;
+    background: #f8fafc;
+    image-rendering: pixelated;
+    image-rendering: crisp-edges;
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+}
+
+.modmaker-grid.placeholder canvas {
+    display: none;
+}
+
+.modmaker-grid-placeholder {
+    position: absolute;
+    inset: 8px;
+    display: none;
     align-items: center;
     justify-content: center;
-    min-height: 140px;
-    padding: 16px;
     text-align: center;
     font-size: 13px;
     color: #6b7280;
+    pointer-events: none;
+    padding: 8px;
+    border-radius: 8px;
 }
 
-.modmaker-grid.placeholder span {
-    pointer-events: none;
+.modmaker-grid.placeholder .modmaker-grid-placeholder {
+    display: flex;
 }
 
 .modmaker-fixed {


### PR DESCRIPTION
## Summary
- replace the structure pattern list with a canvas renderer so tiles and anchors are easier to read
- switch the fixed map editor to the same canvas workflow and support drag painting
- refresh styles and placeholder messaging to match the new canvas layouts

## Testing
- Manual UI verification

------
https://chatgpt.com/codex/tasks/task_e_68d783ce8390832b98c5cc4800f750e8