### PR TITLE
Add Renju stone board mode with foul detection

### DIFF
--- a/games/manifest.json.js
+++ b/games/manifest.json.js
@@ -12,6 +12,7 @@ window.MINIEXP_MANIFEST = [
 '持ち駒と成りを駆使する本格将棋。指し手/捕獲/王手でEXP', category: 'ボード' },
   { id: 'connect6',    name: 'コネクトシックス', entry: 'games/stone_board_games.js', version: '0.1.0', author: 'mod', description: '六目並べ。配置+1/リーチ+10/勝利で高EXP', category: 'ボード' },
   { id: 'gomoku',      name: '五目並べ',        entry: 'games/stone_board_games.js', version: '0.1.0', author: 'mod', description: '配置+1/リーチ+10/勝利ボーナス', category: 'ボード' },
+  { id: 'renju',       name: '連珠',            entry: 'games/stone_board_games.js', version: '0.1.0', author: 'mod', description: '禁手ルール付き五目並べ。配置+1/リーチ+10/勝利ボーナス', category: 'ボード' },
   { id: 'go',          name: '囲碁',            entry: 'games/go.js',             version: '0.1.0', author: 'mod', description: '配置+1/捕獲ボーナス/勝利EXP', category: 'ボード' },
   { id: 'connect4',    name: '四目並べ',        entry: 'games/stone_board_games.js', version: '0.1.0', author: 'mod', description: '落下式四目。配置+1/リーチ+10', category: 'ボード' },
   { id: 'tic_tac_toe', name: '三目並べ',        entry: 'games/stone_board_games.js', version: '0.1.0', author: 'mod', description: '配置+1/リーチ+10/シンプル勝利EXP', category: 'ボード' },


### PR DESCRIPTION
## Summary
- add a Renju ruleset to the shared stone board mini-game configuration and manifest
- implement Renju foul detection, popup feedback, and highlight rendering for illegal moves
- update AI move generation and heuristics to respect Renju restrictions when applicable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8f2b9af9c832bb4e7373167adb930