### PR TITLE
Make the skills modal SP readout sticky

### DIFF
--- a/index.html
+++ b/index.html
@@ -1005,6 +1005,15 @@
     <div id="skills-modal" class="modal" style="display:none;">
         <div class="modal-content skills-modal">
             <h3>スキル</h3>
+            <div id="skills-current-sp" class="skills-current-sp" aria-live="polite">
+                <div class="skills-sp-header">
+                    <span class="skills-sp-label">現在のSP</span>
+                    <span class="skills-sp-value">0/0</span>
+                </div>
+                <div class="skills-sp-bar" aria-hidden="true">
+                    <div class="skills-sp-bar-fill"></div>
+                </div>
+            </div>
             <div id="skills-list" class="skills-list" aria-live="polite"></div>
             <button class="close-modal" data-target="skills-modal">閉じる</button>
         </div>

--- a/main.js
+++ b/main.js
@@ -36,6 +36,9 @@ const itemsModal = document.getElementById('items-modal');
 const statusModal = document.getElementById('status-modal');
 const skillsModal = document.getElementById('skills-modal');
 const skillsList = document.getElementById('skills-list');
+const skillsSpText = document.getElementById('skills-current-sp');
+const skillsSpValueText = skillsSpText ? skillsSpText.querySelector('.skills-sp-value') : null;
+const skillsSpBarFill = skillsSpText ? skillsSpText.querySelector('.skills-sp-bar-fill') : null;
 const invPotion30 = document.getElementById('inv-potion30');
 const invHpBoost = document.getElementById('inv-hp-boost');
 const invAtkBoost = document.getElementById('inv-atk-boost');
@@ -2054,6 +2057,21 @@ function renderSkillsList() {
     updatePlayerSpCap({ silent: true });
     const currentSp = Math.max(0, Number(player.sp) || 0);
     const maxSp = Math.max(0, Number(player.maxSp) || 0);
+    const formattedCurrentSp = currentSp % 1 === 0 ? Math.floor(currentSp) : currentSp.toFixed(1);
+    const spText = maxSp > 0 ? `${formattedCurrentSp}/${maxSp}` : '0/0';
+    if (skillsSpText) {
+        const liveText = `現在のSP: ${spText}`;
+        if (skillsSpValueText) {
+            skillsSpValueText.textContent = spText;
+        } else {
+            skillsSpText.textContent = liveText;
+        }
+        if (skillsSpBarFill) {
+            const spRatio = maxSp > 0 ? Math.min(1, Math.max(0, currentSp / maxSp)) : 0;
+            skillsSpBarFill.style.width = `${Math.round(spRatio * 10000) / 100}%`;
+        }
+        skillsSpText.setAttribute('aria-label', liveText);
+    }
     SKILL_DEFINITIONS.forEach(def => {
         const entry = document.createElement('div');
         entry.className = 'skill-entry';
@@ -2064,7 +2082,6 @@ function renderSkillsList() {
         nameEl.textContent = def.name;
         const metaEl = document.createElement('div');
         metaEl.className = 'skill-meta';
-        const spText = maxSp > 0 ? `${currentSp % 1 === 0 ? Math.floor(currentSp) : currentSp.toFixed(1)}/${maxSp}` : '0/0';
         metaEl.textContent = `消費SP: ${def.cost} / 所持: ${spText}`;
         const availability = evaluateSkillAvailability(def);
         if (!availability.available && availability.reason) {

--- a/style.css
+++ b/style.css
@@ -985,11 +985,69 @@ body.in-game #player-summary { display: none; }
     width: min(560px, 92vw);
 }
 
+.skills-current-sp {
+    position: sticky;
+    top: 24px;
+    z-index: 2;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 14px 18px;
+    margin: 12px 0 20px;
+    border-radius: 16px;
+    background: linear-gradient(135deg, rgba(255,255,255,0.95), rgba(236,241,255,0.9));
+    border: 1px solid rgba(102, 126, 234, 0.3);
+    box-shadow: 0 14px 32px rgba(102, 126, 234, 0.18);
+    color: rgba(44, 62, 80, 0.85);
+    backdrop-filter: blur(12px);
+}
+
+.skills-sp-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+}
+
+.skills-sp-label {
+    text-transform: uppercase;
+    font-size: 13px;
+    color: rgba(44, 62, 80, 0.6);
+    letter-spacing: 0.08em;
+}
+
+.skills-sp-value {
+    font-size: 16px;
+    font-weight: 700;
+    color: rgba(44, 62, 80, 0.9);
+}
+
+.skills-sp-bar {
+    position: relative;
+    width: 100%;
+    height: 12px;
+    border-radius: 999px;
+    background: rgba(102, 126, 234, 0.15);
+    overflow: hidden;
+}
+
+.skills-sp-bar-fill {
+    position: absolute;
+    inset: 0;
+    width: 0%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, #667eea, #764ba2);
+    box-shadow: 0 0 20px rgba(102, 126, 234, 0.45);
+    transition: width 0.25s ease-out;
+}
+
 .skills-list {
     display: flex;
     flex-direction: column;
     gap: 12px;
-    margin: 16px 0;
+    margin: 0 0 16px;
 }
 
 .skills-list .skill-entry {


### PR DESCRIPTION
## Summary
- keep the skills modal SP indicator visible by wrapping it in a sticky, glassmorphic card within the skills modal
- add a gradient SP progress bar and hook it up to the existing render logic so the fill and accessible label track the player’s current/max SP
- adjust surrounding spacing in the modal so the skill list flows beneath the floating SP card

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8eb9b7fb4832b94847dbd95b43617