### PR TITLE
Suppress enemy special effects when significantly underleveled

### DIFF
--- a/index.html
+++ b/index.html
@@ -963,6 +963,10 @@
                     <span class="label">防御力:</span>
                     <span id="enemy-modal-defense">8</span>
                 </div>
+                <div class="stat-row" id="enemy-modal-trait-row" style="display:none;">
+                    <span class="label">特性:</span>
+                    <span id="enemy-modal-trait">-</span>
+                </div>
             </div>
             <div class="damage-simulation">
                 <h4>ダメージ予測</h4>


### PR DESCRIPTION
## Summary
- add guards that detect when an enemy is 5+ levels below the player and surface a suppression message
- skip high-level enemy trait effects (status ailments, warps, instant death, and extra actions) whenever the suppression condition is met

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7d415f0f4832bb5a471b1c6cbfb2a