### PR TITLE
Fix XP pinball launch lane obstruction

### DIFF
--- a/games/pinball.js
+++ b/games/pinball.js
@@ -177,7 +177,8 @@
       { x: table.left + 165, y: table.bottom - 42, r: 18, cooldown: 0, xp: 3 },
       { x: table.right - 165, y: table.bottom - 42, r: 18, cooldown: 0, xp: 3 },
       { x: table.left + 40, y: table.bottom - 150, r: 16, cooldown: 0, xp: 3 },
-      { x: table.right - 40, y: table.bottom - 150, r: 16, cooldown: 0, xp: 3 }
+      // 右下レーンを塞がないよう、ポストを左へ寄せて通路を確保する
+      { x: table.right - 75, y: table.bottom - 150, r: 16, cooldown: 0, xp: 3 }
     ];
 
     const sparks = [];


### PR DESCRIPTION
## Summary
- shift the right-side post away from the plunger lane so the ball can travel upward after launch

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68d7984b12a0832b952eb69da18ce4b8