### PR TITLE
Add selection brush and fix sandbox floor recoloring

### DIFF
--- a/index.html
+++ b/index.html
@@ -443,6 +443,7 @@
                                             </label>
                                         </div>
                                         <div class="sandbox-brush-select" role="radiogroup" aria-label="ブラシ選択">
+                                            <button type="button" class="sandbox-brush" data-brush="select" aria-pressed="false">選択</button>
                                             <button type="button" class="sandbox-brush" data-brush="floor" aria-pressed="true">床</button>
                                             <button type="button" class="sandbox-brush" data-brush="wall" aria-pressed="false">壁</button>
                                             <button type="button" class="sandbox-brush" data-brush="start" aria-pressed="false">開始位置</button>


### PR DESCRIPTION
## Summary
- add a dedicated selection brush that only changes the sandbox editor cursor
- prevent non-floor brushes from overwriting existing floor color metadata while keeping the canvas cursor in sync

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d786eab1cc832ba96248cfed7d0111