### PR TITLE
Add import/export workflow to sandbox dungeon editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -534,9 +534,15 @@
                                 </div>
                                 <div id="sandbox-validation" class="sandbox-validation" aria-live="polite"></div>
                                 <div class="sandbox-start-actions">
-                                    <button type="button" id="sandbox-start-button" class="sandbox-start-button">サンドボックスを開始</button>
+                                    <div class="sandbox-primary-actions">
+                                        <button type="button" id="sandbox-start-button" class="sandbox-start-button">サンドボックスを開始</button>
+                                        <button type="button" id="sandbox-export-button" class="sandbox-secondary-button">設定をエクスポート</button>
+                                        <button type="button" id="sandbox-import-button" class="sandbox-secondary-button">設定をインポート</button>
+                                        <input type="file" id="sandbox-import-file" accept="application/json" hidden>
+                                    </div>
                                     <span class="sandbox-warning">※ サンドボックスでは経験値を獲得できません。</span>
                                 </div>
+                                <p id="sandbox-io-status" class="sandbox-io-status" role="status" aria-live="polite"></p>
                             </section>
                         </section>
                         <section id="tool-blockdata-editor" class="tool-panel" data-tool-panel="blockdata-editor" aria-label="ブロックデータ編集ツール">

--- a/style.css
+++ b/style.css
@@ -1447,7 +1447,8 @@ h1 {
 
 .sandbox-map-actions button,
 #sandbox-add-enemy,
-.sandbox-start-button {
+.sandbox-start-button,
+.sandbox-secondary-button {
     appearance: none;
     border: none;
     border-radius: 8px;
@@ -1462,13 +1463,15 @@ h1 {
 
 .sandbox-map-actions button:hover,
 #sandbox-add-enemy:hover,
-.sandbox-start-button:hover {
+.sandbox-start-button:hover,
+.sandbox-secondary-button:hover {
     transform: translateY(-1px);
     box-shadow: 0 4px 12px rgba(102,126,234,0.35);
 }
 
 .sandbox-map-actions button:disabled,
-.sandbox-start-button:disabled {
+.sandbox-start-button:disabled,
+.sandbox-secondary-button:disabled {
     background: #cbd5f5;
     box-shadow: none;
     color: #475569;
@@ -1879,12 +1882,46 @@ h1 {
     flex-wrap: wrap;
 }
 
+.sandbox-primary-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.sandbox-secondary-button {
+    background: linear-gradient(135deg,#1f2937,#334155);
+    box-shadow: 0 2px 8px rgba(51,65,85,0.35);
+}
+
+.sandbox-secondary-button:hover {
+    box-shadow: 0 4px 12px rgba(51,65,85,0.35);
+}
+
 .sandbox-warning {
     font-size: 12px;
     color: #b45309;
     background: rgba(251,191,36,0.2);
     padding: 6px 8px;
     border-radius: 6px;
+}
+
+.sandbox-io-status {
+    font-size: 13px;
+    margin-top: 8px;
+    min-height: 18px;
+}
+
+.sandbox-io-status[data-tone="success"] {
+    color: #15803d;
+}
+
+.sandbox-io-status[data-tone="error"] {
+    color: #b91c1c;
+}
+
+.sandbox-io-status[data-tone="info"] {
+    color: #1d4ed8;
 }
 
 @media (max-width: 980px) {


### PR DESCRIPTION
## Summary
- add import and export controls to the sandbox dungeon tool and surface operation status updates
- implement serialization helpers and file handling logic for downloading and uploading sandbox configurations
- style the new controls alongside the existing start button and add a status indicator for file IO results

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d78dbb8380832b939f42f9a3e81e32