### PR TITLE
Add five nature-themed dungeon packs

### DIFF
--- a/dungeontypes/amber_marsh.js
+++ b/dungeontypes/amber_marsh.js
@@ -1,0 +1,103 @@
+// Addon: Amber Marsh - autumnal wetlands with misty hollows
+(function(){
+  function algorithm(ctx){
+    const W = ctx.width;
+    const H = ctx.height;
+    const map = ctx.map;
+
+    for(let y=0;y<H;y++){
+      for(let x=0;x<W;x++){
+        const edge = x===0 || y===0 || x===W-1 || y===H-1;
+        map[y][x] = edge ? 1 : (ctx.random() < 0.5 ? 1 : 0);
+      }
+    }
+
+    for(let iter=0; iter<5; iter++){
+      const next = map.map(row => row.slice());
+      for(let y=1;y<H-1;y++){
+        for(let x=1;x<W-1;x++){
+          let walls = 0;
+          for(let yy=y-1; yy<=y+1; yy++){
+            for(let xx=x-1; xx<=x+1; xx++){
+              if(xx===x && yy===y) continue;
+              if(map[yy][xx] === 1) walls++;
+            }
+          }
+          const threshold = iter < 2 ? 5 : 4;
+          next[y][x] = walls >= threshold ? 1 : 0;
+        }
+      }
+      for(let y=1;y<H-1;y++){
+        for(let x=1;x<W-1;x++) map[y][x] = next[y][x];
+      }
+    }
+
+    for(let y=0;y<H;y++){
+      for(let x=0;x<W;x++){
+        if(map[y][x] === 0){
+          const fog = 0.2 + 0.3*Math.sin((x+y)/5);
+          ctx.setFloorColor(x,y,`rgba(${180 + Math.floor(Math.sin(y/3)*40)}, ${120 + Math.floor(Math.cos(x/3)*30)}, 80, 0.95)`);
+          if(ctx.random() < 0.05){
+            ctx.setFloorTexture(x,y, ctx.random() < 0.5 ? 'fallen_leaves' : 'reed_clump');
+          }
+          if(ctx.random() < fog){
+            ctx.setAmbientEffect(x,y,'mist');
+          }
+        } else {
+          const hue = 90 + Math.floor(Math.sin(y/2)*20);
+          ctx.setWallColor(x,y,`rgb(${90 + hue}, ${60 + Math.floor(hue/2)}, ${40 + Math.floor(hue/3)})`);
+        }
+      }
+    }
+
+    ctx.ensureConnectivity();
+  }
+
+  const gen = {
+    id: 'amber-marsh',
+    name: '琥珀湿地',
+    description: '秋色の湿原に漂う靄と泥の迷路',
+    algorithm,
+    mixin: { normalMixed: 0.55, blockDimMixed: 0.5, tags: ['swamp','autumn','mist'] }
+  };
+
+  function boss(depth){
+    const res = [];
+    if(depth >= 3) res.push(3);
+    if(depth >= 7) res.push(7);
+    if(depth >= 11) res.push(11);
+    if(depth >= 15) res.push(15);
+    return res;
+  }
+
+  const blocks = {
+    blocks1:[
+      { key:'amber_theme_01', name:'Marsh Theme I', level:+0,  size:0,  depth:+1, chest:'normal', type:'amber-marsh', bossFloors:boss(3) },
+      { key:'amber_theme_02', name:'Marsh Theme II', level:+4,  size:+1, depth:+1, chest:'less',   type:'amber-marsh', bossFloors:boss(5) },
+      { key:'amber_theme_03', name:'Marsh Theme III',level:+8,  size:+1, depth:+1, chest:'more',   type:'amber-marsh', bossFloors:boss(7) },
+      { key:'amber_theme_04', name:'Marsh Theme IV', level:+12, size:+1, depth:+2, chest:'normal', type:'amber-marsh', bossFloors:boss(9) },
+      { key:'amber_theme_05', name:'Marsh Theme V',  level:+16, size:+2, depth:+2, chest:'less',   type:'amber-marsh', bossFloors:boss(11) },
+      { key:'amber_theme_06', name:'Marsh Theme VI', level:+20, size:+2, depth:+2, chest:'normal', type:'amber-marsh', bossFloors:boss(13) },
+      { key:'amber_theme_07', name:'Marsh Theme VII',level:+24, size:+2, depth:+3, chest:'more',   type:'amber-marsh', bossFloors:boss(15) }
+    ],
+    blocks2:[
+      { key:'amber_core_01', name:'Marsh Core I', level:+0,  size:+1, depth:0,  chest:'normal', type:'amber-marsh' },
+      { key:'amber_core_02', name:'Marsh Core II',level:+5,  size:+1, depth:+1, chest:'more',   type:'amber-marsh' },
+      { key:'amber_core_03', name:'Marsh Core III',level:+9,  size:+1, depth:+1, chest:'less',   type:'amber-marsh' },
+      { key:'amber_core_04', name:'Marsh Core IV', level:+13, size:+2, depth:+2, chest:'normal', type:'amber-marsh' },
+      { key:'amber_core_05', name:'Marsh Core V',  level:+17, size:+2, depth:+2, chest:'more',   type:'amber-marsh' },
+      { key:'amber_core_06', name:'Marsh Core VI', level:+21, size:+2, depth:+3, chest:'less',   type:'amber-marsh' },
+      { key:'amber_core_07', name:'Marsh Core VII',level:+25, size:+3, depth:+3, chest:'normal', type:'amber-marsh' }
+    ],
+    blocks3:[
+      { key:'amber_relic_01', name:'Marsh Relic I', level:+0,  size:0,  depth:+2, chest:'more',    type:'amber-marsh', bossFloors:[3] },
+      { key:'amber_relic_02', name:'Marsh Relic II',level:+6,  size:+1, depth:+2, chest:'normal',  type:'amber-marsh', bossFloors:[7] },
+      { key:'amber_relic_03', name:'Marsh Relic III',level:+12, size:+1, depth:+3, chest:'less',   type:'amber-marsh', bossFloors:[11] },
+      { key:'amber_relic_04', name:'Marsh Relic IV', level:+18, size:+2, depth:+3, chest:'normal', type:'amber-marsh', bossFloors:[15] },
+      { key:'amber_relic_05', name:'Marsh Relic V',  level:+24, size:+2, depth:+4, chest:'more',   type:'amber-marsh', bossFloors:[15] },
+      { key:'amber_relic_06', name:'Marsh Relic VI', level:+30, size:+2, depth:+4, chest:'less',   type:'amber-marsh', bossFloors:[15] }
+    ]
+  };
+
+  window.registerDungeonAddon({ id:'amber_marsh_pack', name:'Amber Marsh Pack', version:'1.0.0', blocks, generators:[gen] });
+})();

--- a/dungeontypes/bamboo_hollows.js
+++ b/dungeontypes/bamboo_hollows.js
@@ -1,0 +1,107 @@
+// Addon: Bamboo Hollows - tranquil bamboo groves with winding streams
+(function(){
+  function algorithm(ctx){
+    const { width: W, height: H, map } = ctx;
+
+    for(let y=0;y<H;y++){
+      for(let x=0;x<W;x++){
+        const edge = x===0 || y===0 || x===W-1 || y===H-1;
+        map[y][x] = edge ? 1 : (ctx.random() < 0.45 ? 1 : 0);
+      }
+    }
+
+    for(let iter=0; iter<4; iter++){
+      const next = map.map(row => row.slice());
+      for(let y=1;y<H-1;y++){
+        for(let x=1;x<W-1;x++){
+          let walls = 0;
+          for(let yy=y-1; yy<=y+1; yy++){
+            for(let xx=x-1; xx<=x+1; xx++){
+              if(xx===x && yy===y) continue;
+              if(map[yy][xx] === 1) walls++;
+            }
+          }
+          const threshold = iter < 2 ? 4 : 5;
+          next[y][x] = walls >= threshold ? 1 : 0;
+        }
+      }
+      for(let y=1;y<H-1;y++){
+        for(let x=1;x<W-1;x++) map[y][x] = next[y][x];
+      }
+    }
+
+    for(let y=0;y<H;y++){
+      for(let x=0;x<W;x++){
+        if(map[y][x] === 0){
+          const sway = Math.sin(x/3) * 0.1 + Math.cos(y/4) * 0.1;
+          const g = Math.floor(180 + sway*40);
+          ctx.setFloorColor(x,y,`rgb(${120 + Math.floor(sway*60)}, ${g}, ${120})`);
+          if(ctx.random() < 0.04) ctx.setFloorTexture(x,y,'bamboo_leaf');
+          if(ctx.random() < 0.03) ctx.setFloorTexture(x,y,'stone_path');
+        } else {
+          const hue = 100 + Math.floor(Math.sin((x+y)/4)*30);
+          ctx.setWallColor(x,y,`rgb(${60 + hue/2}, ${150 + hue/3}, ${80 + hue/4})`);
+        }
+      }
+    }
+
+    for(let i=0;i<Math.floor(W/3);i++){
+      const ry = Math.floor(ctx.random()*H);
+      for(let x=0;x<W;x++){
+        if(ctx.random()<0.03){
+          ctx.setFloorTexture(x,ry,'stream');
+        }
+      }
+    }
+
+    ctx.ensureConnectivity();
+  }
+
+  const gen = {
+    id: 'bamboo-hollows',
+    name: '竹のホロウ',
+    description: '竹林の小道とせせらぎが続く静かな迷路',
+    algorithm,
+    mixin: { normalMixed: 0.48, blockDimMixed: 0.52, tags: ['forest','bamboo','stream'] }
+  };
+
+  function boss(depth){
+    const floors = [];
+    if(depth >= 4) floors.push(4);
+    if(depth >= 9) floors.push(9);
+    if(depth >= 13) floors.push(13);
+    if(depth >= 18) floors.push(18);
+    return floors;
+  }
+
+  const blocks = {
+    blocks1:[
+      { key:'bamboo_theme_01', name:'Bamboo Theme I', level:+0,  size:0,  depth:+1, chest:'normal', type:'bamboo-hollows', bossFloors:boss(4) },
+      { key:'bamboo_theme_02', name:'Bamboo Theme II', level:+4,  size:+1, depth:+1, chest:'less',   type:'bamboo-hollows', bossFloors:boss(6) },
+      { key:'bamboo_theme_03', name:'Bamboo Theme III',level:+8,  size:+1, depth:+1, chest:'normal', type:'bamboo-hollows', bossFloors:boss(8) },
+      { key:'bamboo_theme_04', name:'Bamboo Theme IV', level:+12, size:+1, depth:+2, chest:'more',   type:'bamboo-hollows', bossFloors:boss(10) },
+      { key:'bamboo_theme_05', name:'Bamboo Theme V',  level:+16, size:+2, depth:+2, chest:'less',   type:'bamboo-hollows', bossFloors:boss(12) },
+      { key:'bamboo_theme_06', name:'Bamboo Theme VI', level:+20, size:+2, depth:+2, chest:'normal', type:'bamboo-hollows', bossFloors:boss(14) },
+      { key:'bamboo_theme_07', name:'Bamboo Theme VII',level:+24, size:+2, depth:+3, chest:'more',   type:'bamboo-hollows', bossFloors:boss(16) }
+    ],
+    blocks2:[
+      { key:'bamboo_core_01', name:'Bamboo Core I', level:+0,  size:+1, depth:0,  chest:'normal', type:'bamboo-hollows' },
+      { key:'bamboo_core_02', name:'Bamboo Core II',level:+4,  size:+1, depth:+1, chest:'more',   type:'bamboo-hollows' },
+      { key:'bamboo_core_03', name:'Bamboo Core III',level:+8,  size:+1, depth:+1, chest:'less',   type:'bamboo-hollows' },
+      { key:'bamboo_core_04', name:'Bamboo Core IV', level:+12, size:+1, depth:+2, chest:'normal', type:'bamboo-hollows' },
+      { key:'bamboo_core_05', name:'Bamboo Core V',  level:+16, size:+2, depth:+2, chest:'more',   type:'bamboo-hollows' },
+      { key:'bamboo_core_06', name:'Bamboo Core VI', level:+20, size:+2, depth:+3, chest:'less',   type:'bamboo-hollows' },
+      { key:'bamboo_core_07', name:'Bamboo Core VII',level:+24, size:+3, depth:+3, chest:'normal', type:'bamboo-hollows' }
+    ],
+    blocks3:[
+      { key:'bamboo_relic_01', name:'Bamboo Relic I', level:+0,  size:0,  depth:+2, chest:'more',    type:'bamboo-hollows', bossFloors:[4] },
+      { key:'bamboo_relic_02', name:'Bamboo Relic II',level:+6,  size:+1, depth:+2, chest:'normal',  type:'bamboo-hollows', bossFloors:[9] },
+      { key:'bamboo_relic_03', name:'Bamboo Relic III',level:+12, size:+1, depth:+3, chest:'less',   type:'bamboo-hollows', bossFloors:[13] },
+      { key:'bamboo_relic_04', name:'Bamboo Relic IV', level:+18, size:+2, depth:+3, chest:'normal', type:'bamboo-hollows', bossFloors:[18] },
+      { key:'bamboo_relic_05', name:'Bamboo Relic V',  level:+24, size:+2, depth:+4, chest:'more',   type:'bamboo-hollows', bossFloors:[18] },
+      { key:'bamboo_relic_06', name:'Bamboo Relic VI', level:+30, size:+2, depth:+4, chest:'less',   type:'bamboo-hollows', bossFloors:[18] }
+    ]
+  };
+
+  window.registerDungeonAddon({ id:'bamboo_hollows_pack', name:'Bamboo Hollows Pack', version:'1.0.0', blocks, generators:[gen] });
+})();

--- a/dungeontypes/coral_garden.js
+++ b/dungeontypes/coral_garden.js
@@ -1,0 +1,100 @@
+// Addon: Coral Garden - sunken coral labyrinth with tidal corridors
+(function(){
+  function algorithm(ctx){
+    const { width: W, height: H, map } = ctx;
+
+    for(let y=0;y<H;y++){
+      for(let x=0;x<W;x++){
+        const edge = x===0 || y===0 || x===W-1 || y===H-1;
+        map[y][x] = edge ? 1 : (ctx.random() < 0.42 ? 1 : 0);
+      }
+    }
+
+    for(let iter=0; iter<3; iter++){
+      const next = map.map(row => row.slice());
+      for(let y=1;y<H-1;y++){
+        for(let x=1;x<W-1;x++){
+          let walls = 0;
+          for(let yy=y-1; yy<=y+1; yy++){
+            for(let xx=x-1; xx<=x+1; xx++){
+              if(xx===x && yy===y) continue;
+              if(map[yy][xx] === 1) walls++;
+            }
+          }
+          const threshold = 5 - Math.floor(iter/2);
+          next[y][x] = walls >= threshold ? 1 : 0;
+        }
+      }
+      for(let y=1;y<H-1;y++){
+        for(let x=1;x<W-1;x++) map[y][x] = next[y][x];
+      }
+    }
+
+    for(let y=0;y<H;y++){
+      for(let x=0;x<W;x++){
+        if(map[y][x] === 0){
+          const depthFactor = y/H;
+          const blue = Math.floor(150 + depthFactor*70);
+          const green = Math.floor(120 + depthFactor*60);
+          ctx.setFloorColor(x,y,`rgb(${80 + Math.floor(depthFactor*40)}, ${green}, ${blue})`);
+          if(ctx.random() < 0.06){
+            ctx.setFloorTexture(x,y, ctx.random() < 0.5 ? 'coral_branch' : 'sea_anemone');
+          }
+        } else {
+          const coralHue = 200 + Math.floor(Math.sin(x/2 + y/3)*20);
+          ctx.setWallColor(x,y,`rgb(${coralHue}, ${70 + (coralHue % 90)}, ${90 + (coralHue % 80)})`);
+        }
+      }
+    }
+
+    ctx.ensureConnectivity();
+  }
+
+  const gen = {
+    id: 'coral-garden',
+    name: '珊瑚庭園',
+    description: '潮騒に包まれた珊瑚と海藻の迷路',
+    algorithm,
+    mixin: { normalMixed: 0.5, blockDimMixed: 0.5, tags: ['water','reef','undersea'] }
+  };
+
+  function boss(depth){
+    const res = [];
+    if(depth >= 4) res.push(4);
+    if(depth >= 8) res.push(8);
+    if(depth >= 12) res.push(12);
+    if(depth >= 16) res.push(16);
+    return res;
+  }
+
+  const blocks = {
+    blocks1:[
+      { key:'coral_theme_01', name:'Coral Theme I', level:+0,  size:0,  depth:+1, chest:'normal', type:'coral-garden', bossFloors:boss(4) },
+      { key:'coral_theme_02', name:'Coral Theme II', level:+3,  size:+1, depth:+1, chest:'less',   type:'coral-garden', bossFloors:boss(6) },
+      { key:'coral_theme_03', name:'Coral Theme III',level:+6,  size:+1, depth:+1, chest:'normal', type:'coral-garden', bossFloors:boss(8) },
+      { key:'coral_theme_04', name:'Coral Theme IV', level:+9,  size:+1, depth:+2, chest:'more',   type:'coral-garden', bossFloors:boss(10) },
+      { key:'coral_theme_05', name:'Coral Theme V',  level:+12, size:+2, depth:+2, chest:'less',   type:'coral-garden', bossFloors:boss(12) },
+      { key:'coral_theme_06', name:'Coral Theme VI', level:+15, size:+2, depth:+2, chest:'normal', type:'coral-garden', bossFloors:boss(14) },
+      { key:'coral_theme_07', name:'Coral Theme VII',level:+18, size:+2, depth:+3, chest:'more',   type:'coral-garden', bossFloors:boss(16) }
+    ],
+    blocks2:[
+      { key:'coral_core_01', name:'Coral Core I', level:+0,  size:+1, depth:0,  chest:'normal', type:'coral-garden' },
+      { key:'coral_core_02', name:'Coral Core II',level:+4,  size:+1, depth:+1, chest:'more',   type:'coral-garden' },
+      { key:'coral_core_03', name:'Coral Core III',level:+8,  size:+1, depth:+1, chest:'less',   type:'coral-garden' },
+      { key:'coral_core_04', name:'Coral Core IV', level:+12, size:+1, depth:+2, chest:'normal', type:'coral-garden' },
+      { key:'coral_core_05', name:'Coral Core V',  level:+16, size:+2, depth:+2, chest:'more',   type:'coral-garden' },
+      { key:'coral_core_06', name:'Coral Core VI', level:+20, size:+2, depth:+3, chest:'less',   type:'coral-garden' },
+      { key:'coral_core_07', name:'Coral Core VII',level:+24, size:+3, depth:+3, chest:'normal', type:'coral-garden' }
+    ],
+    blocks3:[
+      { key:'coral_relic_01', name:'Coral Relic I', level:+0,  size:0,  depth:+2, chest:'more',    type:'coral-garden', bossFloors:[4] },
+      { key:'coral_relic_02', name:'Coral Relic II',level:+5,  size:+1, depth:+2, chest:'normal',  type:'coral-garden', bossFloors:[8] },
+      { key:'coral_relic_03', name:'Coral Relic III',level:+10, size:+1, depth:+3, chest:'less',   type:'coral-garden', bossFloors:[12] },
+      { key:'coral_relic_04', name:'Coral Relic IV', level:+15, size:+2, depth:+3, chest:'normal', type:'coral-garden', bossFloors:[16] },
+      { key:'coral_relic_05', name:'Coral Relic V',  level:+20, size:+2, depth:+4, chest:'more',   type:'coral-garden', bossFloors:[20] },
+      { key:'coral_relic_06', name:'Coral Relic VI', level:+25, size:+2, depth:+4, chest:'less',   type:'coral-garden', bossFloors:[20] }
+    ]
+  };
+
+  window.registerDungeonAddon({ id:'coral_garden_pack', name:'Coral Garden Pack', version:'1.0.0', blocks, generators:[gen] });
+})();

--- a/dungeontypes/luminescent_glade.js
+++ b/dungeontypes/luminescent_glade.js
@@ -1,0 +1,103 @@
+// Addon: Luminescent Glade - glowing fungal forest with bioluminescent pools
+(function(){
+  function algorithm(ctx){
+    const W = ctx.width;
+    const H = ctx.height;
+    const map = ctx.map;
+
+    for(let y=0;y<H;y++){
+      for(let x=0;x<W;x++){
+        const edge = x===0 || y===0 || x===W-1 || y===H-1;
+        map[y][x] = edge ? 1 : (ctx.random() < 0.48 ? 1 : 0);
+      }
+    }
+
+    for(let iter=0; iter<4; iter++){
+      const next = map.map(row => row.slice());
+      for(let y=1;y<H-1;y++){
+        for(let x=1;x<W-1;x++){
+          let walls = 0;
+          for(let yy=y-1; yy<=y+1; yy++){
+            for(let xx=x-1; xx<=x+1; xx++){
+              if(xx===x && yy===y) continue;
+              if(map[yy][xx] === 1) walls++;
+            }
+          }
+          const threshold = iter < 2 ? 4 : 5;
+          next[y][x] = walls >= threshold ? 1 : 0;
+        }
+      }
+      for(let y=1;y<H-1;y++){
+        for(let x=1;x<W-1;x++) map[y][x] = next[y][x];
+      }
+    }
+
+    for(let y=0;y<H;y++){
+      for(let x=0;x<W;x++){
+        if(map[y][x] === 0){
+          const glow = Math.sin((x+y)/4) * 0.1 + 0.15;
+          const g = Math.max(0, Math.min(1, 0.6 + glow));
+          ctx.setFloorColor(x,y,`rgba(${Math.floor(80 + g*80)}, ${Math.floor(200*g)}, ${Math.floor(160 + glow*255)}, 1)`);
+        } else {
+          const tint = 0.3 + (Math.sin(y/3) * 0.1);
+          ctx.setWallColor(x,y,`rgba(${Math.floor(30 + tint*60)}, ${Math.floor(90 + tint*90)}, ${Math.floor(120 + tint*70)}, 1)`);
+        }
+      }
+    }
+
+    for(let i=0;i<Math.floor((W*H)/60);i++){
+      const rx = Math.floor(ctx.random()*W);
+      const ry = Math.floor(ctx.random()*H);
+      ctx.setFloorTexture(rx, ry, 'glow_pool');
+    }
+
+    ctx.ensureConnectivity();
+  }
+
+  const gen = {
+    id: 'luminescent-glade',
+    name: '光る木立',
+    description: '発光する水たまりが点在する神秘的な木立のダンジョン',
+    algorithm,
+    mixin: { normalMixed: 0.45, blockDimMixed: 0.6, tags: ['forest','bioluminescent','mystic'] }
+  };
+
+  function mkBoss(depth){
+    const floors = [];
+    if(depth >= 5) floors.push(5);
+    if(depth >= 9) floors.push(9);
+    if(depth >= 14) floors.push(14);
+    return floors;
+  }
+
+  const blocks = {
+    blocks1:[
+      { key:'lumigrove_theme_01', name:'Glade Theme I', level:+0,  size:0,  depth:+1, chest:'normal', type:'luminescent-glade', bossFloors:mkBoss(5) },
+      { key:'lumigrove_theme_02', name:'Glade Theme II', level:+4,  size:+1, depth:+1, chest:'less',   type:'luminescent-glade', bossFloors:mkBoss(7) },
+      { key:'lumigrove_theme_03', name:'Glade Theme III',level:+8,  size:+1, depth:+1, chest:'more',  type:'luminescent-glade', bossFloors:mkBoss(9) },
+      { key:'lumigrove_theme_04', name:'Glade Theme IV', level:+12, size:+1, depth:+2, chest:'normal',type:'luminescent-glade', bossFloors:mkBoss(11) },
+      { key:'lumigrove_theme_05', name:'Glade Theme V',  level:+16, size:+2, depth:+2, chest:'more', type:'luminescent-glade', bossFloors:mkBoss(13) },
+      { key:'lumigrove_theme_06', name:'Glade Theme VI', level:+20, size:+2, depth:+3, chest:'less', type:'luminescent-glade', bossFloors:mkBoss(15) },
+      { key:'lumigrove_theme_07', name:'Glade Theme VII',level:+24, size:+2, depth:+3, chest:'normal',type:'luminescent-glade', bossFloors:mkBoss(17) }
+    ],
+    blocks2:[
+      { key:'lumigrove_core_01', name:'Glade Core I', level:+0,  size:+1, depth:0,  chest:'normal', type:'luminescent-glade' },
+      { key:'lumigrove_core_02', name:'Glade Core II',level:+5,  size:+1, depth:+1, chest:'more',   type:'luminescent-glade' },
+      { key:'lumigrove_core_03', name:'Glade Core III',level:+9,  size:+1, depth:+1, chest:'less',   type:'luminescent-glade' },
+      { key:'lumigrove_core_04', name:'Glade Core IV', level:+13, size:+2, depth:+2, chest:'normal', type:'luminescent-glade' },
+      { key:'lumigrove_core_05', name:'Glade Core V',  level:+17, size:+2, depth:+2, chest:'more',   type:'luminescent-glade' },
+      { key:'lumigrove_core_06', name:'Glade Core VI', level:+21, size:+2, depth:+3, chest:'less',   type:'luminescent-glade' },
+      { key:'lumigrove_core_07', name:'Glade Core VII',level:+25, size:+3, depth:+3, chest:'normal', type:'luminescent-glade' }
+    ],
+    blocks3:[
+      { key:'lumigrove_relic_01', name:'Glade Relic I', level:+0,  size:0,  depth:+2, chest:'more',    type:'luminescent-glade', bossFloors:[5] },
+      { key:'lumigrove_relic_02', name:'Glade Relic II',level:+6,  size:+1, depth:+2, chest:'normal',  type:'luminescent-glade', bossFloors:[7] },
+      { key:'lumigrove_relic_03', name:'Glade Relic III',level:+12, size:+1, depth:+3, chest:'less',   type:'luminescent-glade', bossFloors:[9] },
+      { key:'lumigrove_relic_04', name:'Glade Relic IV', level:+18, size:+2, depth:+3, chest:'normal', type:'luminescent-glade', bossFloors:[11] },
+      { key:'lumigrove_relic_05', name:'Glade Relic V',  level:+24, size:+2, depth:+4, chest:'more',   type:'luminescent-glade', bossFloors:[13] },
+      { key:'lumigrove_relic_06', name:'Glade Relic VI', level:+30, size:+2, depth:+4, chest:'less',   type:'luminescent-glade', bossFloors:[15] }
+    ]
+  };
+
+  window.registerDungeonAddon({ id:'luminescent_glade_pack', name:'Luminescent Glade Pack', version:'1.0.0', blocks, generators:[gen] });
+})();

--- a/dungeontypes/manifest.json.js
+++ b/dungeontypes/manifest.json.js
@@ -23,5 +23,10 @@ window.DUNGEONTYPE_MANIFEST = [
   { id: 'irradiated_plains_pack', name: 'Irradiated Plains Pack', entry: 'dungeontypes/irradiated_plains.js', version: '1.0.0', author: 'builtin-sample' },
   { id: 'conveyor_foundry_pack', name: 'Conveyor Foundry Pack', entry: 'dungeontypes/conveyor_foundry.js', version: '1.0.0', author: 'builtin-sample' },
   { id: 'oneway_labyrinth_pack', name: 'One-Way Labyrinth Pack', entry: 'dungeontypes/oneway_labyrinth.js', version: '1.0.0', author: 'builtin-sample' },
-  { id: 'axis_gallery_pack', name: 'Axis Gallery Pack', entry: 'dungeontypes/axis_gallery.js', version: '1.0.0', author: 'builtin-sample' }
+  { id: 'axis_gallery_pack', name: 'Axis Gallery Pack', entry: 'dungeontypes/axis_gallery.js', version: '1.0.0', author: 'builtin-sample' },
+  { id: 'luminescent_glade_pack', name: 'Luminescent Glade Pack', entry: 'dungeontypes/luminescent_glade.js', version: '1.0.0', author: 'builtin-sample' },
+  { id: 'coral_garden_pack', name: 'Coral Garden Pack', entry: 'dungeontypes/coral_garden.js', version: '1.0.0', author: 'builtin-sample' },
+  { id: 'amber_marsh_pack', name: 'Amber Marsh Pack', entry: 'dungeontypes/amber_marsh.js', version: '1.0.0', author: 'builtin-sample' },
+  { id: 'bamboo_hollows_pack', name: 'Bamboo Hollows Pack', entry: 'dungeontypes/bamboo_hollows.js', version: '1.0.0', author: 'builtin-sample' },
+  { id: 'starlit_canopy_pack', name: 'Starlit Canopy Pack', entry: 'dungeontypes/starlit_canopy.js', version: '1.0.0', author: 'builtin-sample' }
 ];

--- a/dungeontypes/starlit_canopy.js
+++ b/dungeontypes/starlit_canopy.js
@@ -1,0 +1,107 @@
+// Addon: Starlit Canopy - moonlit treetops and glowing constellations
+(function(){
+  function algorithm(ctx){
+    const W = ctx.width;
+    const H = ctx.height;
+    const map = ctx.map;
+
+    for(let y=0;y<H;y++){
+      for(let x=0;x<W;x++){
+        const edge = x===0 || y===0 || x===W-1 || y===H-1;
+        map[y][x] = edge ? 1 : (ctx.random() < 0.46 ? 1 : 0);
+      }
+    }
+
+    for(let iter=0; iter<4; iter++){
+      const next = map.map(row => row.slice());
+      for(let y=1;y<H-1;y++){
+        for(let x=1;x<W-1;x++){
+          let walls = 0;
+          for(let yy=y-1; yy<=y+1; yy++){
+            for(let xx=x-1; xx<=x+1; xx++){
+              if(xx===x && yy===y) continue;
+              if(map[yy][xx] === 1) walls++;
+            }
+          }
+          const threshold = iter < 2 ? 4 : 5;
+          next[y][x] = walls >= threshold ? 1 : 0;
+        }
+      }
+      for(let y=1;y<H-1;y++){
+        for(let x=1;x<W-1;x++) map[y][x] = next[y][x];
+      }
+    }
+
+    for(let y=0;y<H;y++){
+      for(let x=0;x<W;x++){
+        if(map[y][x] === 0){
+          const night = 0.5 + 0.5*Math.sin((x/5)+(y/7));
+          const blue = Math.floor(150 + night*80);
+          ctx.setFloorColor(x,y,`rgb(${60 + Math.floor(night*40)}, ${80 + Math.floor(night*60)}, ${blue})`);
+          if(ctx.random() < 0.08){
+            ctx.setFloorTexture(x,y,'starlight');
+          }
+        } else {
+          const glow = 0.2 + 0.2*Math.sin(y/3);
+          ctx.setWallColor(x,y,`rgba(${40}, ${70 + Math.floor(glow*120)}, ${120 + Math.floor(glow*100)}, 1)`);
+        }
+      }
+    }
+
+    for(let i=0;i<Math.floor(W*H/50);i++){
+      const rx = Math.floor(ctx.random()*W);
+      const ry = Math.floor(ctx.random()*H);
+      ctx.setAmbientEffect(rx, ry, 'firefly');
+    }
+
+    ctx.ensureConnectivity();
+  }
+
+  const gen = {
+    id: 'starlit-canopy',
+    name: '星影樹海',
+    description: '夜空の星々が照らす高木の樹海',
+    algorithm,
+    mixin: { normalMixed: 0.42, blockDimMixed: 0.55, tags: ['forest','night','celestial'] }
+  };
+
+  function boss(depth){
+    const arr = [];
+    if(depth >= 5) arr.push(5);
+    if(depth >= 10) arr.push(10);
+    if(depth >= 15) arr.push(15);
+    if(depth >= 20) arr.push(20);
+    return arr;
+  }
+
+  const blocks = {
+    blocks1:[
+      { key:'starlit_theme_01', name:'Canopy Theme I', level:+0,  size:0,  depth:+1, chest:'normal', type:'starlit-canopy', bossFloors:boss(5) },
+      { key:'starlit_theme_02', name:'Canopy Theme II', level:+4,  size:+1, depth:+1, chest:'less',   type:'starlit-canopy', bossFloors:boss(7) },
+      { key:'starlit_theme_03', name:'Canopy Theme III',level:+8,  size:+1, depth:+1, chest:'more',   type:'starlit-canopy', bossFloors:boss(9) },
+      { key:'starlit_theme_04', name:'Canopy Theme IV', level:+12, size:+1, depth:+2, chest:'normal', type:'starlit-canopy', bossFloors:boss(11) },
+      { key:'starlit_theme_05', name:'Canopy Theme V',  level:+16, size:+2, depth:+2, chest:'less',   type:'starlit-canopy', bossFloors:boss(13) },
+      { key:'starlit_theme_06', name:'Canopy Theme VI', level:+20, size:+2, depth:+2, chest:'normal', type:'starlit-canopy', bossFloors:boss(15) },
+      { key:'starlit_theme_07', name:'Canopy Theme VII',level:+24, size:+2, depth:+3, chest:'more',   type:'starlit-canopy', bossFloors:boss(17) }
+    ],
+    blocks2:[
+      { key:'starlit_core_01', name:'Canopy Core I', level:+0,  size:+1, depth:0,  chest:'normal', type:'starlit-canopy' },
+      { key:'starlit_core_02', name:'Canopy Core II',level:+5,  size:+1, depth:+1, chest:'more',   type:'starlit-canopy' },
+      { key:'starlit_core_03', name:'Canopy Core III',level:+9,  size:+1, depth:+1, chest:'less',   type:'starlit-canopy' },
+      { key:'starlit_core_04', name:'Canopy Core IV', level:+13, size:+1, depth:+2, chest:'normal', type:'starlit-canopy' },
+      { key:'starlit_core_05', name:'Canopy Core V',  level:+17, size:+2, depth:+2, chest:'more',   type:'starlit-canopy' },
+      { key:'starlit_core_06', name:'Canopy Core VI', level:+21, size:+2, depth:+3, chest:'less',   type:'starlit-canopy' },
+      { key:'starlit_core_07', name:'Canopy Core VII',level:+25, size:+3, depth:+3, chest:'normal', type:'starlit-canopy' }
+    ],
+    blocks3:[
+      { key:'starlit_relic_01', name:'Canopy Relic I', level:+0,  size:0,  depth:+2, chest:'more',    type:'starlit-canopy', bossFloors:[5] },
+      { key:'starlit_relic_02', name:'Canopy Relic II',level:+6,  size:+1, depth:+2, chest:'normal',  type:'starlit-canopy', bossFloors:[10] },
+      { key:'starlit_relic_03', name:'Canopy Relic III',level:+12, size:+1, depth:+3, chest:'less',   type:'starlit-canopy', bossFloors:[15] },
+      { key:'starlit_relic_04', name:'Canopy Relic IV', level:+18, size:+2, depth:+3, chest:'normal', type:'starlit-canopy', bossFloors:[20] },
+      { key:'starlit_relic_05', name:'Canopy Relic V',  level:+24, size:+2, depth:+4, chest:'more',   type:'starlit-canopy', bossFloors:[20] },
+      { key:'starlit_relic_06', name:'Canopy Relic VI', level:+30, size:+2, depth:+4, chest:'less',   type:'starlit-canopy', bossFloors:[20] }
+    ]
+  };
+
+  window.registerDungeonAddon({ id:'starlit_canopy_pack', name:'Starlit Canopy Pack', version:'1.0.0', blocks, generators:[gen] });
+})();


### PR DESCRIPTION
## Summary
- introduce Luminescent Glade, Coral Garden, Amber Marsh, Bamboo Hollows, and Starlit Canopy generators with bespoke environmental effects
- register each pack with around twenty themed block definitions blending progression, loot distribution, and boss floors
- update the addon manifest so the new nature packs are available in the selector

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8dedb3874832ba37a34eb36d956dc