### PR TITLE
Fix duplicate identifier errors in dungeon addon mixColor helpers

### DIFF
--- a/dungeontypes/abyssal_whorl.js
+++ b/dungeontypes/abyssal_whorl.js
@@ -95,8 +95,8 @@
     const rb=(pb>>16)&0xff, gb=(pb>>8)&0xff, bb=pb&0xff;
     const r=Math.round(ra+(rb-ra)*t);
     const g=Math.round(ga+(gb-ga)*t);
-    const b=Math.round(ba+(bb-ba)*t);
-    return `#${r.toString(16).padStart(2,'0')}${g.toString(16).padStart(2,'0')}${b.toString(16).padStart(2,'0')}`;
+    const blue=Math.round(ba+(bb-ba)*t);
+    return `#${r.toString(16).padStart(2,'0')}${g.toString(16).padStart(2,'0')}${blue.toString(16).padStart(2,'0')}`;
   }
 
   const gen = {

--- a/dungeontypes/emberglass_caverns.js
+++ b/dungeontypes/emberglass_caverns.js
@@ -29,8 +29,8 @@
     const rb=(pb>>16)&0xff, gb=(pb>>8)&0xff, bb=pb&0xff;
     const r=Math.round(ra+(rb-ra)*t);
     const g=Math.round(ga+(gb-ga)*t);
-    const b=Math.round(ba+(bb-ba)*t);
-    return `#${r.toString(16).padStart(2,'0')}${g.toString(16).padStart(2,'0')}${b.toString(16).padStart(2,'0')}`;
+    const blue=Math.round(ba+(bb-ba)*t);
+    return `#${r.toString(16).padStart(2,'0')}${g.toString(16).padStart(2,'0')}${blue.toString(16).padStart(2,'0')}`;
   }
 
   function algorithm(ctx){

--- a/dungeontypes/prismatic_stalactites.js
+++ b/dungeontypes/prismatic_stalactites.js
@@ -9,8 +9,8 @@
     const rb = (pb >> 16) & 0xff, gb = (pb >> 8) & 0xff, bb = pb & 0xff;
     const r = Math.round(lerp(ra, rb, t));
     const g = Math.round(lerp(ga, gb, t));
-    const b = Math.round(lerp(ba, bb, t));
-    return `#${r.toString(16).padStart(2,'0')}${g.toString(16).padStart(2,'0')}${b.toString(16).padStart(2,'0')}`;
+    const blue = Math.round(lerp(ba, bb, t));
+    return `#${r.toString(16).padStart(2,'0')}${g.toString(16).padStart(2,'0')}${blue.toString(16).padStart(2,'0')}`;
   }
 
   function algorithm(ctx){


### PR DESCRIPTION
## Summary
- rename the blue-channel temporary in each addon mixColor helper to avoid redeclaration syntax errors
- keep the addon registrations aligned with the documented dungeon addon API so the packs load cleanly

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d8eb6e4400832bb3f8f11dc64f09d7