### PR TITLE
Add five nature-themed dungeon addon packs

### DIFF
--- a/dungeontypes/aurora_canopy.js
+++ b/dungeontypes/aurora_canopy.js
@@ -1,0 +1,114 @@
+// Addon: Aurora Canopy - shimmering boreal forest canopies
+(function(){
+  function lerp(a,b,t){ return a + (b-a)*t; }
+  function lerpColor(c1,c2,t){
+    const p = parseInt(c1.slice(1),16);
+    const q = parseInt(c2.slice(1),16);
+    const r1 = (p>>16)&255, g1=(p>>8)&255, b1=p&255;
+    const r2 = (q>>16)&255, g2=(q>>8)&255, b2=q&255;
+    const r = Math.round(lerp(r1,r2,t));
+    const g = Math.round(lerp(g1,g2,t));
+    const b = Math.round(lerp(b1,b2,t));
+    return `#${r.toString(16).padStart(2,'0')}${g.toString(16).padStart(2,'0')}${b.toString(16).padStart(2,'0')}`;
+  }
+
+  function carveGlowPath(ctx,start,steps,widthBias){
+    let {x,y} = start;
+    const dirs = [[1,0],[-1,0],[0,1],[0,-1],[1,1],[-1,1],[1,-1],[-1,-1]];
+    for(let i=0;i<steps;i++){
+      for(let yy=-1; yy<=1; yy++){
+        for(let xx=-1; xx<=1; xx++){
+          if(Math.abs(xx)+Math.abs(yy) <= widthBias){
+            const nx=x+xx, ny=y+yy;
+            if(ctx.inBounds(nx,ny)) ctx.set(nx,ny,0);
+          }
+        }
+      }
+      const dir = dirs[Math.floor(ctx.random()*dirs.length)];
+      x = Math.min(Math.max(x+dir[0],1), ctx.width-2);
+      y = Math.min(Math.max(y+dir[1],1), ctx.height-2);
+      if(ctx.random() < 0.25){
+        widthBias = Math.max(1, widthBias + (ctx.random() < 0.5 ? -1 : 1));
+        widthBias = Math.min(widthBias, 2);
+      }
+    }
+  }
+
+  function algorithm(ctx){
+    const W=ctx.width, H=ctx.height;
+    for(let y=0;y<H;y++)
+      for(let x=0;x<W;x++) ctx.set(x,y,1);
+
+    const seeds = [
+      { x: Math.floor(W*0.3), y: 1 },
+      { x: Math.floor(W*0.7), y: H-2 },
+      { x: Math.floor(W*0.5), y: Math.floor(H/2) }
+    ];
+    seeds.forEach((s,idx)=>{
+      carveGlowPath(ctx,s,Math.floor(W*H*0.25), idx===2?2:1);
+    });
+
+    for(let y=1;y<H-1;y++){
+      const t = y/(H-1);
+      const floorColor = lerpColor('#0b7285','#e0f7ff',t);
+      const wallColor  = lerpColor('#16324f','#274060',t);
+      for(let x=1;x<W-1;x++){
+        if(ctx.get(x,y)===0){
+          ctx.setFloorColor(x,y,floorColor);
+        } else {
+          ctx.setWallColor(x,y,wallColor);
+        }
+      }
+    }
+
+    ctx.ensureConnectivity();
+  }
+
+  const gen = {
+    id: 'aurora-canopy',
+    name: '極光樹冠',
+    description: '夜空に揺らめくオーロラが照らす森冠の遊歩路',
+    algorithm,
+    mixin: { normalMixed: 0.45, blockDimMixed: 0.5, tags: ['forest','organic','light'] }
+  };
+
+  function mkBoss(depth){
+    const floors=[];
+    if(depth>=5) floors.push(5);
+    if(depth>=10) floors.push(10);
+    if(depth>=15) floors.push(15);
+    if(depth>=20) floors.push(20);
+    return floors;
+  }
+
+  const blocks = {
+    blocks1:[
+      { key:'aurora_theme_01', name:'Aurora Theme I', level:+0,  size:0,  depth:+1, chest:'normal', type:'aurora-canopy', bossFloors:mkBoss(6) },
+      { key:'aurora_theme_02', name:'Aurora Theme II',level:+5,  size:+1, depth:+1, chest:'less',   type:'aurora-canopy', bossFloors:mkBoss(8) },
+      { key:'aurora_theme_03', name:'Aurora Theme III',level:+10, size:+1, depth:+2, chest:'more',  type:'aurora-canopy', bossFloors:mkBoss(10) },
+      { key:'aurora_theme_04', name:'Aurora Theme IV',level:+15, size:+1, depth:+2, chest:'normal', type:'aurora-canopy', bossFloors:mkBoss(12) },
+      { key:'aurora_theme_05', name:'Aurora Theme V', level:+20, size:+2, depth:+3, chest:'more',  type:'aurora-canopy', bossFloors:mkBoss(14) },
+      { key:'aurora_theme_06', name:'Aurora Theme VI',level:+24, size:+2, depth:+3, chest:'less',  type:'aurora-canopy', bossFloors:mkBoss(16) },
+      { key:'aurora_theme_07', name:'Aurora Theme VII',level:+28, size:+2, depth:+4, chest:'normal',type:'aurora-canopy', bossFloors:mkBoss(18) },
+      { key:'aurora_theme_08', name:'Aurora Theme VIII',level:+32,size:+3, depth:+4, chest:'more', type:'aurora-canopy', bossFloors:mkBoss(20) }
+    ],
+    blocks2:[
+      { key:'aurora_trail_01', name:'Aurora Trail I', level:+0,  size:+1, depth:0,  chest:'normal', type:'aurora-canopy' },
+      { key:'aurora_trail_02', name:'Aurora Trail II',level:+4,  size:+1, depth:+1, chest:'less',   type:'aurora-canopy' },
+      { key:'aurora_trail_03', name:'Aurora Trail III',level:+8, size:+1, depth:+1, chest:'normal', type:'aurora-canopy' },
+      { key:'aurora_trail_04', name:'Aurora Trail IV',level:+12, size:+2, depth:+2, chest:'more',   type:'aurora-canopy' },
+      { key:'aurora_trail_05', name:'Aurora Trail V', level:+16, size:+2, depth:+2, chest:'less',   type:'aurora-canopy' },
+      { key:'aurora_trail_06', name:'Aurora Trail VI',level:+22, size:+3, depth:+3, chest:'normal', type:'aurora-canopy' }
+    ],
+    blocks3:[
+      { key:'aurora_grove_01', name:'Aurora Grove I', level:+0,  size:0,  depth:+2, chest:'more',   type:'aurora-canopy', bossFloors:[5] },
+      { key:'aurora_grove_02', name:'Aurora Grove II',level:+6,  size:+1, depth:+2, chest:'normal', type:'aurora-canopy', bossFloors:[8] },
+      { key:'aurora_grove_03', name:'Aurora Grove III',level:+12,size:+1, depth:+3, chest:'less',   type:'aurora-canopy', bossFloors:[12] },
+      { key:'aurora_grove_04', name:'Aurora Grove IV',level:+18,size:+2, depth:+3, chest:'more',    type:'aurora-canopy', bossFloors:[16] },
+      { key:'aurora_grove_05', name:'Aurora Grove V', level:+24,size:+2, depth:+4, chest:'normal',  type:'aurora-canopy', bossFloors:[20] },
+      { key:'aurora_grove_06', name:'Aurora Grove VI',level:+30,size:+3, depth:+4, chest:'more',    type:'aurora-canopy', bossFloors:[10,20] }
+    ]
+  };
+
+  window.registerDungeonAddon({ id:'aurora_canopy_pack', name:'Aurora Canopy Pack', version:'1.0.0', blocks, generators:[gen] });
+})();

--- a/dungeontypes/bamboo_highlands.js
+++ b/dungeontypes/bamboo_highlands.js
@@ -1,0 +1,86 @@
+// Addon: Bamboo Highlands - terraced bamboo groves and ridges
+(function(){
+  function algorithm(ctx){
+    const {width:W,height:H} = ctx;
+    for(let y=0;y<H;y++)
+      for(let x=0;x<W;x++) ctx.set(x,y,1);
+
+    for(let x=2;x<W-2;x+=3){
+      for(let y=1;y<H-1;y++){
+        if(ctx.random()<0.8) ctx.set(x,y,0);
+        if(ctx.random()<0.4) ctx.set(x-1,y,0);
+      }
+    }
+
+    for(let y=2;y<H-2;y+=4){
+      for(let x=1;x<W-1;x++){
+        if(ctx.random()<0.7) ctx.set(x,y,0);
+      }
+    }
+
+    for(let y=1;y<H-1;y++){
+      for(let x=1;x<W-1;x++){
+        if(ctx.get(x,y)===0){
+          const terrace = Math.floor(y/4)%2;
+          const shade = terrace? '#9bd37a' : '#b2e58a';
+          ctx.setFloorColor(x,y,shade);
+          if(ctx.random()<0.08) ctx.setFloorType(x,y,'normal');
+        } else {
+          const groove = (x+y)%3===0;
+          ctx.setWallColor(x,y, groove ? '#556b2f' : '#6f8f37');
+        }
+      }
+    }
+
+    ctx.ensureConnectivity();
+  }
+
+  const gen = {
+    id: 'bamboo-highlands',
+    name: '竹嶺段丘',
+    description: '段々の高地に竹が密生する風鳴りの谷',
+    algorithm,
+    mixin: { normalMixed: 0.5, blockDimMixed: 0.6, tags: ['forest','terrace','wind'] }
+  };
+
+  function mkBoss(depth){
+    const floors=[];
+    if(depth>=5) floors.push(5);
+    if(depth>=9) floors.push(9);
+    if(depth>=13) floors.push(13);
+    if(depth>=17) floors.push(17);
+    if(depth>=21) floors.push(21);
+    return floors;
+  }
+
+  const blocks = {
+    blocks1:[
+      { key:'bamboo_theme_01', name:'Bamboo Theme I', level:+0,  size:0,  depth:+1, chest:'normal', type:'bamboo-highlands', bossFloors:mkBoss(5) },
+      { key:'bamboo_theme_02', name:'Bamboo Theme II',level:+4,  size:+1, depth:+1, chest:'less',   type:'bamboo-highlands', bossFloors:mkBoss(7) },
+      { key:'bamboo_theme_03', name:'Bamboo Theme III',level:+8, size:+1, depth:+2, chest:'more',  type:'bamboo-highlands', bossFloors:mkBoss(9) },
+      { key:'bamboo_theme_04', name:'Bamboo Theme IV',level:+12, size:+1, depth:+2, chest:'normal', type:'bamboo-highlands', bossFloors:mkBoss(11) },
+      { key:'bamboo_theme_05', name:'Bamboo Theme V', level:+16, size:+2, depth:+3, chest:'more',  type:'bamboo-highlands', bossFloors:mkBoss(13) },
+      { key:'bamboo_theme_06', name:'Bamboo Theme VI',level:+20, size:+2, depth:+3, chest:'less',  type:'bamboo-highlands', bossFloors:mkBoss(15) },
+      { key:'bamboo_theme_07', name:'Bamboo Theme VII',level:+24,size:+2, depth:+4, chest:'normal',type:'bamboo-highlands', bossFloors:mkBoss(17) }
+    ],
+    blocks2:[
+      { key:'bamboo_ridge_01', name:'Bamboo Ridge I', level:+0,  size:+1, depth:0,  chest:'normal', type:'bamboo-highlands' },
+      { key:'bamboo_ridge_02', name:'Bamboo Ridge II',level:+3,  size:+1, depth:+1, chest:'less',   type:'bamboo-highlands' },
+      { key:'bamboo_ridge_03', name:'Bamboo Ridge III',level:+6, size:+1, depth:+1, chest:'normal', type:'bamboo-highlands' },
+      { key:'bamboo_ridge_04', name:'Bamboo Ridge IV',level:+9,  size:+2, depth:+2, chest:'more',   type:'bamboo-highlands' },
+      { key:'bamboo_ridge_05', name:'Bamboo Ridge V', level:+12, size:+2, depth:+2, chest:'less',   type:'bamboo-highlands' },
+      { key:'bamboo_ridge_06', name:'Bamboo Ridge VI',level:+15, size:+2, depth:+3, chest:'normal', type:'bamboo-highlands' },
+      { key:'bamboo_ridge_07', name:'Bamboo Ridge VII',level:+18,size:+3, depth:+3, chest:'more',   type:'bamboo-highlands' }
+    ],
+    blocks3:[
+      { key:'bamboo_zen_01', name:'Bamboo Zen I', level:+0,  size:0,  depth:+2, chest:'more',   type:'bamboo-highlands', bossFloors:[5] },
+      { key:'bamboo_zen_02', name:'Bamboo Zen II',level:+5,  size:+1, depth:+2, chest:'normal', type:'bamboo-highlands', bossFloors:[9] },
+      { key:'bamboo_zen_03', name:'Bamboo Zen III',level:+10,size:+1, depth:+3, chest:'less',   type:'bamboo-highlands', bossFloors:[13] },
+      { key:'bamboo_zen_04', name:'Bamboo Zen IV', level:+15,size:+2, depth:+3, chest:'more',   type:'bamboo-highlands', bossFloors:[17] },
+      { key:'bamboo_zen_05', name:'Bamboo Zen V',  level:+20,size:+2, depth:+4, chest:'normal', type:'bamboo-highlands', bossFloors:[21] },
+      { key:'bamboo_zen_06', name:'Bamboo Zen VI', level:+25,size:+3, depth:+4, chest:'more',   type:'bamboo-highlands', bossFloors:[11,21] }
+    ]
+  };
+
+  window.registerDungeonAddon({ id:'bamboo_highlands_pack', name:'Bamboo Highlands Pack', version:'1.0.0', blocks, generators:[gen] });
+})();

--- a/dungeontypes/coral_sanctuary.js
+++ b/dungeontypes/coral_sanctuary.js
@@ -1,0 +1,120 @@
+// Addon: Coral Sanctuary - tidepools and coral labyrinths
+(function(){
+  function carveCircle(ctx,cx,cy,r){
+    for(let y=-r;y<=r;y++){
+      for(let x=-r;x<=r;x++){
+        const nx=cx+x, ny=cy+y;
+        if(!ctx.inBounds(nx,ny)) continue;
+        if(x*x + y*y <= r*r) ctx.set(nx,ny,0);
+      }
+    }
+  }
+
+  function scatterCoral(ctx,count){
+    for(let i=0;i<count;i++){
+      const cx = 2 + Math.floor(ctx.random()*(ctx.width-4));
+      const cy = 2 + Math.floor(ctx.random()*(ctx.height-4));
+      const r = 2 + Math.floor(ctx.random()*3);
+      carveCircle(ctx,cx,cy,r);
+    }
+  }
+
+  function linkPools(ctx,points){
+    for(let i=0;i<points.length-1;i++){
+      const a=points[i], b=points[i+1];
+      let x=a.x, y=a.y;
+      while(x!==b.x || y!==b.y){
+        if(ctx.inBounds(x,y)) ctx.set(x,y,0);
+        if(x<b.x) x++; else if(x>b.x) x--;
+        if(ctx.inBounds(x,y)) ctx.set(x,y,0);
+        if(y<b.y) y++; else if(y>b.y) y--;
+      }
+    }
+  }
+
+  function algorithm(ctx){
+    const {width:W,height:H} = ctx;
+    for(let y=0;y<H;y++)
+      for(let x=0;x<W;x++) ctx.set(x,y,1);
+
+    const pools=[];
+    for(let i=0;i<5;i++){
+      const px = 2 + Math.floor(ctx.random()*(W-4));
+      const py = 2 + Math.floor(ctx.random()*(H-4));
+      const r = 3 + Math.floor(ctx.random()*3);
+      carveCircle(ctx,px,py,r);
+      pools.push({x:px,y:py});
+    }
+    scatterCoral(ctx, 8 + Math.floor(W*H*0.02));
+    linkPools(ctx,pools.sort((a,b)=>a.x-b.x));
+
+    for(let y=1;y<H-1;y++){
+      for(let x=1;x<W-1;x++){
+        if(ctx.get(x,y)===0){
+          const tide = (Math.sin((x/3)+(y/4))+1)/2;
+          const blue = Math.floor(lerp(120,210,tide));
+          const green = Math.floor(lerp(160,230,tide));
+          const color = `rgb(${Math.floor(lerp(90,130,tide))},${green},${blue})`;
+          ctx.setFloorColor(x,y,color);
+          if(ctx.random()<0.05) ctx.setFloorType(x,y,'ice');
+        } else {
+          const coral = `rgb(${150+((x+y)%50)},${80+((x*3)%70)},${120+((y*5)%50)})`;
+          ctx.setWallColor(x,y,coral);
+        }
+      }
+    }
+
+    ctx.ensureConnectivity();
+  }
+
+  function lerp(a,b,t){ return a + (b-a)*t; }
+
+  const gen = {
+    id: 'coral-sanctuary',
+    name: '珊瑚聖域',
+    description: '潮溜まりと珊瑚礁が広がる海底の迷宮',
+    algorithm,
+    mixin: { normalMixed: 0.4, blockDimMixed: 0.55, tags: ['aquatic','organic','cavern'] }
+  };
+
+  function mkBoss(depth){
+    const floors=[];
+    if(depth>=4) floors.push(4);
+    if(depth>=8) floors.push(8);
+    if(depth>=12) floors.push(12);
+    if(depth>=16) floors.push(16);
+    if(depth>=20) floors.push(20);
+    return floors;
+  }
+
+  const blocks = {
+    blocks1:[
+      { key:'coral_theme_01', name:'Coral Theme I', level:+0,  size:0,  depth:+1, chest:'normal', type:'coral-sanctuary', bossFloors:mkBoss(5) },
+      { key:'coral_theme_02', name:'Coral Theme II',level:+4,  size:+1, depth:+1, chest:'more',   type:'coral-sanctuary', bossFloors:mkBoss(7) },
+      { key:'coral_theme_03', name:'Coral Theme III',level:+8, size:+1, depth:+2, chest:'less',   type:'coral-sanctuary', bossFloors:mkBoss(9) },
+      { key:'coral_theme_04', name:'Coral Theme IV',level:+12, size:+2, depth:+2, chest:'normal', type:'coral-sanctuary', bossFloors:mkBoss(11) },
+      { key:'coral_theme_05', name:'Coral Theme V', level:+16, size:+2, depth:+3, chest:'more',   type:'coral-sanctuary', bossFloors:mkBoss(13) },
+      { key:'coral_theme_06', name:'Coral Theme VI',level:+20, size:+2, depth:+3, chest:'less',   type:'coral-sanctuary', bossFloors:mkBoss(15) },
+      { key:'coral_theme_07', name:'Coral Theme VII',level:+24,size:+3, depth:+4, chest:'normal', type:'coral-sanctuary', bossFloors:mkBoss(17) }
+    ],
+    blocks2:[
+      { key:'reef_path_01', name:'Reef Path I', level:+0,  size:+1, depth:0,  chest:'normal', type:'coral-sanctuary' },
+      { key:'reef_path_02', name:'Reef Path II',level:+3,  size:+1, depth:+1, chest:'less',   type:'coral-sanctuary' },
+      { key:'reef_path_03', name:'Reef Path III',level:+6, size:+1, depth:+1, chest:'normal', type:'coral-sanctuary' },
+      { key:'reef_path_04', name:'Reef Path IV',level:+9,  size:+2, depth:+2, chest:'more',   type:'coral-sanctuary' },
+      { key:'reef_path_05', name:'Reef Path V', level:+12, size:+2, depth:+2, chest:'less',   type:'coral-sanctuary' },
+      { key:'reef_path_06', name:'Reef Path VI',level:+15, size:+2, depth:+3, chest:'normal', type:'coral-sanctuary' },
+      { key:'reef_path_07', name:'Reef Path VII',level:+18,size:+3, depth:+3, chest:'more',   type:'coral-sanctuary' }
+    ],
+    blocks3:[
+      { key:'tidepool_core_01', name:'Tidepool Core I', level:+0,  size:0,  depth:+2, chest:'more',   type:'coral-sanctuary', bossFloors:[4] },
+      { key:'tidepool_core_02', name:'Tidepool Core II',level:+5,  size:+1, depth:+2, chest:'normal', type:'coral-sanctuary', bossFloors:[8] },
+      { key:'tidepool_core_03', name:'Tidepool Core III',level:+10,size:+1, depth:+3, chest:'less',   type:'coral-sanctuary', bossFloors:[12] },
+      { key:'tidepool_core_04', name:'Tidepool Core IV', level:+15,size:+2, depth:+3, chest:'more',   type:'coral-sanctuary', bossFloors:[16] },
+      { key:'tidepool_core_05', name:'Tidepool Core V',  level:+20,size:+2, depth:+4, chest:'normal', type:'coral-sanctuary', bossFloors:[20] },
+      { key:'tidepool_core_06', name:'Tidepool Core VI', level:+25,size:+3, depth:+4, chest:'more',   type:'coral-sanctuary', bossFloors:[10,20] }
+    ]
+  };
+
+  window.registerDungeonAddon({ id:'coral_sanctuary_pack', name:'Coral Sanctuary Pack', version:'1.0.0', blocks, generators:[gen] });
+})();

--- a/dungeontypes/lotus_archipelago.js
+++ b/dungeontypes/lotus_archipelago.js
@@ -1,0 +1,117 @@
+// Addon: Lotus Archipelago - floating isles with lotus blooms
+(function(){
+  function carveEllipse(ctx,cx,cy,rx,ry){
+    for(let y=-ry;y<=ry;y++){
+      for(let x=-rx;x<=rx;x++){
+        const nx=cx+x, ny=cy+y;
+        if(!ctx.inBounds(nx,ny)) continue;
+        const v = (x*x)/(rx*rx) + (y*y)/(ry*ry);
+        if(v<=1.1) ctx.set(nx,ny,0);
+      }
+    }
+  }
+
+  function connect(ctx,a,b){
+    const dx = b.x - a.x;
+    const dy = b.y - a.y;
+    const steps = Math.max(Math.abs(dx), Math.abs(dy));
+    for(let i=0;i<=steps;i++){
+      const t = i/steps;
+      const x = Math.round(a.x + dx*t);
+      const y = Math.round(a.y + dy*t);
+      for(let oy=-1; oy<=1; oy++)
+        for(let ox=-1; ox<=1; ox++)
+          if(ctx.inBounds(x+ox,y+oy)) ctx.set(x+ox,y+oy,0);
+    }
+  }
+
+  function algorithm(ctx){
+    const {width:W,height:H} = ctx;
+    for(let y=0;y<H;y++)
+      for(let x=0;x<W;x++) ctx.set(x,y,1);
+
+    const isles=[];
+    const isleCount = 6;
+    for(let i=0;i<isleCount;i++){
+      const cx = 3 + Math.floor(ctx.random()*(W-6));
+      const cy = 3 + Math.floor(ctx.random()*(H-6));
+      const rx = 2 + Math.floor(ctx.random()*3);
+      const ry = 2 + Math.floor(ctx.random()*3);
+      carveEllipse(ctx,cx,cy,rx,ry);
+      isles.push({x:cx,y:cy});
+    }
+
+    isles.sort((a,b)=>a.x-b.x);
+    for(let i=0;i<isles.length-1;i++) connect(ctx,isles[i],isles[i+1]);
+
+    for(let y=1;y<H-1;y++){
+      for(let x=1;x<W-1;x++){
+        if(ctx.get(x,y)===0){
+          const bloom = (Math.sin(x*0.4)+Math.cos(y*0.3)+2)/4;
+          const r = Math.floor(lerp(180,240,bloom));
+          const g = Math.floor(lerp(120,200,bloom));
+          const b = Math.floor(lerp(160,220,bloom));
+          ctx.setFloorColor(x,y,`rgb(${r},${g},${b})`);
+          if(ctx.random()<0.07) ctx.setFloorType(x,y,'normal');
+        } else {
+          const mist = (Math.sin((x+y)*0.2)+1)/2;
+          const color = `rgb(${Math.floor(lerp(90,140,mist))},${Math.floor(lerp(110,160,mist))},${Math.floor(lerp(170,220,mist))})`;
+          ctx.setWallColor(x,y,color);
+        }
+      }
+    }
+
+    ctx.ensureConnectivity();
+  }
+
+  function lerp(a,b,t){ return a + (b-a)*t; }
+
+  const gen = {
+    id: 'lotus-archipelago',
+    name: '蓮華群島',
+    description: '浮遊する蓮の島々を繋ぐ光の橋',
+    algorithm,
+    mixin: { normalMixed: 0.55, blockDimMixed: 0.6, tags: ['floating','garden','mystic'] }
+  };
+
+  function mkBoss(depth){
+    const floors=[];
+    if(depth>=5) floors.push(5);
+    if(depth>=9) floors.push(9);
+    if(depth>=13) floors.push(13);
+    if(depth>=17) floors.push(17);
+    if(depth>=21) floors.push(21);
+    return floors;
+  }
+
+  const blocks = {
+    blocks1:[
+      { key:'lotus_theme_01', name:'Lotus Theme I', level:+0,  size:0,  depth:+1, chest:'normal', type:'lotus-archipelago', bossFloors:mkBoss(5) },
+      { key:'lotus_theme_02', name:'Lotus Theme II',level:+4,  size:+1, depth:+1, chest:'more',   type:'lotus-archipelago', bossFloors:mkBoss(7) },
+      { key:'lotus_theme_03', name:'Lotus Theme III',level:+8, size:+1, depth:+2, chest:'less',   type:'lotus-archipelago', bossFloors:mkBoss(9) },
+      { key:'lotus_theme_04', name:'Lotus Theme IV',level:+12, size:+2, depth:+2, chest:'normal', type:'lotus-archipelago', bossFloors:mkBoss(11) },
+      { key:'lotus_theme_05', name:'Lotus Theme V', level:+16, size:+2, depth:+3, chest:'more',   type:'lotus-archipelago', bossFloors:mkBoss(13) },
+      { key:'lotus_theme_06', name:'Lotus Theme VI',level:+20, size:+2, depth:+3, chest:'less',   type:'lotus-archipelago', bossFloors:mkBoss(15) },
+      { key:'lotus_theme_07', name:'Lotus Theme VII',level:+24,size:+3, depth:+4, chest:'normal', type:'lotus-archipelago', bossFloors:mkBoss(17) }
+    ],
+    blocks2:[
+      { key:'isle_link_01', name:'Isle Link I', level:+0,  size:+1, depth:0,  chest:'normal', type:'lotus-archipelago' },
+      { key:'isle_link_02', name:'Isle Link II',level:+3,  size:+1, depth:+1, chest:'less',   type:'lotus-archipelago' },
+      { key:'isle_link_03', name:'Isle Link III',level:+6, size:+1, depth:+1, chest:'normal', type:'lotus-archipelago' },
+      { key:'isle_link_04', name:'Isle Link IV',level:+9,  size:+2, depth:+2, chest:'more',   type:'lotus-archipelago' },
+      { key:'isle_link_05', name:'Isle Link V', level:+12, size:+2, depth:+2, chest:'less',   type:'lotus-archipelago' },
+      { key:'isle_link_06', name:'Isle Link VI',level:+15, size:+2, depth:+3, chest:'normal', type:'lotus-archipelago' },
+      { key:'isle_link_07', name:'Isle Link VII',level:+18,size:+3, depth:+3, chest:'more',   type:'lotus-archipelago' }
+    ],
+    blocks3:[
+      { key:'lotus_sanctum_01', name:'Lotus Sanctum I', level:+0,  size:0,  depth:+2, chest:'more',   type:'lotus-archipelago', bossFloors:[5] },
+      { key:'lotus_sanctum_02', name:'Lotus Sanctum II',level:+5,  size:+1, depth:+2, chest:'normal', type:'lotus-archipelago', bossFloors:[9] },
+      { key:'lotus_sanctum_03', name:'Lotus Sanctum III',level:+10,size:+1, depth:+3, chest:'less',   type:'lotus-archipelago', bossFloors:[13] },
+      { key:'lotus_sanctum_04', name:'Lotus Sanctum IV', level:+15,size:+2, depth:+3, chest:'more',   type:'lotus-archipelago', bossFloors:[17] },
+      { key:'lotus_sanctum_05', name:'Lotus Sanctum V',  level:+20,size:+2, depth:+4, chest:'normal', type:'lotus-archipelago', bossFloors:[21] },
+      { key:'lotus_sanctum_06', name:'Lotus Sanctum VI', level:+25,size:+3, depth:+4, chest:'more',   type:'lotus-archipelago', bossFloors:[11,21] }
+    ]
+  };
+
+  window.registerDungeonAddon({ id:'lotus_archipelago_pack', name:'Lotus Archipelago Pack', version:'1.0.0', blocks, generators:[gen] });
+})();

--- a/dungeontypes/manifest.json.js
+++ b/dungeontypes/manifest.json.js
@@ -16,5 +16,10 @@ window.DUNGEONTYPE_MANIFEST = [
   { id: 'forest_pack',    name: 'Verdant Forest Pack', entry: 'dungeontypes/forest_caverns.js', version: '1.0.0', author: 'builtin-sample' },
   { id: 'shore_pack',     name: 'Sunlit Shore Pack', entry: 'dungeontypes/beach_shore.js', version: '1.0.0', author: 'builtin-sample' },
   { id: 'desert_pack',    name: 'Scorched Desert Pack', entry: 'dungeontypes/desert_field.js', version: '1.0.0', author: 'builtin-sample' },
-  { id: 'bog_pack',       name: 'Toxic Boglands Pack', entry: 'dungeontypes/poison_bogs.js', version: '1.0.0', author: 'builtin-sample' }
+  { id: 'bog_pack',       name: 'Toxic Boglands Pack', entry: 'dungeontypes/poison_bogs.js', version: '1.0.0', author: 'builtin-sample' },
+  { id: 'aurora_canopy_pack', name: 'Aurora Canopy Pack', entry: 'dungeontypes/aurora_canopy.js', version: '1.0.0', author: 'builtin-sample' },
+  { id: 'coral_sanctuary_pack', name: 'Coral Sanctuary Pack', entry: 'dungeontypes/coral_sanctuary.js', version: '1.0.0', author: 'builtin-sample' },
+  { id: 'bamboo_highlands_pack', name: 'Bamboo Highlands Pack', entry: 'dungeontypes/bamboo_highlands.js', version: '1.0.0', author: 'builtin-sample' },
+  { id: 'sunstone_canyons_pack', name: 'Sunstone Canyons Pack', entry: 'dungeontypes/sunstone_canyons.js', version: '1.0.0', author: 'builtin-sample' },
+  { id: 'lotus_archipelago_pack', name: 'Lotus Archipelago Pack', entry: 'dungeontypes/lotus_archipelago.js', version: '1.0.0', author: 'builtin-sample' }
 ];

--- a/dungeontypes/sunstone_canyons.js
+++ b/dungeontypes/sunstone_canyons.js
@@ -1,0 +1,92 @@
+// Addon: Sunstone Canyons - sunlit slot canyons with warm winds
+(function(){
+  function algorithm(ctx){
+    const {width:W,height:H} = ctx;
+    for(let y=0;y<H;y++)
+      for(let x=0;x<W;x++) ctx.set(x,y,1);
+
+    let currentY = Math.floor(H/2);
+    for(let x=1;x<W-1;x++){
+      currentY += Math.floor((ctx.random()-0.5)*3);
+      currentY = Math.max(2, Math.min(H-3,currentY));
+      for(let w=-2;w<=2;w++){
+        const ny = currentY+w;
+        if(ctx.inBounds(x,ny)) ctx.set(x,ny,0);
+        if(ctx.random()<0.4 && ctx.inBounds(x+1,ny)) ctx.set(x+1,ny,0);
+      }
+      if(x%6===0){
+        const branchY = currentY + (ctx.random()<0.5?-1:1)* (2+Math.floor(ctx.random()*3));
+        for(let y=currentY; Math.abs(y-branchY)>0 && y>1 && y<H-2; y += branchY>currentY?1:-1){
+          if(ctx.random()<0.8) ctx.set(x,y,0);
+        }
+      }
+    }
+
+    for(let y=1;y<H-1;y++){
+      const t = y/(H-1);
+      const floorColor = `rgb(${Math.floor(lerp(210,255,t))},${Math.floor(lerp(150,190,t))},${Math.floor(lerp(90,130,t))})`;
+      const wallColor = `rgb(${Math.floor(lerp(120,180,t))},${Math.floor(lerp(70,120,t))},${Math.floor(lerp(40,80,t))})`;
+      for(let x=1;x<W-1;x++){
+        if(ctx.get(x,y)===0){
+          ctx.setFloorColor(x,y,floorColor);
+          if(ctx.random()<0.04) ctx.setFloorType(x,y,'normal');
+        } else {
+          ctx.setWallColor(x,y,wallColor);
+        }
+      }
+    }
+
+    ctx.ensureConnectivity();
+  }
+
+  function lerp(a,b,t){ return a + (b-a)*t; }
+
+  const gen = {
+    id: 'sunstone-canyons',
+    name: '陽石峡谷',
+    description: '太陽に焼かれた狭隘な峡谷が風で形を変える',
+    algorithm,
+    mixin: { normalMixed: 0.35, blockDimMixed: 0.45, tags: ['canyon','wind','arid'] }
+  };
+
+  function mkBoss(depth){
+    const floors=[];
+    if(depth>=6) floors.push(6);
+    if(depth>=10) floors.push(10);
+    if(depth>=14) floors.push(14);
+    if(depth>=18) floors.push(18);
+    if(depth>=22) floors.push(22);
+    return floors;
+  }
+
+  const blocks = {
+    blocks1:[
+      { key:'sunstone_theme_01', name:'Sunstone Theme I', level:+0,  size:0,  depth:+1, chest:'normal', type:'sunstone-canyons', bossFloors:mkBoss(6) },
+      { key:'sunstone_theme_02', name:'Sunstone Theme II',level:+5,  size:+1, depth:+1, chest:'less',   type:'sunstone-canyons', bossFloors:mkBoss(8) },
+      { key:'sunstone_theme_03', name:'Sunstone Theme III',level:+10, size:+1, depth:+2, chest:'more', type:'sunstone-canyons', bossFloors:mkBoss(10) },
+      { key:'sunstone_theme_04', name:'Sunstone Theme IV',level:+15, size:+2, depth:+2, chest:'normal', type:'sunstone-canyons', bossFloors:mkBoss(12) },
+      { key:'sunstone_theme_05', name:'Sunstone Theme V', level:+20, size:+2, depth:+3, chest:'more',  type:'sunstone-canyons', bossFloors:mkBoss(14) },
+      { key:'sunstone_theme_06', name:'Sunstone Theme VI',level:+24, size:+2, depth:+3, chest:'less',  type:'sunstone-canyons', bossFloors:mkBoss(16) },
+      { key:'sunstone_theme_07', name:'Sunstone Theme VII',level:+28,size:+3, depth:+4, chest:'normal',type:'sunstone-canyons', bossFloors:mkBoss(18) }
+    ],
+    blocks2:[
+      { key:'canyon_pass_01', name:'Canyon Pass I', level:+0,  size:+1, depth:0,  chest:'normal', type:'sunstone-canyons' },
+      { key:'canyon_pass_02', name:'Canyon Pass II',level:+4,  size:+1, depth:+1, chest:'less',   type:'sunstone-canyons' },
+      { key:'canyon_pass_03', name:'Canyon Pass III',level:+8, size:+1, depth:+1, chest:'normal', type:'sunstone-canyons' },
+      { key:'canyon_pass_04', name:'Canyon Pass IV',level:+12, size:+2, depth:+2, chest:'more',   type:'sunstone-canyons' },
+      { key:'canyon_pass_05', name:'Canyon Pass V', level:+16, size:+2, depth:+2, chest:'less',   type:'sunstone-canyons' },
+      { key:'canyon_pass_06', name:'Canyon Pass VI',level:+20, size:+2, depth:+3, chest:'normal', type:'sunstone-canyons' },
+      { key:'canyon_pass_07', name:'Canyon Pass VII',level:+24,size:+3, depth:+3, chest:'more',   type:'sunstone-canyons' }
+    ],
+    blocks3:[
+      { key:'sun_altar_01', name:'Sun Altar I', level:+0,  size:0,  depth:+2, chest:'more',   type:'sunstone-canyons', bossFloors:[6] },
+      { key:'sun_altar_02', name:'Sun Altar II',level:+6,  size:+1, depth:+2, chest:'normal', type:'sunstone-canyons', bossFloors:[10] },
+      { key:'sun_altar_03', name:'Sun Altar III',level:+12,size:+1, depth:+3, chest:'less',   type:'sunstone-canyons', bossFloors:[14] },
+      { key:'sun_altar_04', name:'Sun Altar IV', level:+18,size:+2, depth:+3, chest:'more',   type:'sunstone-canyons', bossFloors:[18] },
+      { key:'sun_altar_05', name:'Sun Altar V',  level:+24,size:+2, depth:+4, chest:'normal', type:'sunstone-canyons', bossFloors:[22] },
+      { key:'sun_altar_06', name:'Sun Altar VI', level:+30,size:+3, depth:+4, chest:'more',   type:'sunstone-canyons', bossFloors:[12,22] }
+    ]
+  };
+
+  window.registerDungeonAddon({ id:'sunstone_canyons_pack', name:'Sunstone Canyons Pack', version:'1.0.0', blocks, generators:[gen] });
+})();


### PR DESCRIPTION
## Summary
- add the Aurora Canopy generator with aurora-lit forest paths and matching block sets
- add the Coral Sanctuary generator with tidepool caverns and matching block sets
- add Bamboo Highlands, Sunstone Canyons, and Lotus Archipelago generators with their 20-entry block suites and register them in the manifest

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8cfd17c80832b91827bae51a5ca7c