### PR TITLE
Allow high level heroes to break weak dungeon walls

### DIFF
--- a/main.js
+++ b/main.js
@@ -3174,6 +3174,27 @@ function isFloor(x, y) {
     return map[y] && map[y][x] === 0;
 }
 
+function canPlayerBreakWalls() {
+    if (player.level < 500) return false;
+    const recommended = recommendedLevelForSelection(selectedWorld, selectedDungeonBase, dungeonLevel);
+    if (!Number.isFinite(recommended)) return false;
+    return recommended <= player.level - 5;
+}
+
+function breakWallAt(x, y) {
+    if (!map[y] || map[y][x] !== 1) return false;
+    if (x <= 0 || x >= MAP_WIDTH - 1 || y <= 0 || y >= MAP_HEIGHT - 1) return false;
+
+    map[y][x] = 0;
+    if (tileMeta[y]) {
+        tileMeta[y][x] = null;
+    }
+
+    addMessage('壁を破壊した！');
+    addPopup(x, y, '破壊', '#ffa94d', 1.2);
+    return true;
+}
+
 function countFloorTiles() {
     let n = 0;
     for (let y = 0; y < MAP_HEIGHT; y++) {
@@ -6014,7 +6035,10 @@ function attemptPlayerStep(dx, dy) {
         return true;
     }
 
-    if (!isFloor(targetX, targetY)) return false;
+    if (!isFloor(targetX, targetY)) {
+        const canBreak = canPlayerBreakWalls() && breakWallAt(targetX, targetY);
+        if (!canBreak) return false;
+    }
 
     addSeparator();
     let moveSoundPlayed = false;


### PR DESCRIPTION
## Summary
- allow level 500+ players to shatter walls when the dungeon recommendation is at least 5 levels lower
- convert the destroyed wall tile into a standard floor tile and emit log/popup feedback for the action

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7d31690b8832ba245304227836a75