### PR TITLE
Expand SF dungeon pack with new themes and blocks

### DIFF
--- a/SFダンジョン生成追加パックMODの設計.md
+++ b/SFダンジョン生成追加パックMODの設計.md
@@ -1,0 +1,353 @@
+# SFダンジョン生成追加パックMOD 設計書（API v1 実装準拠）
+
+## 1. 概要
+- **目的**: 既存ゲームの `registerDungeonAddon` API に沿って、宇宙船・サイバー空間・未来都市を中心とした SF テーマのダンジョン生成と大量の BlockDim ブロックを追加する。
+- **対象バージョン**: `main.js`（2025-09-16 時点）で公開されている DungeonType/BlockDim MOD API v1。
+- **主な特徴**:
+  - ダンジョンタイプ系統を10カテゴリ・計50タイプまで拡張し、Normal/BlockDim 両モードの混合抽選に対応。
+  - 各タイプは床/壁/アクセント色のカラーパレットと照明設定を JSON 定義で提供し、光源タグを最大3色まで許容。
+  - 110種の BlockDim ブロック（1st/2nd/3rd 段階 32/43/35 構成）と5次元追加、危険ギミック・ユーティリティを含めた豊富なバリエーション。
+  - `ctx.structures.place`・`ctx.carvePath`・`ctx.ensureConnectivity` など現行 API が提供するユーティリティを活用した生成アルゴリズムを設計。
+  - マニフェスト/レジストリ統合フロー、テスト計画、将来拡張のブレインストーミングを整理。
+
+## 2. API連携とモジュール構成
+### 2.1 ファイル構造
+```
+dungeontypes/
+  ├─ manifest.json.js  // window.DUNGEONTYPE_MANIFEST を定義
+  ├─ sf_expansion.js   // 本アドオン本体
+  ├─ structures.json   // 任意: 構造テンプレート別出力
+  └─ palettes.json     // 任意: カラーパレット設定
+```
+
+### 2.2 登録手順
+1. `manifest.json.js` に `{ id: 'sf_pack', entry: 'dungeontypes/sf_expansion.js', name: 'SF Expansion' }` を追加。
+2. `sf_expansion.js` は即時関数で `window.registerDungeonAddon(addonDef);` を呼び出す。`addonDef` は以下のプロパティを持つ:
+   - `id: 'sf_pack'`
+   - `api: '1.0.0'`（API バージョン）
+   - `blocks: { dimensions, blocks1, blocks2, blocks3 }`
+   - `structures: [...]`（必要な静的パターン）
+  - `generators: [...]`（後述50タイプを定義）
+3. `main.js` 側は読み込み時に `DungeonGenRegistry` と BlockDim テーブルへ統合する。
+
+### 2.3 BlockSpec の割り当て規則
+- `type` フィールドに対応する生成タイプ ID を格納。Normal 混合向けには `mixin.normalMixed` を 0.2〜0.5 程度で調整。
+- `level`/`size`/`depth`/`chest` などはゲーム内バランスと連携。極端な値は避け、±2 程度の補正幅を基本とする。
+- 追加ディメンションには `baseLevel` と `description` を付与し、BlockDim UI に表示されるようにする。
+
+### 2.4 サンプルスケルトン
+```js
+(function(){
+  const addon = {
+    id: 'sf_pack',
+    name: 'SF Expansion Pack',
+    api: '1.0.0',
+    description: '宇宙船・サイバー空間・未来都市など50タイプを収録した大規模SF拡張。',
+    structures: createStructures(),
+    blocks: createBlocks(),
+    generators: createGenerators()
+  };
+  window.registerDungeonAddon(addon);
+})();
+```
+`createGenerators()` で返す各タイプの `algorithm(ctx)` 内では、`ctx.set(x, y, 0|1)`・`ctx.carvePath(x1, y1, x2, y2)`・`ctx.ensureConnectivity()`・`ctx.aStar(start, goal)` を組み合わせる。
+
+## 3. 追加ダンジョンタイプ体系
+### 3.1 テーマカテゴリ一覧
+| 系統 | タイプID | 名称 | 床/壁/アクセント色 | 主な追加ブロック | Normal混合 | BlockDim混合 |
+|------|----------|------|--------------------|------------------|------------|--------------|
+| 宇宙船セクション | `spaceship_core` | 機関部ノード | #0F1E33 / #08111F / #2FD3FF | リアクターハブ、磁束導管、プラズマ遮蔽壁 | 0.30 | 0.50 |
+| | `spaceship_hab` | 居住区モジュール | #1F2D3F / #32465A / #4BE2C2 | スリープポッド、循環農園床、生活配線 | 0.25 | 0.40 |
+| | `spaceship_dock` | ドックベイ | #15283B / #071421 / #5AA4FF | ドッキングクランプ、貨物軌条、強化観測窓 | 0.35 | 0.50 |
+| | `spaceship_ai` | 指令AI中枢 | #112233 / #050B11 / #7E5CFF | 演算コア、監視ノード、シールドハッチ | 0.20 | 0.35 |
+| | `spaceship_medbay` | メディカルベイ | #143347 / #0B1E2B / #55F3E9 | 滅菌床、救急ポッド、バイタルサージ壁 | 0.22 | 0.35 |
+| | `spaceship_engineering` | 保守機関層 | #1A2639 / #0A141F / #FFB347 | 熱交換床、補修アーム、補強梁 | 0.28 | 0.45 |
+| | `spaceship_warp` | ワープハンガー | #081F38 / #050D18 / #5C9DFF | ワープ導管、ゲートリング、遮蔽隔壁 | 0.18 | 0.32 |
+| | `spaceship_observatory` | 星間観測ドーム | #0C1F33 / #091423 / #7DE9FF | 星図投影床、観測アレイ、透明ドーム | 0.20 | 0.34 |
+| サイバー空間層 | `cyber_grid` | データグリッド | #090513 / #211A6B / #45E0FF | 光子タイル、量子ゲート、グリッドノード | 0.30 | 0.45 |
+| | `cyber_vault` | セキュリティヴォールト | #12132A / #2E1B4B / #8F53FF | ファイアウォール壁、暗号鍵ポッド、ICE塔 | 0.25 | 0.40 |
+| | `cyber_glitch` | グリッチ領域 | #0A3B3C / #0F1F20 / #C1FF2E | グリッチ床、デシンク壁、乱数ポータル | 0.15 | 0.35 |
+| | `cyber_stream` | 情報フロー帯 | #051B2C / #0B3857 / #1BFF9F | フローライン床、信号橋、バンド幅調整器 | 0.30 | 0.40 |
+| | `cyber_forum` | ソーシャルホール | #1A0D3A / #3A1266 / #FF4BD1 | ホログラム座席、議論リング、共鳴壁 | 0.28 | 0.42 |
+| | `cyber_subroutine` | サブルーチン回廊 | #051F2A / #04353F / #5CFF8F | サブルーチン床、診断壁、同期ゲート | 0.32 | 0.45 |
+| | `cyber_arena` | シミュレーションアリーナ | #0A1230 / #1C2461 / #FF43B9 | ホログラム壁、訓練リング、シールドポール | 0.26 | 0.40 |
+| | `cyber_mirror` | ミラールーム | #071428 / #1D305A / #7CFFEE | 反射壁、ミラーシャード、折り畳み回廊 | 0.21 | 0.36 |
+| 未来都市区画 | `future_plaza` | ホログラム広場 | #124652 / #1D6F7A / #3BFFFF | ホロパネル、空中歩道、広告塔 | 0.35 | 0.50 |
+| | `future_industrial` | メガ工場層 | #1E2B3C / #3A5169 / #FFBF3B | コンベア、ナノ炉、補強支柱 | 0.30 | 0.45 |
+| | `future_sky` | スカイドメイン | #101A33 / #233A66 / #77F6FF | 浮遊プラットフォーム、垂直エレベーター、風制御壁 | 0.25 | 0.40 |
+| | `future_core` | 都市制御局 | #162938 / #0C141D / #49FFB5 | コントロール卓、データ塔、監視ガラス | 0.20 | 0.35 |
+| | `future_residential` | コロニー住居帯 | #1B2F39 / #223B44 / #7FFFD7 | モジュラーフロア、隣接バルコニー、遮光壁 | 0.32 | 0.45 |
+| | `future_underworks` | アンダーワークス | #0D1724 / #121E2D / #88FF52 | 保守トンネル、廃熱管、補修橋 | 0.26 | 0.38 |
+| | `future_metro` | ハイパーメトロ網 | #142A38 / #1B3C4F / #54FFE2 | リニア軌条、乗換プラットフォーム、信号塔 | 0.33 | 0.48 |
+| | `future_cloudport` | クラウドポート | #12284C / #152036 / #8DFFFA | 浮遊港、気流橋、アンカータワー | 0.24 | 0.38 |
+| 軌道・星間施設 | `orbital_ring` | 軌道リング廊 | #111B28 / #202F45 / #64FFE3 | 慣性制御床、ソーラーパネル壁、軌道ハブ | 0.30 | 0.45 |
+| | `orbital_lab` | 真空ラボ | #132435 / #06121E / #7BD8FF | 真空ロック、零G実験床、封印カプセル | 0.25 | 0.35 |
+| | `orbital_armory` | 軍備庫層 | #1B1E2B / #2F3547 / #FF4F64 | 軍事ラック、磁気弾薬庫、反応装甲壁 | 0.20 | 0.35 |
+| | `orbital_greenhouse` | 宇宙温室帯 | #123123 / #071A10 / #6CFF7A | 水耕床、光合成パネル、気圧バリア | 0.22 | 0.35 |
+| | `orbital_command` | 指令甲板 | #0F1626 / #1D2740 / #4CF0FF | 指揮卓、センサー壁、緊急転送床 | 0.18 | 0.32 |
+| | `orbital_scrapyard` | 軌道スクラップ場 | #1B1F2C / #242F3D / #FF7B42 | 廃船板、修繕クレーン、浮遊支柱 | 0.27 | 0.38 |
+| | `orbital_listening` | リスニングステーション | #0E1D2F / #142A3F / #4CF2FF | アンテナアレイ、傍受ディッシュ、共鳴床 | 0.19 | 0.32 |
+| 量子・時間研究群 | `quantum_reactor` | 量子炉チャンバー | #170B2C / #2A1752 / #FF3CF0 | 量子束柱、位相制御床、特異点遮蔽 | 0.20 | 0.30 |
+| | `quantum_archive` | 記録保管層 | #1F142E / #2C1F43 / #3CE3FF | 時間結晶書架、クロノ端末、安定化壁 | 0.15 | 0.30 |
+| | `quantum_void` | 位相虚空 | #04070E / #000000 / #66FFAA | 虚空タイル、位相門、次元杭 | 0.10 | 0.25 |
+| | `quantum_prism` | プリズム観測塔 | #1E0E36 / #2F125A / #FFD84F | プリズム床、光束導鏡、スペクトラム壁 | 0.18 | 0.28 |
+| | `quantum_flux` | フラックス遷移域 | #150926 / #26103F / #FF72ED | 位相リボン、共鳴柱、フラックスゲート | 0.17 | 0.30 |
+| | `chrono_station` | 時間駅 | #14243E / #233861 / #FF6BC4 | 時間導線床、停滞ホーム、クロノ壁 | 0.16 | 0.30 |
+| | `chrono_archive` | 時間アーカイブ | #111C31 / #19273F / #FF85D6 | 年代書架、クロノ織路、位相索引 | 0.15 | 0.29 |
+| | `chrono_loop` | 反復ループ域 | #0B1A21 / #132A32 / #74FFE5 | ループ床、逆再生ポータル、時間梁 | 0.14 | 0.28 |
+| | `chrono_fracture` | 時空断層帯 | #0A1A24 / #121F2C / #74FFF4 | 断層ゲート、時間楔、乱流裂け目 | 0.13 | 0.28 |
+| 異星バイオーム | `xeno_jungle` | 異星樹海 | #093326 / #042018 / #5BFF8C | バイオルミ床、樹液壁、寄生蔓 | 0.28 | 0.38 |
+| | `xeno_crystal` | 結晶洞 | #0B1430 / #16224A / #7DFFFB | 結晶床、共鳴壁、光子芽 | 0.22 | 0.34 |
+| | `xeno_ruins` | 古代遺構 | #1E1B26 / #2C2433 / #FFAA54 | 遺跡床、刻印壁、動力オベリスク | 0.24 | 0.36 |
+| | `xeno_tide` | 潮汐ラボ | #0A1E3F / #083A5C / #4DF6FF | 潮汐床、液体壁、波動橋 | 0.20 | 0.32 |
+| | `xeno_desert` | 微粒砂層 | #2B1C0F / #3A2815 / #FFC66B | 砂丘床、シルト壁、耐砂ブリッジ | 0.26 | 0.35 |
+| | `xeno_hive` | 異星ハイブ | #132C1C / #0B1A11 / #83FF5A | 胞巣床、共鳴蔓、樹脂壁 | 0.29 | 0.40 |
+| | `xeno_reef` | 星間リーフ | #0C2430 / #16353F / #5EFFF7 | 珊瑚梁、光苔床、潮流ゲート | 0.25 | 0.36 |
+| メガコロニー支柱 | `colony_foundry` | 鋳造区画 | #1F1F2D / #2D2D44 / #FF7A3C | モールド床、レーザー炉壁、補給レール | 0.30 | 0.44 |
+| | `colony_spire` | 管制スパイア | #101B2C / #1C2F46 / #5AF0FF | スパイア床、通信梁、護衛壁 | 0.18 | 0.30 |
+| | `colony_commons` | コモンズ | #1A2D2E / #223B3C / #94FFDD | コモンズ床、交流モジュール、ミスト壁 | 0.34 | 0.48 |
+| | `colony_reactor` | コロニー炉心 | #220F2C / #331635 / #FF57B0 | 炉心床、イオン壁、余熱導管 | 0.22 | 0.34 |
+| | `colony_vault` | 戦略備蓄庫 | #1A1E32 / #242B3F / #FF9A4F | 備蓄庫床、封鎖扉、監視塔 | 0.20 | 0.33 |
+| | `colony_arcology` | アーコロジースパイン | #101C2A / #172535 / #4CFFF4 | 垂直街区、環状ブリッジ、上昇シャフト | 0.31 | 0.46 |
+
+- **追加アルゴリズムスタイル**:
+  - `sector`: 放射状リングと扇状分岐で構成する星系ハブ向け。`spaceship_warp` や `orbital_listening` で使用。
+  - `weave`: 交差する帯状コリドーを織り込むスタイル。`future_metro`、`spaceship_observatory`、`chrono_archive` などで利用。
+  - `cluster`: 離散した円盤群と連結ラインで浮遊構造を表現。`orbital_scrapyard`、`xeno_hive`、`cyber_mirror` などが該当。
+
+- **照明方針**: タイプごとに `neon_light`（色温度差あり）と `plasma_beam` のカラーバリエーションを同梱。アクセント色を HSL で +20% 輝度にし、`ctx.lightmap`（内部API）へ転送するユーティリティを提供。
+- **サウンド環境**: `addon.generators[].meta.soundscape` にキーを設定し、ゲーム側が将来参照できるようタグを付与（例: `soundscape: 'ship-engine'`).
+
+### 3.2 構造テンプレート
+- `structures` には 33 個の標準パターンを登録（例: 放射状制御室、六角ハブ、グリッドトンネル、垂直昇降井戸、ワープゲートリング、観測グリッド、シミュレーションメッシュ、メトロ交差、スクラップノード、フラックスセル、時間アーカイブスタック、ハイブチャンバー、アーコロジー核など）。
+- `ctx.structures.pick({ tags: ['sf_pack', 'orbital'] })` で系統別に抽選し、`opts.rotation` を 45 度単位でランダム化。`chrono_loop` 系は `opts.mirror` を true にして左右反転パターンを生成する。
+
+## 4. BlockDim 拡張設計
+### 4.1 追加ディメンション
+| key | 名称 | baseLevel | 説明 |
+|-----|------|-----------|------|
+| `sf-deep-orbit` | ディープオービット | 120 | 宇宙船/軌道基地を再現した高層ダンジョン帯。 |
+| `sf-cyber-lattice` | サイバーラティス | 150 | 情報層へ侵入するデジタル迷宮。 |
+| `sf-quantum-fold` | 量子折り畳み階層 | 180 | 位相空間が交錯する高難度エリア。 |
+| `sf-stellar-halo` | ステラーハローベルト | 200 | 星間ワープ路やアンテナ群を再現する最終帯域。 |
+| `sf-bio-cascade` | バイオカスケード | 135 | 異星生態系と都市境界が混ざり合う中層エリア。 |
+
+### 4.2 追加ブロック一覧
+50タイプの特徴を支える 110 種の BlockDim ブロックを 1st/2nd/3rd に段階別で配分する（32/43/35）。
+#### 1st ブロック（探索導入〜中盤向け、推奨Lv 110〜160）
+| key | 名称 | level | size | type | chest | カラー |
+|-----|------|-------|------|------|-------|--------|
+| `sf-reactor-floor` | プラズマ反応床 | +1 | 0 | `spaceship_core` | normal | #1B2F4C |
+| `sf-magnetic-wall` | 磁束壁板 | +1 | 0 | `spaceship_core` | less | #0F1727 |
+| `sf-hab-garden` | ハイドロポニクス床 | 0 | 0 | `spaceship_hab` | more | #2F7A59 |
+| `sf-ai-server` | AI サーバーパネル | +2 | +1 | `spaceship_ai` | less | #372B6F |
+| `sf-grid-node` | グリッドノード床 | +1 | 0 | `cyber_grid` | normal | #122060 |
+| `sf-firewall-wall` | ファイアウォール壁 | +2 | 0 | `cyber_vault` | less | #2B1456 |
+| `sf-glitch-tile` | グリッチタイル | 0 | -1 | `cyber_glitch` | less | #1AA186 |
+| `sf-stream-bridge` | 信号橋梁 | +1 | +1 | `cyber_stream` | normal | #0F3F66 |
+| `sf-plaza-holo` | ホログラム床 | 0 | 0 | `future_plaza` | more | #29CBDD |
+| `sf-industrial-conveyor` | メガライン床 | +2 | +1 | `future_industrial` | normal | #F2A43A |
+| `sf-sky-lift` | 垂直リフト床 | +1 | +1 | `future_sky` | less | #59E8FF |
+| `sf-core-glass` | 強化監視壁 | +1 | 0 | `future_core` | less | #1D3E57 |
+| `sf-medbay-sterile` | 無菌メディカル床 | 0 | 0 | `spaceship_medbay` | more | #2DAECC |
+| `sf-engineering-grate` | エンジニアリンググレーチング | +1 | 0 | `spaceship_engineering` | normal | #FF9F45 |
+| `sf-forum-stage` | ソーシャルホール舞台床 | 0 | -1 | `cyber_forum` | less | #AF46FF |
+| `sf-subroutine-panel` | サブルーチン診断床 | +1 | 0 | `cyber_subroutine` | normal | #3CE89B |
+| `sf-residential-terrace` | テラスフロア | 0 | 0 | `future_residential` | more | #4ED9C3 |
+| `sf-underworks-catwalk` | アンダーワークス猫歩き床 | +1 | 0 | `future_underworks` | less | #78FF4C |
+| `sf-xeno-jungle-floor` | バイオルミ床板 | +1 | 0 | `xeno_jungle` | normal | #1AE978 |
+| `sf-colony-commons-floor` | コモンズ共有床 | 0 | 0 | `colony_commons` | more | #6BFFE4 |
+| `sf-warp-pad` | ワープパッド床 | +2 | 0 | `spaceship_warp` | less | #1A2F48 |
+| `sf-observatory-plate` | 観測ドーム床板 | +1 | 0 | `spaceship_observatory` | normal | #1C3954 |
+| `sf-arena-track` | アリーナトラック床 | +1 | 0 | `cyber_arena` | more | #221C58 |
+| `sf-mirror-panel` | ミラーパネル壁 | +1 | 0 | `cyber_mirror` | less | #1F2F56 |
+| `sf-metro-strut` | メトロ支持梁 | +2 | +1 | `future_metro` | normal | #2A4C60 |
+| `sf-cloud-dock-floor` | クラウドドック床 | +1 | 0 | `future_cloudport` | normal | #1A3655 |
+| `sf-scrap-plating` | スクラップ装甲板 | +1 | 0 | `orbital_scrapyard` | less | #272C38 |
+| `sf-listening-array` | リスニングアレイ床 | +1 | 0 | `orbital_listening` | normal | #1B3142 |
+| `sf-reef-trellis` | リーフトレリス床 | +1 | 0 | `xeno_reef` | more | #144456 |
+| `sf-hive-pith` | ハイブピス床 | +2 | 0 | `xeno_hive` | less | #193722 |
+| `sf-arcology-floor` | アーコロジーフロア | +2 | +1 | `colony_arcology` | normal | #1A3245 |
+| `sf-vault-plate` | 備蓄庫床板 | +1 | 0 | `colony_vault` | less | #21283A |
+
+#### 2nd ブロック（中盤〜終盤、推奨Lv 150〜190）
+| key | 名称 | level | size | depth | type | chest | カラー |
+|-----|------|-------|------|-------|------|-------|--------|
+| `sf-orbit-ring-floor` | 軌道リング床 | +2 | +1 | +1 | `orbital_ring` | normal | #244F68 |
+| `sf-orbit-solar` | ソーラー壁板 | +2 | 0 | +1 | `orbital_ring` | less | #3CD0FF |
+| `sf-orbit-lab` | 零G実験床 | +3 | 0 | +1 | `orbital_lab` | less | #2B6EA1 |
+| `sf-orbit-armory` | 反応装甲床 | +3 | +1 | +1 | `orbital_armory` | less | #47273A |
+| `sf-quantum-column` | 量子束柱 | +4 | 0 | +2 | `quantum_reactor` | less | #8A1CFF |
+| `sf-quantum-phasewall` | 位相壁 | +3 | 0 | +2 | `quantum_reactor` | less | #43117E |
+| `sf-quantum-archive` | 時間結晶棚 | +2 | 0 | +1 | `quantum_archive` | normal | #1E7DAF |
+| `sf-quantum-anchor` | 次元アンカー | +4 | +1 | +2 | `quantum_void` | less | #46FFAF |
+| `sf-cyber-cache` | データキャッシュ床 | +2 | +1 | +1 | `cyber_vault` | more | #3B2D74 |
+| `sf-cyber-wave` | 波形パネル壁 | +3 | 0 | +1 | `cyber_stream` | less | #1B64B2 |
+| `sf-future-transit` | リニアトランジット床 | +3 | +1 | +1 | `future_core` | normal | #3CD3A3 |
+| `sf-future-aero` | エアロバリア壁 | +2 | 0 | +1 | `future_sky` | less | #2F83A9 |
+| `sf-greenhouse-canopy` | 温室キャノピー床 | +2 | +1 | +1 | `orbital_greenhouse` | more | #4CFF8B |
+| `sf-command-console` | 指令コンソール壁 | +3 | 0 | +1 | `orbital_command` | less | #3B76FF |
+| `sf-quantum-prism` | プリズム導光床 | +3 | 0 | +2 | `quantum_prism` | normal | #FFC94F |
+| `sf-chrono-platform` | 時間駅プラットフォーム | +2 | +1 | +1 | `chrono_station` | normal | #FF7BD1 |
+| `sf-loop-gate` | ループゲート壁 | +3 | 0 | +2 | `chrono_loop` | less | #5DFFF2 |
+| `sf-xeno-crystal-spire` | 結晶尖塔床 | +2 | +1 | +1 | `xeno_crystal` | normal | #5CF7FF |
+| `sf-xeno-ruins-pillar` | 遺跡支柱壁 | +3 | 0 | +1 | `xeno_ruins` | less | #FFB86B |
+| `sf-colony-foundry-crane` | 鋳造クレーン床 | +3 | +1 | +1 | `colony_foundry` | normal | #FF9055 |
+| `sf-warp-conduit` | ワープ導管柱 | +3 | 0 | +1 | `spaceship_warp` | less | #5C9DFF |
+| `sf-observatory-array` | 観測アレイ床 | +2 | +1 | +1 | `spaceship_observatory` | normal | #7DE9FF |
+| `sf-arena-barrier` | アリーナ障壁 | +3 | 0 | +1 | `cyber_arena` | less | #FF43B9 |
+| `sf-mirror-spire` | ミラースパイア | +2 | 0 | +1 | `cyber_mirror` | less | #7CFFEE |
+| `sf-metro-switch` | メトロ分岐床 | +3 | +1 | +1 | `future_metro` | normal | #54FFE2 |
+| `sf-cloud-anchor` | 浮遊アンカー | +2 | 0 | +1 | `future_cloudport` | less | #8DFFFA |
+| `sf-scrap-gantry` | スクラップガントリー | +2 | +1 | +1 | `orbital_scrapyard` | normal | #FF7B42 |
+| `sf-listening-dish` | 傍受ディッシュ | +3 | 0 | +1 | `orbital_listening` | less | #4CF2FF |
+| `sf-flux-ribbon` | フラックスリボン床 | +3 | 0 | +2 | `quantum_flux` | normal | #FF72ED |
+| `sf-chrono-weave` | クロノ織路 | +2 | +1 | +1 | `chrono_archive` | normal | #FF85D6 |
+| `sf-fracture-gate` | 断層ゲート | +3 | 0 | +2 | `chrono_fracture` | less | #74FFF4 |
+| `sf-hive-resonator` | ハイブレゾネーター | +2 | 0 | +1 | `xeno_hive` | less | #83FF5A |
+| `sf-reef-bloom` | リーフブルーム | +2 | +1 | +1 | `xeno_reef` | normal | #5EFFF7 |
+| `sf-vault-lockdown` | ロックダウン装置 | +3 | 0 | +1 | `colony_vault` | less | #FF9A4F |
+| `sf-arcology-bridge` | アーコロジーブリッジ | +3 | +1 | +1 | `colony_arcology` | normal | #4CFFF4 |
+
+#### 3rd ブロック（終盤〜エンドコンテンツ、推奨Lv 180〜220）
+| key | 名称 | level | size | depth | bossFloors | type | chest | カラー |
+|-----|------|-------|------|-------|------------|------|-------|--------|
+| `sf-reactor-heart` | 炉心安定床 | +5 | +2 | +2 | [10,20] | `spaceship_core` | normal | #2FF5FF |
+| `sf-ai-overmind` | オーバーマインド核 | +6 | +1 | +2 | [15] | `spaceship_ai` | less | #8F6CFF |
+| `sf-glitch-singularity` | グリッチ特異点 | +6 | +1 | +3 | [12, 18] | `cyber_glitch` | less | #BCFF4D |
+| `sf-vault-guardian` | ICE ガーディアン床 | +5 | +2 | +3 | [20] | `cyber_vault` | less | #5830C9 |
+| `sf-sky-zenith` | ゼニス浮遊床 | +4 | +2 | +2 | [9, 18] | `future_sky` | more | #7FFFF8 |
+| `sf-industrial-forge` | 星鋳炉床 | +5 | +2 | +2 | [14] | `future_industrial` | normal | #FFCB42 |
+| `sf-orbit-guardian` | 軌道防衛壁 | +5 | +1 | +2 | [16] | `orbital_armory` | less | #FF546E |
+| `sf-orbit-null` | 無重力制御床 | +5 | +1 | +2 | [12] | `orbital_lab` | normal | #66C9FF |
+| `sf-quantum-core` | 量子核床 | +6 | +2 | +3 | [20] | `quantum_reactor` | less | #E23BFF |
+| `sf-quantum-horizon` | 地平遮蔽壁 | +6 | +1 | +3 | [18] | `quantum_void` | less | #53FFCC |
+| `sf-cyber-cascade` | 情報カスケード床 | +5 | +1 | +2 | [10, 15] | `cyber_stream` | normal | #35FFC0 |
+| `sf-plaza-crown` | 王冠ホロ床 | +4 | +2 | +2 | [12] | `future_plaza` | more | #51FFFF |
+| `sf-medbay-overseer` | メディカル監督核 | +5 | +1 | +2 | [8, 14] | `spaceship_medbay` | less | #66FFF3 |
+| `sf-engineering-core` | エンジン制御心核 | +5 | +2 | +3 | [16] | `spaceship_engineering` | normal | #FFBE5C |
+| `sf-forum-oracle` | フォーラムオラクル床 | +6 | +1 | +3 | [15] | `cyber_forum` | less | #D36BFF |
+| `sf-subroutine-kernel` | サブルーチン核壁 | +5 | +1 | +2 | [11, 17] | `cyber_subroutine` | less | #4CFFB1 |
+| `sf-chrono-paradox` | パラドックス交差床 | +6 | +2 | +3 | [13, 19] | `chrono_loop` | normal | #89FFF5 |
+| `sf-xeno-elder` | 異星守護床 | +5 | +2 | +3 | [18] | `xeno_ruins` | less | #FFCD7A |
+| `sf-xeno-maelstrom` | 潮汐メイルストロム床 | +5 | +2 | +3 | [10, 20] | `xeno_tide` | normal | #5DF7FF |
+| `sf-colony-reactor-heart` | コロニー炉心核 | +6 | +2 | +3 | [20] | `colony_reactor` | less | #FF6CC4 |
+| `sf-warp-singularity` | ワープ特異核 | +6 | +2 | +3 | [18] | `spaceship_warp` | less | #5C9DFF |
+| `sf-observatory-core` | 観測中枢核 | +5 | +1 | +2 | [14] | `spaceship_observatory` | normal | #7DE9FF |
+| `sf-arena-champion` | アリーナチャンピオン床 | +5 | +2 | +3 | [16] | `cyber_arena` | more | #FF43B9 |
+| `sf-mirror-overseer` | ミラーオーバーシア壁 | +5 | +1 | +2 | [13] | `cyber_mirror` | less | #7CFFEE |
+| `sf-metro-command` | メトロ司令床 | +5 | +2 | +2 | [15,22] | `future_metro` | normal | #54FFE2 |
+| `sf-cloud-throne` | クラウドスローン床 | +5 | +2 | +2 | [12,19] | `future_cloudport` | more | #8DFFFA |
+| `sf-scrap-overseer` | スクラップ監督核 | +5 | +1 | +2 | [17] | `orbital_scrapyard` | less | #FF7B42 |
+| `sf-listening-core` | リスニング中枢 | +5 | +1 | +2 | [11,18] | `orbital_listening` | less | #4CF2FF |
+| `sf-flux-heart` | フラックス心核 | +6 | +2 | +3 | [21] | `quantum_flux` | less | #FF72ED |
+| `sf-chrono-vault` | クロノヴォールト床 | +5 | +1 | +2 | [13,20] | `chrono_archive` | normal | #FF85D6 |
+| `sf-fracture-core` | 断層中核 | +6 | +1 | +3 | [19] | `chrono_fracture` | less | #74FFF4 |
+| `sf-hive-queen` | ハイブクイーン床 | +5 | +2 | +3 | [18,24] | `xeno_hive` | more | #83FF5A |
+| `sf-reef-titan` | リーフタイタン床 | +5 | +2 | +2 | [16] | `xeno_reef` | normal | #5EFFF7 |
+| `sf-vault-command` | 備蓄指令核 | +6 | +1 | +2 | [19] | `colony_vault` | less | #FF9A4F |
+| `sf-arcology-nexus` | アーコロジーネクサス | +6 | +2 | +3 | [22] | `colony_arcology` | normal | #4CFFF4 |
+
+### 4.3 危険ブロック・ギミック
+- `sf-laser-grid`（範囲ダメージ、周期3ターン）
+- `sf-gravity-inverter`（上下反転、BlockDim 深度+1）
+- `sf-data-spike`（データ破損デバフ、サイバー系）
+- `sf-quantum-rift`（瞬間移動罠、位相ノード指定）
+- `sf-arena-barrier`（ホログラム壁の開閉ギミック、周期4ターン）
+- `sf-cloud-anchor`（強風ノックバック、浮遊ステージ）
+- `sf-listening-dish`（信号パルスによる視界阻害）
+- `sf-fracture-gate`（時間断層ワープ、接触で再配置）
+- `sf-hive-resonator`（バフ/デバフ拡散、バイオ系）
+- `sf-vault-lockdown`（ロックダウンで宝箱封鎖、解除条件付き）
+- `sf-temporal-loop`（1ターン行動停止、`chrono_loop` 区画で高確率）
+- `sf-crystal-resonator`（共鳴による範囲スタン、`xeno_crystal` 系）
+- `sf-bio-spore`（継続毒ダメージ、`xeno_jungle` 系で拡散）
+- `sf-nanite-surge`（装備耐久低下、`colony_foundry`/`future_underworks` で発生）
+
+### 4.4 ユーティリティ/装飾ブロック案
+- `sf-neon-beacon`（照明強化、`future_plaza`/`cyber_forum` で演出値+5）
+- `sf-holo-directory`（案内端末、`future_core`/`colony_commons` でイベント誘発）
+- `sf-zeroG-anchor`（浮遊制御、`orbital_lab`/`orbital_greenhouse` で移動速度+1）
+- `sf-time-marker`（チェックポイント、`chrono_station` で復帰地点設定）
+- `sf-xeno-pollen`（環境バフ、`xeno_jungle` でHP再生+継続毒の相殺）
+
+## 5. 生成アルゴリズム詳細
+### 5.1 共通フェーズ
+1. **初期化**: `ctx.map` を壁で埋め、`ctx.random` をテーマごとにシード補正。
+2. **層分割**: `Core/Support/Peripheral` を `ctx.height` に応じて帯域化。`spaceship_core` など特定タイプは Core の比率を 40% 以上に設定。
+3. **ルーム敷設**: `ctx.structures.place` で中核構造を固定し、周辺は `ctx.carvePath` とランダムルーム生成（矩形/楕円/フラクタル）を組み合わせる。
+4. **通路接続**: `ctx.aStar` でメインステーションを連結後、`ctx.ensureConnectivity()` で孤立領域を統合。
+5. **ギミック配置**: `PoissonDiskSampler`（内部ユーティリティを addon 内に同梱）で候補点を生成し、`ctx.set` で罠/装飾を配置。危険密度は難易度スライダーから取得できる `ctx.meta.dangerLevel`（無い場合は推定）で調整。
+6. **出口/ボス処理**: `ctx.fixedMaps.available` を確認し、固定マップが無い場合は最深部にボスルーム構造を配置。
+
+### 5.2 タイプ別カスタマイズ例
+- **`spaceship_core`**: 中央のリアクターチャンバーを `structures` の「放射状制御室」で生成。周囲に 6 本のベクタートンネルを `ctx.carvePath` で引き、`sf-reactor-heart` 系ブロックを優先配置。`ctx.meta.gravityVector`（Addon 内部管理）を階層ごとに変更し、プレイヤー向けに視覚エフェクトをタグ付け。
+- **`spaceship_dock`**: MAP 全体を 3x3 の巨大セクションに分割し、中央に格納庫空間を確保。`ctx.structures.placePattern` で大型扉パターンを左右に設置し、`sf-magnetic-wall` を境界に使う。
+- **`cyber_glitch`**: 乱数シードを 4 つ用意し、各ルームで `openSimplex2D` を適用して壁の歪みを計算。`ctx.set` で 5% の確率で `sf-glitch-singularity` を設置し、`ctx.structures.place` で断片パターンをランダム回転。
+- **`cyber_stream`**: `ctx.carvePath` をベジエ補間（addon 内の `carveSpline` ヘルパー）で滑らかな曲線に変換。主要ルートには `sf-stream-bridge` を敷き、分岐点に `sf-cyber-cascade` を配置。
+- **`future_sky`**: `ctx.height` を 3 層に分け、各層をフローティングプラットフォームとして `ctx.structures.place`。垂直連結は `createElevatorShaft(ctx)` ヘルパーで `sf-sky-lift` を連続配置。
+- **`future_industrial`**: `ctx.width` をベルトラインに沿ってグリッド化し、`sf-industrial-conveyor` をストリーム配置。`ctx.ensureConnectivity()` 後に不要な壁を 20% 削除し、回遊動線を確保。
+- **`future_metro`**: `weave` スタイルで水平・垂直ラインを編み込み、`ctx.scheduleTrain` でリニア車両を流す。`sf-metro-switch` と `sf-metro-command` をノードに置き、`ctx.meta.metroSignals` へ時刻表を保存。
+- **`orbital_lab`**: `ctx.meta.zeroGravity = true` をセットし、プレイヤー向けに漂う通路を `ctx.structures.place` で小規模ハブとして配置。`sf-orbit-null` を 3D的に配置するため `scaleY` を 0.5 にしたパターンを用意。
+- **`future_cloudport`**: `cluster` スタイルで浮遊港を構築し、`ctx.meta.windField` をノイズで生成。`sf-cloud-anchor` の座標で突風イベントを起こし、足場移動をダイナミックに演出。
+- **`quantum_void`**: 基本レイアウトを `ctx.carvePath` で作らず、`ctx.structures.placePattern` でフラクタル型の空間を生成。`ctx.meta.phaseSlipPoints` を3箇所登録し、ワープリンクを `ctx.meta.warpPairs` に設定。
+- **`quantum_flux`**: `sector` スタイルで多重リングを構築し、`ctx.meta.fluxPhase` を進行度で更新。リング交点に `sf-flux-ribbon` を配置し、中心に `sf-flux-heart` を据えてフェーズ変調ライトを演出。
+- **`spaceship_medbay`**: `ctx.meta.infectionLevel` を管理し、滅菌ゾーン（Safe）と感染ゾーン（Risk）を色で明示。`sf-medbay-sterile` を Safe へ集中配置し、危険ゾーンには `sf-bio-spore` を混在させる。
+- **`spaceship_engineering`**: `ctx.structures.grid` を使い、配管シャフトを縦横に巡らせる。`sf-engineering-grate` の連鎖でプレイヤー導線を暗示し、`sf-engineering-core` をボス部屋に固定。
+- **`spaceship_warp`**: `sector` スタイルで 7 分割リングを生成し、`ctx.meta.warpPairs` に出入口ペアを設定。扇状アーム終端に `sf-warp-conduit` と `sf-warp-singularity` を配置し、緊急ベント用の `ctx.toggleDoor` ルーチンを追加。
+- **`spaceship_observatory`**: `weave` スタイルで格子状の観測廊下を生成し、`ctx.meta.skybox` に星図IDを記録。交差点に `sf-observatory-array`、中央に `sf-observatory-core` を据えて光源を青白系に調整。
+- **`cyber_forum`**: `ctx.meta.discussionNodes` を生成し、各ノードを `ctx.carvePath` で円形に接続。`sf-forum-stage` 周辺は `ctx.lightmap` にピンク系ネオンを追加。
+- **`cyber_subroutine`**: `ctx.random.weightedPick` で補助ルーチン（回復/防御/攻撃）の比率を制御し、タイル種を `sf-subroutine-panel`・`sf-subroutine-kernel` で切り替える。
+- **`cyber_arena`**: `weave` パターンをベースにラウンド数を `ctx.meta.arenaRounds` で制御。`sf-arena-barrier` の周期を4ターンで回し、敵ウェーブ生成を `ctx.scheduleEvent` に登録。
+- **`cyber_mirror`**: `cluster` スタイルでミラーノードを生成し、`ctx.meta.reflectionPairs` を用意。`sf-mirror-spire` を中継して `ctx.teleport` 演出を挟み、色反転シェーダを割り当て。
+- **`future_residential`**: 住居クラスターを `ctx.partitionGrid(4,4)` で生成し、共有スペースに `sf-colony-commons-floor` を取り込む。`ctx.meta.population` を算出し、イベントトリガー候補を記録。
+- **`orbital_greenhouse`**: `ctx.meta.gravityVector` を微振動させ、植物プラットフォームを `sf-greenhouse-canopy` でリング状に配置。中央に `sf-zeroG-anchor` を置き浮遊を抑制。
+- **`orbital_scrapyard`**: `cluster` スタイルのノードを `ctx.meta.scrapClusters` に記録し、`sf-scrap-gantry` で橋渡し。局所的に重力方向を反転させ、浮遊破片イベントを追加。
+- **`orbital_listening`**: `sector` スタイルでアンテナリングを展開し、`ctx.meta.signalSweep` を時間更新。`sf-listening-dish` のパルスでマップ全体に一時的な霧を発生させる。
+- **`chrono_station`/`chrono_loop`**: `ctx.timeline.split()`（addon 内ヘルパー）で時刻帯を分割し、`sf-chrono-platform`→`sf-loop-gate` の順に接続。時間逆行ルートは `sf-chrono-paradox` を通してショートカット化。
+- **`chrono_archive`**: `weave` スタイルのアーカイブ路を `ctx.timeline.archives` に記録し、`sf-chrono-weave` と `sf-chrono-vault` を連結。取得したタイムログを `ctx.meta.timelineArtifacts` に保存してイベント連動を可能にする。
+- **`chrono_fracture`**: `cluster` スタイルで断層ゲートを配置し、`ctx.timeline.fractures` に遅延イベントを追加。`sf-fracture-gate` の接触でプレイヤーを別セクターへ転送し、復帰地点に `ctx.markReturnPoint` を設定。
+- **`xeno_jungle`**: `ctx.noise.fractal` で密度マップを生成し、密林セルに `sf-xeno-jungle-floor` と `sf-bio-spore` を 30% 比率で配置。開けた場所には `sf-xeno-elder` を配置し、イベント旗を立てる。
+- **`xeno_hive`**: `cluster` スタイルで胞巣を生成し、`ctx.meta.hiveLanes` を敵AI経路として保持。`sf-hive-pith` と `sf-hive-queen` にフェロモン効果タグを付与し、出現敵のバフ制御に利用。
+- **`xeno_reef`**: `weave` + ノイズ補正で潮流ルートを形成。`sf-reef-trellis` を主航路に、`sf-reef-bloom` を資源ポイントに配置し、`ctx.meta.tideCycle` で波周期を管理。
+- **`colony_foundry`**: `ctx.structures.placeLine` でクレーン走行路を構築し、`sf-colony-foundry-crane` をチェックポイントに。`sf-nanite-surge` の配置密度でリスクコントロールを行う。
+- **`colony_vault`**: `sector` スタイルで多重セキュリティリングを構築。`sf-vault-lockdown` が作動すると `ctx.lockDoors` で一定時間封鎖し、解除キーを `ctx.meta.vaultAccess` に格納。
+- **`colony_arcology`**: `weave` スタイルで垂直街区を形成し、`sf-arcology-bridge` を高さ差分に応じて配置。`sf-arcology-nexus` を都市管理ノードとし、`ctx.meta.arcologyState` に住民動態を保存。
+
+### 5.3 データ構造
+- `addon.generators[].algorithm` 内では `ctx.meta` にカスタム情報を格納（例: `ctx.meta.gravityVector`, `ctx.meta.warpPairs`）。これらは `afterGenerate` コールバック（将来拡張）でも利用できるようキーを整理。
+- `structures` の `tags` に `['sf_pack', 系統ID]` を付与し、他アドオンとの衝突を避けるため ID をネームスペース化。
+
+## 6. データ定義ファイル
+- `palettes.json`: `{ typeId: { floor: '#...', wall: '#...', accent: '#...', light: '#...' } }` 形式。`createGenerators()` 内で読み込み、`ctx.meta.palette` に付与。
+- `structures.json`: ツールズタブで生成したパターンを収録。`importStructures()` で JSON を JS オブジェクトへ変換し、`addon.structures` に注入。
+- `sf_pack_testcases.json`: 自動テスト用に、生成条件（難易度・乱数シード・プレイヤーレベル）を列挙するファイル。
+
+## 7. ゲームプレイ連携
+- `blockdata.json` 読み込み後に `blocks1/2/3` をマージするため、`key` が既存と衝突しないよう `sf-` プレフィックスを統一。
+- Normal モードでは `mixin.normalMixed` を設定し、`DungeonGenRegistry` で重み付け抽選に参加。BlockDim 専用にしたい場合は `blockDimMixed` のみ設定。
+- 敵・宝箱は既存テーブルを利用しつつ、`sf_spawn_rules.json` で推奨設定を別途提案（将来の敵拡張向け）。
+
+## 8. テスト計画
+1. **自動回帰**: `npm run test:dungeon -- --addon=sf_pack --count=1000`（ツールズタブ提供スクリプト）で 1000 回生成し、床タイル比率・平均経路長・ギミック密度を記録。
+2. **視覚検証**: `tools/dungeon_viewer.html` を使い、各タイプ10回ずつスクリーンショット化。色ズレがあれば `palettes.json` を修正。
+3. **性能測定**: `performance.now()` で `algorithm` 実行時間を取得し、1 回あたり 8ms 以内を目標。
+4. **プレイテスト**: Normal/BlockDim でそれぞれ 3 階層攻略し、ギミック挙動とブロック出現率を確認。
+
+## 9. ブレインストーミングノート
+- **イベント**: 
+  - 宇宙船系: 暴走 AI のシステムリブート、航行モード切替による環境変化。
+  - サイバー系: ICE とハッカーの攻防戦、同期ノードの奪還タイムアタック。
+  - 未来都市系: 空中交通を操作して経路制御、住民避難の護衛ミッション。
+  - 軌道/量子系: ソーラー嵐の回避、位相崩壊を抑えるリアルタイムギミック。
+- **協力プレイ**: 役割別（エンジニア・ハッカー・スカウト・クロノマンサー）に応じた補助ドローンを `ctx.meta.supportDrones` で制御する案。
+- **拡張ブロック案**: 反射レーザー壁、時限ブリッジ、音響パズルタイル。`BlockSpec.meta` に挙動パラメータを持たせてスクリプト拡張。
+- **追加生成タイプ候補**:
+  - `spaceship_memorial`: 英雄記念ホール。追悼イベントとメモリアルデータログを配置。
+  - `cyber_arena`: 対戦シミュレーション用アリーナ。プレイヤーとの模擬戦ギミック。
+  - `future_harbor`: 空中港湾をテーマにして離着陸ルートと輸送ドローン管理を組み込む。
+  - `xeno_reef`: 発光珊瑚の海底遺跡。水中重力と呼吸管理ギミックを追加。
+  - `colony_archive`: 植民地の歴史資料庫。プレイヤーがログを収集して報酬獲得。
+- **UI 連携**: BlockDim タブに「SF フィルター」を追加し、`type` が `sf_pack` で始まるブロックをまとめて表示するフィルタボタンを提案。
+- **敵タイプ**: 位相ハンター、磁束セントリー、ホログラム幻影を想定し、将来の `sf_spawn_rules.json` 拡張に記録。
+

--- a/dungeontypes/manifest.json.js
+++ b/dungeontypes/manifest.json.js
@@ -35,5 +35,6 @@ window.DUNGEONTYPE_MANIFEST = [
   { id: 'echo_vaults_pack', name: 'Echo Vaults Pack', entry: 'dungeontypes/echo_vaults.js', version: '1.0.0', author: 'builtin-sample' },
   { id: 'emberglass_caverns_pack', name: 'Emberglass Caverns Pack', entry: 'dungeontypes/emberglass_caverns.js', version: '1.0.0', author: 'builtin-sample' },
   { id: 'abyssal_whorl_pack', name: 'Abyssal Whorl Pack', entry: 'dungeontypes/abyssal_whorl.js', version: '1.0.0', author: 'builtin-sample' },
-  { id: 'ruined_labyrinth_pack', name: 'Ruined Labyrinth Pack', entry: 'dungeontypes/ruined_labyrinth.js', version: '1.0.0', author: 'builtin-sample' }
+  { id: 'ruined_labyrinth_pack', name: 'Ruined Labyrinth Pack', entry: 'dungeontypes/ruined_labyrinth.js', version: '1.0.0', author: 'builtin-sample' },
+  { id: 'sf_expansion_pack', name: 'SF Expansion Pack', entry: 'dungeontypes/sf_expansion.js', version: '1.0.0', author: 'builtin-sample' }
 ];

--- a/dungeontypes/sf_expansion.js
+++ b/dungeontypes/sf_expansion.js
@@ -1,0 +1,1114 @@
+(function(){
+  const ADDON_ID = 'sf_expansion_pack';
+  const ADDON_NAME = 'SF Expansion Pack';
+  const VERSION = '1.1.0';
+
+  function clamp(value, min, max) {
+    return value < min ? min : (value > max ? max : value);
+  }
+
+  function brighten(hex, ratio = 0.2) {
+    if (!hex || typeof hex !== 'string') return hex;
+    const normalized = hex.trim().replace(/^#/, '');
+    if (!/^[0-9a-fA-F]{6}$/.test(normalized)) return hex;
+    const r = parseInt(normalized.slice(0, 2), 16);
+    const g = parseInt(normalized.slice(2, 4), 16);
+    const b = parseInt(normalized.slice(4, 6), 16);
+    const mix = (channel) => {
+      const v = Math.round(channel + (255 - channel) * ratio);
+      return clamp(v, 0, 255);
+    };
+    const toHex = (value) => value.toString(16).padStart(2, '0');
+    return '#' + toHex(mix(r)) + toHex(mix(g)) + toHex(mix(b));
+  }
+
+  function fillSolid(ctx, value) {
+    const fill = value ? 1 : 0;
+    for (let y = 1; y < ctx.height - 1; y++) {
+      for (let x = 1; x < ctx.width - 1; x++) {
+        ctx.set(x, y, fill);
+      }
+    }
+  }
+
+  function carveRect(ctx, x0, y0, x1, y1) {
+    const minX = Math.max(1, Math.min(x0, x1));
+    const maxX = Math.min(ctx.width - 2, Math.max(x0, x1));
+    const minY = Math.max(1, Math.min(y0, y1));
+    const maxY = Math.min(ctx.height - 2, Math.max(y0, y1));
+    for (let y = minY; y <= maxY; y++) {
+      for (let x = minX; x <= maxX; x++) {
+        ctx.set(x, y, 0);
+      }
+    }
+  }
+
+  function carveDisc(ctx, cx, cy, radius) {
+    const r = Math.max(1, radius);
+    const r2 = r * r;
+    for (let y = cy - r - 1; y <= cy + r + 1; y++) {
+      for (let x = cx - r - 1; x <= cx + r + 1; x++) {
+        const dx = x - cx;
+        const dy = y - cy;
+        if (dx * dx + dy * dy <= r2) {
+          if (ctx.inBounds(x, y)) ctx.set(x, y, 0);
+        }
+      }
+    }
+  }
+
+  function carveRing(ctx, cx, cy, radius, thickness = 2) {
+    const r = Math.max(2, radius);
+    const t = Math.max(1, thickness);
+    const outer2 = r * r;
+    const inner = Math.max(0, r - t);
+    const inner2 = inner * inner;
+    for (let y = cy - r - 1; y <= cy + r + 1; y++) {
+      for (let x = cx - r - 1; x <= cx + r + 1; x++) {
+        const dx = x - cx;
+        const dy = y - cy;
+        const d2 = dx * dx + dy * dy;
+        if (d2 <= outer2 && d2 >= inner2) {
+          if (ctx.inBounds(x, y)) ctx.set(x, y, 0);
+        }
+      }
+    }
+  }
+
+  function carveRectRing(ctx, x0, y0, x1, y1, thickness = 1) {
+    const minX = Math.max(1, Math.min(x0, x1));
+    const maxX = Math.min(ctx.width - 2, Math.max(x0, x1));
+    const minY = Math.max(1, Math.min(y0, y1));
+    const maxY = Math.min(ctx.height - 2, Math.max(y0, y1));
+    const t = Math.max(1, thickness);
+    for (let i = 0; i < t; i++) {
+      for (let x = minX + i; x <= maxX - i; x++) {
+        ctx.set(x, minY + i, 0);
+        ctx.set(x, maxY - i, 0);
+      }
+      for (let y = minY + i; y <= maxY - i; y++) {
+        ctx.set(minX + i, y, 0);
+        ctx.set(maxX - i, y, 0);
+      }
+    }
+  }
+
+  function carveLine(ctx, x0, y0, x1, y1, width = 1) {
+    let dx = Math.abs(x1 - x0);
+    let sx = x0 < x1 ? 1 : -1;
+    let dy = -Math.abs(y1 - y0);
+    let sy = y0 < y1 ? 1 : -1;
+    let err = dx + dy;
+    const half = Math.max(0, Math.floor(width / 2));
+    while (true) {
+      for (let yy = -half; yy <= half; yy++) {
+        for (let xx = -half; xx <= half; xx++) {
+          const tx = x0 + xx;
+          const ty = y0 + yy;
+          if (ctx.inBounds(tx, ty)) ctx.set(tx, ty, 0);
+        }
+      }
+      if (x0 === x1 && y0 === y1) break;
+      const e2 = 2 * err;
+      if (e2 >= dy) {
+        err += dy;
+        x0 += sx;
+      }
+      if (e2 <= dx) {
+        err += dx;
+        y0 += sy;
+      }
+    }
+  }
+
+  function randomInt(ctx, min, max) {
+    if (max <= min) return min;
+    const r = ctx.random ? ctx.random() : Math.random();
+    return Math.floor(r * (max - min + 1)) + min;
+  }
+
+  function applyPalette(ctx, palette, options = {}) {
+    const accentStride = options.accentStride ?? 5;
+    const accentChance = options.accentChance ?? 0.08;
+    const accentColor = options.accentColor || palette.accent;
+    const finalAccent = accentColor ? brighten(accentColor, 0.15) : null;
+    const wallColor = palette.wall ? brighten(palette.wall, 0.05) : null;
+    for (let y = 1; y < ctx.height - 1; y++) {
+      for (let x = 1; x < ctx.width - 1; x++) {
+        if (ctx.get(x, y) === 0) {
+          let color = palette.floor;
+          if (finalAccent && ((x + y) % accentStride === 0 || (ctx.random && ctx.random() < accentChance))) {
+            color = finalAccent;
+          }
+          ctx.setFloorColor(x, y, color);
+        } else if (wallColor) {
+          ctx.setWallColor(x, y, wallColor);
+        }
+      }
+    }
+  }
+
+  function sprinkleStructures(ctx, tags, attempts = 2) {
+    const normalizedTags = Array.isArray(tags) ? tags : (typeof tags === 'string' ? [tags] : []);
+    if (!normalizedTags.length) return;
+    const pool = ctx.structures.list ? ctx.structures.list({ addonId: ADDON_ID }) : [];
+    if (!pool.length) return;
+    for (let i = 0; i < attempts; i++) {
+      const tag = normalizedTags[i % normalizedTags.length];
+      const subset = pool.filter(def => Array.isArray(def.tags) && def.tags.includes(tag));
+      const choices = subset.length ? subset : pool;
+      if (!choices.length) break;
+      const pick = choices[randomInt(ctx, 0, choices.length - 1)];
+      const px = randomInt(ctx, 3, ctx.width - 4);
+      const py = randomInt(ctx, 3, ctx.height - 4);
+      try {
+        ctx.structures.place(pick.id, px, py, { allowRotation: true, allowMirror: true, anchor: 'center' });
+      } catch (_) {}
+    }
+  }
+  function createHubAlgorithm(options) {
+    const {
+      arms = 6,
+      rings = 3,
+      armWidth = 2,
+      coreRadius = 4,
+      structureTags,
+      palette
+    } = options;
+    return function(ctx) {
+      fillSolid(ctx, 1);
+      const cx = Math.floor(ctx.width / 2);
+      const cy = Math.floor(ctx.height / 2);
+      const maxRadius = Math.min(ctx.width, ctx.height) / 2 - 3;
+      carveDisc(ctx, cx, cy, Math.max(3, coreRadius));
+      const spacing = Math.max(3, Math.floor((maxRadius - coreRadius) / Math.max(1, rings)));
+      for (let i = 1; i <= rings; i++) {
+        carveRing(ctx, cx, cy, coreRadius + spacing * i, armWidth);
+      }
+      const offset = (ctx.random ? ctx.random() : Math.random()) * Math.PI * 2;
+      for (let i = 0; i < arms; i++) {
+        const angle = offset + (Math.PI * 2 * i) / arms;
+        const length = maxRadius + 2;
+        const targetX = Math.round(cx + Math.cos(angle) * length);
+        const targetY = Math.round(cy + Math.sin(angle) * length);
+        carveLine(ctx, cx, cy, targetX, targetY, armWidth);
+        carveDisc(ctx, Math.round(cx + Math.cos(angle) * (coreRadius + spacing)), Math.round(cy + Math.sin(angle) * (coreRadius + spacing)), Math.max(2, armWidth + 1));
+      }
+      for (let i = 0; i < arms; i++) {
+        const angle = offset + (Math.PI * 2 * i) / arms;
+        const next = offset + (Math.PI * 2 * (i + 1)) / arms;
+        const innerR = coreRadius + spacing * Math.max(1, Math.floor(rings / 2));
+        const x1 = Math.round(cx + Math.cos(angle) * innerR);
+        const y1 = Math.round(cy + Math.sin(angle) * innerR);
+        const x2 = Math.round(cx + Math.cos(next) * innerR);
+        const y2 = Math.round(cy + Math.sin(next) * innerR);
+        carveLine(ctx, x1, y1, x2, y2, 1);
+      }
+      if (structureTags) sprinkleStructures(ctx, structureTags, 3);
+      ctx.ensureConnectivity();
+      applyPalette(ctx, palette, options.paletteOptions || {});
+    };
+  }
+
+  function createGridAlgorithm(options) {
+    const {
+      cellSize = 4,
+      corridorWidth = 2,
+      margin = 2,
+      openings = 6,
+      structureTags,
+      palette
+    } = options;
+    return function(ctx) {
+      fillSolid(ctx, 1);
+      for (let y = margin; y < ctx.height - margin; y += cellSize + corridorWidth) {
+        for (let x = margin; x < ctx.width - margin; x += cellSize + corridorWidth) {
+          carveRect(ctx, x, y, x + cellSize - 1, y + cellSize - 1);
+        }
+      }
+      for (let y = margin + cellSize; y < ctx.height - margin; y += cellSize + corridorWidth) {
+        carveRect(ctx, margin, y, ctx.width - margin - 1, y + corridorWidth - 1);
+      }
+      for (let x = margin + cellSize; x < ctx.width - margin; x += cellSize + corridorWidth) {
+        carveRect(ctx, x, margin, x + corridorWidth - 1, ctx.height - margin - 1);
+      }
+      for (let i = 0; i < openings; i++) {
+        const rx = randomInt(ctx, margin, ctx.width - margin - 2);
+        const ry = randomInt(ctx, margin, ctx.height - margin - 2);
+        carveRect(ctx, rx, ry, rx + 1, ry + 1);
+      }
+      if (structureTags) sprinkleStructures(ctx, structureTags, 3);
+      ctx.ensureConnectivity();
+      applyPalette(ctx, palette, options.paletteOptions || {});
+    };
+  }
+
+  function createFlowAlgorithm(options) {
+    const {
+      streams = 4,
+      steps = 90,
+      width = 2,
+      margin = 2,
+      branchInterval = 18,
+      structureTags,
+      palette
+    } = options;
+    return function(ctx) {
+      fillSolid(ctx, 1);
+      carveRect(ctx, margin, Math.floor(ctx.height / 2) - Math.floor(width / 2), ctx.width - margin - 1, Math.floor(ctx.height / 2) + Math.floor(width / 2));
+      carveRect(ctx, Math.floor(ctx.width / 2) - Math.floor(width / 2), margin, Math.floor(ctx.width / 2) + Math.floor(width / 2), ctx.height - margin - 1);
+      for (let s = 0; s < streams; s++) {
+        let x = randomInt(ctx, margin, ctx.width - margin - 1);
+        let y = randomInt(ctx, margin, ctx.height - margin - 1);
+        for (let step = 0; step < steps; step++) {
+          carveRect(ctx, x - Math.floor(width / 2), y - Math.floor(width / 2), x + Math.floor(width / 2), y + Math.floor(width / 2));
+          const dirBias = s % 2 === 0 ? 1 : -1;
+          const optionsDir = [
+            [1, 0],
+            [-1, 0],
+            [0, 1],
+            [0, -1]
+          ];
+          const choice = optionsDir[randomInt(ctx, 0, optionsDir.length - 1)];
+          const jitter = optionsDir[randomInt(ctx, 0, optionsDir.length - 1)];
+          x += choice[0] + (step % 5 === 0 ? dirBias : 0);
+          y += choice[1] + (step % 7 === 0 ? -dirBias : 0);
+          if (step % branchInterval === 0) {
+            carveLine(ctx, x, y, Math.floor(ctx.width / 2), Math.floor(ctx.height / 2), width);
+          }
+          x = clamp(x, margin, ctx.width - margin - 1);
+          y = clamp(y, margin, ctx.height - margin - 1);
+          if (step % 11 === 0) {
+            carveRect(ctx, x + jitter[0], y + jitter[1], x + jitter[0], y + jitter[1]);
+          }
+        }
+      }
+      for (let i = 0; i < streams; i++) {
+        const edge = i % 4;
+        let sx, sy;
+        if (edge === 0) { sx = randomInt(ctx, margin, ctx.width - margin - 1); sy = margin; }
+        else if (edge === 1) { sx = ctx.width - margin - 1; sy = randomInt(ctx, margin, ctx.height - margin - 1); }
+        else if (edge === 2) { sx = randomInt(ctx, margin, ctx.width - margin - 1); sy = ctx.height - margin - 1; }
+        else { sx = margin; sy = randomInt(ctx, margin, ctx.height - margin - 1); }
+        carveLine(ctx, sx, sy, Math.floor(ctx.width / 2), Math.floor(ctx.height / 2), width);
+      }
+      if (structureTags) sprinkleStructures(ctx, structureTags, 2);
+      ctx.ensureConnectivity();
+      applyPalette(ctx, palette, options.paletteOptions || {});
+    };
+  }
+
+  function createOrganicAlgorithm(options) {
+    const {
+      fillChance = 0.45,
+      smoothSteps = 3,
+      structureTags,
+      palette
+    } = options;
+    return function(ctx) {
+      const w = ctx.width;
+      const h = ctx.height;
+      const data = [];
+      for (let y = 0; y < h; y++) {
+        const row = [];
+        for (let x = 0; x < w; x++) {
+          if (x === 0 || y === 0 || x === w - 1 || y === h - 1) {
+            row.push(1);
+          } else {
+            const chance = fillChance + (Math.sin(x * 0.2) + Math.cos(y * 0.17)) * 0.05;
+            row.push((ctx.random && ctx.random() < chance) ? 0 : 1);
+          }
+        }
+        data.push(row);
+      }
+      for (let step = 0; step < smoothSteps; step++) {
+        const next = [];
+        for (let y = 0; y < h; y++) {
+          const row = [];
+          for (let x = 0; x < w; x++) {
+            if (x === 0 || y === 0 || x === w - 1 || y === h - 1) {
+              row.push(1);
+              continue;
+            }
+            let floors = 0;
+            for (let yy = -1; yy <= 1; yy++) {
+              for (let xx = -1; xx <= 1; xx++) {
+                if (xx === 0 && yy === 0) continue;
+                if (data[y + yy]?.[x + xx] === 0) floors++;
+              }
+            }
+            if (floors >= 4) row.push(0);
+            else if (floors <= 2) row.push(1);
+            else row.push(data[y][x]);
+          }
+          next.push(row);
+        }
+        for (let y = 0; y < h; y++) data[y] = next[y];
+      }
+      for (let y = 1; y < h - 1; y++) {
+        for (let x = 1; x < w - 1; x++) {
+          ctx.set(x, y, data[y][x] ? 1 : 0);
+        }
+      }
+      carveDisc(ctx, Math.floor(w / 2), Math.floor(h / 2), 4);
+      carveRect(ctx, 2, Math.floor(h / 2) - 1, w - 3, Math.floor(h / 2) + 1);
+      if (structureTags) sprinkleStructures(ctx, structureTags, 2);
+      ctx.ensureConnectivity();
+      applyPalette(ctx, palette, options.paletteOptions || {});
+    };
+  }
+
+  function createPlatformAlgorithm(options) {
+    const {
+      islands = 7,
+      platformRadius = 3,
+      bridgeWidth = 2,
+      structureTags,
+      palette
+    } = options;
+    return function(ctx) {
+      fillSolid(ctx, 1);
+      const cx = Math.floor(ctx.width / 2);
+      const cy = Math.floor(ctx.height / 2);
+      carveDisc(ctx, cx, cy, platformRadius + 2);
+      for (let i = 0; i < islands; i++) {
+        const angle = (Math.PI * 2 * i) / islands + (ctx.random ? ctx.random() * 0.6 : Math.random() * 0.6);
+        const radius = platformRadius + 4 + (ctx.random ? ctx.random() * 6 : Math.random() * 6);
+        const px = Math.round(cx + Math.cos(angle) * radius);
+        const py = Math.round(cy + Math.sin(angle) * radius);
+        carveDisc(ctx, px, py, platformRadius);
+        carveLine(ctx, cx, cy, px, py, bridgeWidth);
+        if (i % 2 === 0) {
+          const nextAngle = angle + Math.PI / islands;
+          const nx = Math.round(cx + Math.cos(nextAngle) * (radius + 3));
+          const ny = Math.round(cy + Math.sin(nextAngle) * (radius + 3));
+          carveLine(ctx, px, py, nx, ny, 1);
+        }
+      }
+      if (structureTags) sprinkleStructures(ctx, structureTags, 3);
+      ctx.ensureConnectivity();
+      applyPalette(ctx, palette, options.paletteOptions || {});
+    };
+  }
+
+  function createLoopAlgorithm(options) {
+    const {
+      loops = 4,
+      spacing = 3,
+      corridorWidth = 2,
+      structureTags,
+      palette
+    } = options;
+    return function(ctx) {
+      fillSolid(ctx, 1);
+      const margin = Math.max(2, spacing);
+      for (let i = 0; i < loops; i++) {
+        const inset = margin + i * spacing;
+        carveRectRing(ctx, inset, inset, ctx.width - inset - 1, ctx.height - inset - 1, corridorWidth);
+        if (i % 2 === 0) {
+          carveDisc(ctx, Math.floor(ctx.width / 2), inset + 2, 2);
+          carveDisc(ctx, Math.floor(ctx.width / 2), ctx.height - inset - 3, 2);
+        }
+      }
+      for (let i = 2; i < ctx.height - 2; i += Math.max(4, spacing + 1)) {
+        carveRect(ctx, Math.floor(ctx.width / 2) - 1, i, Math.floor(ctx.width / 2) + 1, i + 1);
+      }
+      if (structureTags) sprinkleStructures(ctx, structureTags, 2);
+      ctx.ensureConnectivity();
+      applyPalette(ctx, palette, options.paletteOptions || {});
+    };
+  }
+
+  function createSymmetryAlgorithm(options) {
+    const {
+      armLength = 12,
+      crossWidth = 2,
+      includeDiagonals = true,
+      structureTags,
+      palette
+    } = options;
+    return function(ctx) {
+      fillSolid(ctx, 1);
+      const cx = Math.floor(ctx.width / 2);
+      const cy = Math.floor(ctx.height / 2);
+      carveRect(ctx, cx - crossWidth, Math.max(2, cy - armLength), cx + crossWidth, Math.min(ctx.height - 3, cy + armLength));
+      carveRect(ctx, Math.max(2, cx - armLength), cy - crossWidth, Math.min(ctx.width - 3, cx + armLength), cy + crossWidth);
+      carveDisc(ctx, cx, cy, crossWidth + 2);
+      carveRect(ctx, Math.max(2, cx - crossWidth - 4), Math.max(2, cy - crossWidth - 4), Math.min(ctx.width - 3, cx + crossWidth + 4), Math.min(ctx.height - 3, cy + crossWidth + 4));
+      if (includeDiagonals) {
+        carveLine(ctx, 2, 2, ctx.width - 3, ctx.height - 3, 1);
+        carveLine(ctx, ctx.width - 3, 2, 2, ctx.height - 3, 1);
+      }
+      if (structureTags) sprinkleStructures(ctx, structureTags, 2);
+      ctx.ensureConnectivity();
+      applyPalette(ctx, palette, options.paletteOptions || {});
+    };
+  }
+
+  function createPlazaAlgorithm(options) {
+    const {
+      radius = 8,
+      spokes = 6,
+      structureTags,
+      palette
+    } = options;
+    return function(ctx) {
+      fillSolid(ctx, 1);
+      const cx = Math.floor(ctx.width / 2);
+      const cy = Math.floor(ctx.height / 2);
+      carveDisc(ctx, cx, cy, radius);
+      carveRing(ctx, cx, cy, radius + 3, 2);
+      for (let i = 0; i < spokes; i++) {
+        const angle = (Math.PI * 2 * i) / spokes;
+        const tx = Math.round(cx + Math.cos(angle) * (radius + 6));
+        const ty = Math.round(cy + Math.sin(angle) * (radius + 6));
+        carveLine(ctx, cx, cy, tx, ty, 2);
+        carveDisc(ctx, Math.round(cx + Math.cos(angle) * (radius + 3)), Math.round(cy + Math.sin(angle) * (radius + 3)), 2);
+      }
+      if (structureTags) sprinkleStructures(ctx, structureTags, 4);
+      ctx.ensureConnectivity();
+      applyPalette(ctx, palette, options.paletteOptions || {});
+    };
+  }
+
+  function createSpiralAlgorithm(options) {
+    const {
+      turns = 3,
+      spacing = 2,
+      width = 2,
+      structureTags,
+      palette
+    } = options;
+    return function(ctx) {
+      fillSolid(ctx, 1);
+      let x0 = 2;
+      let y0 = 2;
+      let x1 = ctx.width - 3;
+      let y1 = ctx.height - 3;
+      let toggle = 0;
+      while (x0 <= x1 && y0 <= y1) {
+        if (toggle % 4 === 0) carveRect(ctx, x0, y0, x1, y0 + width - 1);
+        if (toggle % 4 === 1) carveRect(ctx, x1 - width + 1, y0, x1, y1);
+        if (toggle % 4 === 2) carveRect(ctx, x0, y1 - width + 1, x1, y1);
+        if (toggle % 4 === 3) carveRect(ctx, x0, y0, x0 + width - 1, y1);
+        if (toggle >= turns * 4) break;
+        x0 += spacing;
+        y0 += spacing;
+        x1 -= spacing;
+        y1 -= spacing;
+        toggle++;
+      }
+      carveDisc(ctx, Math.floor((x0 + x1) / 2), Math.floor((y0 + y1) / 2), width + 1);
+      if (structureTags) sprinkleStructures(ctx, structureTags, 2);
+      ctx.ensureConnectivity();
+      applyPalette(ctx, palette, options.paletteOptions || {});
+    };
+  }
+
+  function createSectorAlgorithm(options) {
+    const {
+      sectors = 6,
+      ringSpacing = 3,
+      corridorWidth = 2,
+      coreRadius = 3,
+      structureTags,
+      palette
+    } = options;
+    return function(ctx) {
+      fillSolid(ctx, 1);
+      const cx = Math.floor(ctx.width / 2);
+      const cy = Math.floor(ctx.height / 2);
+      const maxRadius = Math.min(cx, cy) - 2;
+      carveDisc(ctx, cx, cy, Math.max(2, coreRadius));
+      for (let r = coreRadius + ringSpacing; r < maxRadius; r += ringSpacing) {
+        carveRing(ctx, cx, cy, r, 1);
+      }
+      const offset = (ctx.random ? ctx.random() : Math.random()) * Math.PI * 2;
+      for (let i = 0; i < sectors; i++) {
+        const angle = offset + (Math.PI * 2 * i) / sectors;
+        const next = offset + (Math.PI * 2 * (i + 1)) / sectors;
+        const mid = (angle + next) / 2;
+        for (let step = coreRadius + 1; step < maxRadius; step += Math.max(2, corridorWidth + 1)) {
+          const x = Math.round(cx + Math.cos(angle) * step);
+          const y = Math.round(cy + Math.sin(angle) * step);
+          carveRect(ctx, x - Math.floor(corridorWidth / 2), y - Math.floor(corridorWidth / 2), x + Math.floor(corridorWidth / 2), y + Math.floor(corridorWidth / 2));
+          if (step % (ringSpacing * 2) === 0) {
+            const mx = Math.round(cx + Math.cos(mid) * step);
+            const my = Math.round(cy + Math.sin(mid) * step);
+            carveLine(ctx, x, y, mx, my, Math.max(1, corridorWidth - 1));
+          }
+        }
+      }
+      carveRing(ctx, cx, cy, maxRadius - 1, corridorWidth);
+      if (structureTags) sprinkleStructures(ctx, structureTags, 3);
+      ctx.ensureConnectivity();
+      applyPalette(ctx, palette, options.paletteOptions || {});
+    };
+  }
+
+  function createWeaveAlgorithm(options) {
+    const {
+      bands = 6,
+      bandWidth = 2,
+      gap = 2,
+      diagonal = false,
+      structureTags,
+      palette
+    } = options;
+    return function(ctx) {
+      fillSolid(ctx, 1);
+      let toggle = 0;
+      for (let y = 2; y < ctx.height - 2; y += bandWidth + gap) {
+        for (let yy = 0; yy < bandWidth && y + yy < ctx.height - 2; yy++) {
+          if (toggle % 2 === 0) {
+            carveRect(ctx, 2, y + yy, ctx.width - 3, y + yy);
+          } else {
+            for (let x = 2; x < ctx.width - 2; x += gap + bandWidth) {
+              carveRect(ctx, x, y + yy, Math.min(ctx.width - 3, x + bandWidth - 1), y + yy);
+            }
+          }
+        }
+        toggle++;
+      }
+      toggle = 0;
+      for (let x = 2; x < ctx.width - 2; x += bandWidth + gap) {
+        for (let xx = 0; xx < bandWidth && x + xx < ctx.width - 2; xx++) {
+          if (toggle % 2 === 0) {
+            carveRect(ctx, x + xx, 2, x + xx, ctx.height - 3);
+          } else {
+            for (let y = 2; y < ctx.height - 2; y += gap + bandWidth) {
+              carveRect(ctx, x + xx, y, x + xx, Math.min(ctx.height - 3, y + bandWidth - 1));
+            }
+          }
+        }
+        toggle++;
+      }
+      if (diagonal) {
+        carveLine(ctx, 2, 2, ctx.width - 3, ctx.height - 3, 1);
+        carveLine(ctx, ctx.width - 3, 2, 2, ctx.height - 3, 1);
+      }
+      carveRect(ctx, Math.floor(ctx.width / 2) - 1, 2, Math.floor(ctx.width / 2) + 1, ctx.height - 3);
+      carveRect(ctx, 2, Math.floor(ctx.height / 2) - 1, ctx.width - 3, Math.floor(ctx.height / 2) + 1);
+      if (structureTags) sprinkleStructures(ctx, structureTags, 4);
+      ctx.ensureConnectivity();
+      applyPalette(ctx, palette, options.paletteOptions || {});
+    };
+  }
+
+  function createClusterAlgorithm(options) {
+    const {
+      clusters = 8,
+      minRadius = 2,
+      maxRadius = 5,
+      connectors = 6,
+      structureTags,
+      palette
+    } = options;
+    return function(ctx) {
+      fillSolid(ctx, 1);
+      const points = [];
+      for (let i = 0; i < clusters; i++) {
+        const radius = randomInt(ctx, minRadius, maxRadius);
+        const px = randomInt(ctx, 4, ctx.width - 5);
+        const py = randomInt(ctx, 4, ctx.height - 5);
+        carveDisc(ctx, px, py, radius);
+        points.push({ x: px, y: py });
+      }
+      const cx = Math.floor(ctx.width / 2);
+      const cy = Math.floor(ctx.height / 2);
+      carveDisc(ctx, cx, cy, Math.max(minRadius + 1, 3));
+      points.forEach(p => {
+        carveLine(ctx, cx, cy, p.x, p.y, 2);
+      });
+      for (let i = 0; i < connectors && points.length > 1; i++) {
+        const a = points[randomInt(ctx, 0, points.length - 1)];
+        const b = points[randomInt(ctx, 0, points.length - 1)];
+        if (a !== b) carveLine(ctx, a.x, a.y, b.x, b.y, 2);
+      }
+      if (structureTags) sprinkleStructures(ctx, structureTags, 3);
+      ctx.ensureConnectivity();
+      applyPalette(ctx, palette, options.paletteOptions || {});
+    };
+  }
+
+  const styleFactories = {
+    hub: createHubAlgorithm,
+    grid: createGridAlgorithm,
+    flow: createFlowAlgorithm,
+    organic: createOrganicAlgorithm,
+    platforms: createPlatformAlgorithm,
+    loop: createLoopAlgorithm,
+    symmetry: createSymmetryAlgorithm,
+    plaza: createPlazaAlgorithm,
+    spiral: createSpiralAlgorithm,
+    sector: createSectorAlgorithm,
+    weave: createWeaveAlgorithm,
+    cluster: createClusterAlgorithm
+  };
+  const generatorConfigs = [
+    { id: 'spaceship_core', name: '機関部ノード', description: '反応炉周辺のリングと放射状の保守路。', palette: { floor: '#0F1E33', wall: '#08111F', accent: '#2FD3FF' }, mixin: { normalMixed: 0.3, blockDimMixed: 0.5, tags: ['sf', 'spaceship', 'technical'] }, style: 'hub', arms: 6, rings: 4, coreRadius: 4, paletteOptions: { accentStride: 6 }, structureTags: ['spaceship', 'hub'], soundscape: 'ship-engine' },
+    { id: 'spaceship_hab', name: '居住区モジュール', description: 'コリドーがグリッド状に走る生活区画。', palette: { floor: '#1F2D3F', wall: '#32465A', accent: '#4BE2C2' }, mixin: { normalMixed: 0.25, blockDimMixed: 0.4, tags: ['sf', 'spaceship', 'residential'] }, style: 'grid', cellSize: 4, corridorWidth: 2, openings: 8, structureTags: ['spaceship', 'residential'], paletteOptions: { accentChance: 0.1 }, soundscape: 'habitat-murmur' },
+    { id: 'spaceship_dock', name: 'ドックベイ', description: '巨大ハンガーと貨物レーンが交差する船舶ドック。', palette: { floor: '#15283B', wall: '#071421', accent: '#5AA4FF' }, mixin: { normalMixed: 0.35, blockDimMixed: 0.5, tags: ['sf', 'spaceship', 'industrial'] }, style: 'flow', streams: 5, steps: 110, width: 3, branchInterval: 14, structureTags: ['spaceship', 'industrial'], paletteOptions: { accentStride: 4 }, soundscape: 'dock-hum' },
+    { id: 'spaceship_ai', name: '指令AI中枢', description: '演算コアが同心ループで守られた制御中枢。', palette: { floor: '#112233', wall: '#050B11', accent: '#7E5CFF' }, mixin: { normalMixed: 0.2, blockDimMixed: 0.35, tags: ['sf', 'spaceship', 'ai'] }, style: 'loop', loops: 5, spacing: 2, corridorWidth: 2, structureTags: ['spaceship', 'ai'], paletteOptions: { accentChance: 0.06 }, soundscape: 'core-thrum' },
+    { id: 'spaceship_medbay', name: 'メディカルベイ', description: '無菌処置室が十字に配置された治療層。', palette: { floor: '#143347', wall: '#0B1E2B', accent: '#55F3E9' }, mixin: { normalMixed: 0.22, blockDimMixed: 0.35, tags: ['sf', 'spaceship', 'medical'] }, style: 'symmetry', armLength: 10, crossWidth: 2, includeDiagonals: false, structureTags: ['spaceship', 'medical'], paletteOptions: { accentStride: 4, accentChance: 0.12 }, soundscape: 'med-lab' },
+    { id: 'spaceship_engineering', name: '保守機関層', description: '補修用ブリッジと配管が密集する工学区画。', palette: { floor: '#1A2639', wall: '#0A141F', accent: '#FFB347' }, mixin: { normalMixed: 0.28, blockDimMixed: 0.45, tags: ['sf', 'spaceship', 'engineering'] }, style: 'flow', streams: 5, steps: 120, width: 2, branchInterval: 12, structureTags: ['spaceship', 'engineering'], paletteOptions: { accentChance: 0.1 }, soundscape: 'maintenance-rattle' },
+
+    { id: 'cyber_grid', name: 'データグリッド', description: '直交グリッドが無限に伸びるデータ層。', palette: { floor: '#090513', wall: '#211A6B', accent: '#45E0FF' }, mixin: { normalMixed: 0.3, blockDimMixed: 0.45, tags: ['sf', 'cyber', 'grid'] }, style: 'grid', cellSize: 3, corridorWidth: 2, openings: 10, structureTags: ['cyber', 'grid'], paletteOptions: { accentStride: 3 }, soundscape: 'data-flow' },
+    { id: 'cyber_vault', name: 'セキュリティヴォールト', description: '層状のファイアウォールとバンカーが守るデータ金庫。', palette: { floor: '#12132A', wall: '#2E1B4B', accent: '#8F53FF' }, mixin: { normalMixed: 0.25, blockDimMixed: 0.4, tags: ['sf', 'cyber', 'security'] }, style: 'loop', loops: 4, spacing: 3, corridorWidth: 3, structureTags: ['cyber', 'security'], paletteOptions: { accentChance: 0.05 }, soundscape: 'vault-drone' },
+    { id: 'cyber_glitch', name: 'グリッチ領域', description: '乱数的な欠損が散在する不安定領域。', palette: { floor: '#0A3B3C', wall: '#0F1F20', accent: '#C1FF2E' }, mixin: { normalMixed: 0.15, blockDimMixed: 0.35, tags: ['sf', 'cyber', 'chaos'] }, style: 'organic', fillChance: 0.52, smoothSteps: 2, structureTags: ['cyber', 'chaos'], paletteOptions: { accentChance: 0.15 }, soundscape: 'glitch-static' },
+    { id: 'cyber_stream', name: '情報フロー帯', description: '流線的な情報の大河が流れる帯域。', palette: { floor: '#051B2C', wall: '#0B3857', accent: '#1BFF9F' }, mixin: { normalMixed: 0.3, blockDimMixed: 0.4, tags: ['sf', 'cyber', 'flow'] }, style: 'flow', streams: 6, steps: 130, width: 2, branchInterval: 16, structureTags: ['cyber', 'flow'], paletteOptions: { accentChance: 0.12 }, soundscape: 'data-stream' },
+    { id: 'cyber_forum', name: 'ソーシャルホール', description: 'ホログラム座席が円環状に整列する交流広場。', palette: { floor: '#1A0D3A', wall: '#3A1266', accent: '#FF4BD1' }, mixin: { normalMixed: 0.28, blockDimMixed: 0.42, tags: ['sf', 'cyber', 'forum'] }, style: 'plaza', radius: 7, spokes: 8, structureTags: ['cyber', 'forum'], paletteOptions: { accentChance: 0.14 }, soundscape: 'holo-voices' },
+    { id: 'cyber_subroutine', name: 'サブルーチン回廊', description: '同期ゲートで区切られた連続回廊。', palette: { floor: '#051F2A', wall: '#04353F', accent: '#5CFF8F' }, mixin: { normalMixed: 0.32, blockDimMixed: 0.45, tags: ['sf', 'cyber', 'utility'] }, style: 'symmetry', armLength: 14, crossWidth: 1, includeDiagonals: true, structureTags: ['cyber', 'utility'], paletteOptions: { accentStride: 4 }, soundscape: 'clocked-ticks' },
+    { id: 'future_plaza', name: 'ホログラム広場', description: '浮遊広告塔が立ち並ぶ中心広場。', palette: { floor: '#124652', wall: '#1D6F7A', accent: '#3BFFFF' }, mixin: { normalMixed: 0.35, blockDimMixed: 0.5, tags: ['sf', 'city', 'plaza'] }, style: 'plaza', radius: 9, spokes: 6, structureTags: ['future', 'plaza'], paletteOptions: { accentChance: 0.16 }, soundscape: 'city-hum' },
+    { id: 'future_industrial', name: 'メガ工場層', description: 'ナノ炉とコンベアが連結する工業区。', palette: { floor: '#1E2B3C', wall: '#3A5169', accent: '#FFBF3B' }, mixin: { normalMixed: 0.3, blockDimMixed: 0.45, tags: ['sf', 'city', 'industrial'] }, style: 'grid', cellSize: 5, corridorWidth: 2, openings: 7, structureTags: ['future', 'industrial'], paletteOptions: { accentChance: 0.08 }, soundscape: 'factory-rumble' },
+    { id: 'future_sky', name: 'スカイドメイン', description: '浮遊プラットフォームと昇降路が交差する高層域。', palette: { floor: '#101A33', wall: '#233A66', accent: '#77F6FF' }, mixin: { normalMixed: 0.25, blockDimMixed: 0.4, tags: ['sf', 'city', 'aerial'] }, style: 'platforms', islands: 8, platformRadius: 3, bridgeWidth: 2, structureTags: ['future', 'aerial'], paletteOptions: { accentChance: 0.1 }, soundscape: 'wind-turbine' },
+    { id: 'future_core', name: '都市制御局', description: '制御卓が集中する統制センター。', palette: { floor: '#162938', wall: '#0C141D', accent: '#49FFB5' }, mixin: { normalMixed: 0.2, blockDimMixed: 0.35, tags: ['sf', 'city', 'control'] }, style: 'symmetry', armLength: 12, crossWidth: 2, includeDiagonals: true, structureTags: ['future', 'control'], paletteOptions: { accentChance: 0.06 }, soundscape: 'command-ops' },
+    { id: 'future_residential', name: 'コロニー住居帯', description: 'モジュール住宅が連なる住居棟。', palette: { floor: '#1B2F39', wall: '#223B44', accent: '#7FFFD7' }, mixin: { normalMixed: 0.32, blockDimMixed: 0.45, tags: ['sf', 'city', 'residential'] }, style: 'grid', cellSize: 4, corridorWidth: 2, openings: 6, structureTags: ['future', 'residential'], paletteOptions: { accentChance: 0.12 }, soundscape: 'residence-soft' },
+    { id: 'future_underworks', name: 'アンダーワークス', description: '廃熱管と補修橋が巡る地下保守層。', palette: { floor: '#0D1724', wall: '#121E2D', accent: '#88FF52' }, mixin: { normalMixed: 0.26, blockDimMixed: 0.38, tags: ['sf', 'city', 'maintenance'] }, style: 'organic', fillChance: 0.48, smoothSteps: 3, structureTags: ['future', 'maintenance'], paletteOptions: { accentChance: 0.09 }, soundscape: 'steam-vents' },
+
+    { id: 'orbital_ring', name: '軌道リング廊', description: 'リング状の回廊が星を周回する。', palette: { floor: '#111B28', wall: '#202F45', accent: '#64FFE3' }, mixin: { normalMixed: 0.3, blockDimMixed: 0.45, tags: ['sf', 'orbital', 'ring'] }, style: 'hub', arms: 8, rings: 5, coreRadius: 5, paletteOptions: { accentStride: 5 }, structureTags: ['orbital', 'ring'], soundscape: 'orbital-comm' },
+    { id: 'orbital_lab', name: '真空ラボ', description: '零G実験室が配置された研究ハブ。', palette: { floor: '#132435', wall: '#06121E', accent: '#7BD8FF' }, mixin: { normalMixed: 0.25, blockDimMixed: 0.35, tags: ['sf', 'orbital', 'lab'] }, style: 'grid', cellSize: 4, corridorWidth: 2, openings: 5, structureTags: ['orbital', 'lab'], paletteOptions: { accentChance: 0.07 }, soundscape: 'lab-hum' },
+    { id: 'orbital_armory', name: '軍備庫層', description: '磁気弾薬庫が並ぶ防衛セクション。', palette: { floor: '#1B1E2B', wall: '#2F3547', accent: '#FF4F64' }, mixin: { normalMixed: 0.2, blockDimMixed: 0.35, tags: ['sf', 'orbital', 'armory'] }, style: 'loop', loops: 4, spacing: 2, corridorWidth: 3, structureTags: ['orbital', 'armory'], paletteOptions: { accentChance: 0.05 }, soundscape: 'armory-drum' },
+    { id: 'orbital_greenhouse', name: '宇宙温室帯', description: '水耕プールが連なる生態維持区画。', palette: { floor: '#123123', wall: '#071A10', accent: '#6CFF7A' }, mixin: { normalMixed: 0.22, blockDimMixed: 0.35, tags: ['sf', 'orbital', 'bio'] }, style: 'organic', fillChance: 0.5, smoothSteps: 4, structureTags: ['orbital', 'bio'], paletteOptions: { accentChance: 0.11 }, soundscape: 'greenhouse-air' },
+    { id: 'orbital_command', name: '指令甲板', description: '指揮卓とセンサーが集中する管制甲板。', palette: { floor: '#0F1626', wall: '#1D2740', accent: '#4CF0FF' }, mixin: { normalMixed: 0.18, blockDimMixed: 0.32, tags: ['sf', 'orbital', 'command'] }, style: 'symmetry', armLength: 11, crossWidth: 2, includeDiagonals: true, structureTags: ['orbital', 'command'], paletteOptions: { accentChance: 0.05 }, soundscape: 'command-bridge' },
+
+    { id: 'quantum_reactor', name: '量子炉チャンバー', description: '螺旋状に配置された量子束柱が唸る。', palette: { floor: '#170B2C', wall: '#2A1752', accent: '#FF3CF0' }, mixin: { normalMixed: 0.2, blockDimMixed: 0.3, tags: ['sf', 'quantum', 'reactor'] }, style: 'spiral', turns: 4, spacing: 2, width: 2, structureTags: ['quantum', 'reactor'], paletteOptions: { accentChance: 0.12 }, soundscape: 'quantum-thrum' },
+    { id: 'quantum_archive', name: '記録保管層', description: '時間結晶が整然と並ぶ書架帯。', palette: { floor: '#1F142E', wall: '#2C1F43', accent: '#3CE3FF' }, mixin: { normalMixed: 0.15, blockDimMixed: 0.3, tags: ['sf', 'quantum', 'archive'] }, style: 'grid', cellSize: 3, corridorWidth: 2, openings: 5, structureTags: ['quantum', 'archive'], paletteOptions: { accentChance: 0.06 }, soundscape: 'archive-chime' },
+    { id: 'quantum_void', name: '位相虚空', description: '断片的な足場が浮遊する虚無領域。', palette: { floor: '#04070E', wall: '#000000', accent: '#66FFAA' }, mixin: { normalMixed: 0.1, blockDimMixed: 0.25, tags: ['sf', 'quantum', 'void'] }, style: 'platforms', islands: 6, platformRadius: 2, bridgeWidth: 1, structureTags: ['quantum', 'void'], paletteOptions: { accentChance: 0.18 }, soundscape: 'void-whisper' },
+    { id: 'quantum_prism', name: 'プリズム観測塔', description: '光束導鏡で構成された観測ループ。', palette: { floor: '#1E0E36', wall: '#2F125A', accent: '#FFD84F' }, mixin: { normalMixed: 0.18, blockDimMixed: 0.28, tags: ['sf', 'quantum', 'light'] }, style: 'hub', arms: 5, rings: 3, coreRadius: 4, paletteOptions: { accentChance: 0.1 }, structureTags: ['quantum', 'light'], soundscape: 'prism-hum' },
+    { id: 'chrono_station', name: '時間駅', description: '停滞ホームが並ぶクロノ・プラットフォーム。', palette: { floor: '#14243E', wall: '#233861', accent: '#FF6BC4' }, mixin: { normalMixed: 0.16, blockDimMixed: 0.3, tags: ['sf', 'chrono', 'station'] }, style: 'symmetry', armLength: 13, crossWidth: 2, includeDiagonals: false, structureTags: ['chrono', 'station'], paletteOptions: { accentChance: 0.08 }, soundscape: 'station-chime' },
+    { id: 'chrono_loop', name: '反復ループ域', description: '閉じたループが時間を循環させる領域。', palette: { floor: '#0B1A21', wall: '#132A32', accent: '#74FFE5' }, mixin: { normalMixed: 0.14, blockDimMixed: 0.28, tags: ['sf', 'chrono', 'loop'] }, style: 'spiral', turns: 5, spacing: 2, width: 2, structureTags: ['chrono', 'loop'], paletteOptions: { accentChance: 0.14 }, soundscape: 'loop-echo' },
+    { id: 'xeno_jungle', name: '異星樹海', description: '繁茂する発光樹液で満たされた樹海。', palette: { floor: '#093326', wall: '#042018', accent: '#5BFF8C' }, mixin: { normalMixed: 0.28, blockDimMixed: 0.38, tags: ['sf', 'xeno', 'jungle'] }, style: 'organic', fillChance: 0.55, smoothSteps: 4, structureTags: ['xeno', 'organic'], paletteOptions: { accentChance: 0.15 }, soundscape: 'alien-fauna' },
+    { id: 'xeno_crystal', name: '結晶洞', description: '共鳴結晶が層を為す洞窟帯。', palette: { floor: '#0B1430', wall: '#16224A', accent: '#7DFFFB' }, mixin: { normalMixed: 0.22, blockDimMixed: 0.34, tags: ['sf', 'xeno', 'crystal'] }, style: 'loop', loops: 4, spacing: 3, corridorWidth: 2, structureTags: ['xeno', 'crystal'], paletteOptions: { accentChance: 0.13 }, soundscape: 'crystal-tone' },
+    { id: 'xeno_ruins', name: '古代遺構', description: '刻印された遺跡が散在する異星遺構帯。', palette: { floor: '#1E1B26', wall: '#2C2433', accent: '#FFAA54' }, mixin: { normalMixed: 0.24, blockDimMixed: 0.36, tags: ['sf', 'xeno', 'ruins'] }, style: 'plaza', radius: 8, spokes: 5, structureTags: ['xeno', 'ruins'], paletteOptions: { accentChance: 0.09 }, soundscape: 'ruin-wind' },
+    { id: 'xeno_tide', name: '潮汐ラボ', description: '液状の潮汐が往復する研究帯。', palette: { floor: '#0A1E3F', wall: '#083A5C', accent: '#4DF6FF' }, mixin: { normalMixed: 0.2, blockDimMixed: 0.32, tags: ['sf', 'xeno', 'tide'] }, style: 'flow', streams: 5, steps: 120, width: 2, branchInterval: 15, structureTags: ['xeno', 'tide'], paletteOptions: { accentChance: 0.11 }, soundscape: 'tidal-rush' },
+    { id: 'xeno_desert', name: '微粒砂層', description: '砂丘と耐砂ブリッジが複雑に絡む砂層。', palette: { floor: '#2B1C0F', wall: '#3A2815', accent: '#FFC66B' }, mixin: { normalMixed: 0.26, blockDimMixed: 0.35, tags: ['sf', 'xeno', 'desert'] }, style: 'flow', streams: 4, steps: 100, width: 2, branchInterval: 20, structureTags: ['xeno', 'desert'], paletteOptions: { accentChance: 0.1 }, soundscape: 'sand-shift' },
+
+    { id: 'colony_foundry', name: '鋳造区画', description: 'レーザー炉と補給レールが並列する生産柱。', palette: { floor: '#1F1F2D', wall: '#2D2D44', accent: '#FF7A3C' }, mixin: { normalMixed: 0.3, blockDimMixed: 0.44, tags: ['sf', 'colony', 'foundry'] }, style: 'grid', cellSize: 4, corridorWidth: 2, openings: 6, structureTags: ['colony', 'foundry'], paletteOptions: { accentChance: 0.07 }, soundscape: 'forge-roar' },
+    { id: 'colony_spire', name: '管制スパイア', description: '縦方向へ積層された管制塔。', palette: { floor: '#101B2C', wall: '#1C2F46', accent: '#5AF0FF' }, mixin: { normalMixed: 0.18, blockDimMixed: 0.3, tags: ['sf', 'colony', 'command'] }, style: 'symmetry', armLength: 14, crossWidth: 2, includeDiagonals: true, structureTags: ['colony', 'command'], paletteOptions: { accentChance: 0.05 }, soundscape: 'spire-signal' },
+    { id: 'colony_commons', name: 'コモンズ', description: '市民交流のための共有中庭。', palette: { floor: '#1A2D2E', wall: '#223B3C', accent: '#94FFDD' }, mixin: { normalMixed: 0.34, blockDimMixed: 0.48, tags: ['sf', 'colony', 'commons'] }, style: 'plaza', radius: 9, spokes: 7, structureTags: ['colony', 'commons'], paletteOptions: { accentChance: 0.16 }, soundscape: 'commons-voices' },
+    { id: 'colony_reactor', name: 'コロニー炉心', description: '余熱導管が束ねられた炉心基底。', palette: { floor: '#220F2C', wall: '#331635', accent: '#FF57B0' }, mixin: { normalMixed: 0.22, blockDimMixed: 0.34, tags: ['sf', 'colony', 'reactor'] }, style: 'hub', arms: 6, rings: 4, coreRadius: 4, structureTags: ['colony', 'reactor'], paletteOptions: { accentChance: 0.1 }, soundscape: 'reactor-core' },
+    { id: 'spaceship_warp', name: 'ワープハンガー', description: '星間跳躍ゲートが扇状に配置されたベイ。', palette: { floor: '#081F38', wall: '#050D18', accent: '#5C9DFF' }, mixin: { normalMixed: 0.18, blockDimMixed: 0.32, tags: ['sf', 'spaceship', 'warp'] }, style: 'sector', sectors: 7, ringSpacing: 3, corridorWidth: 2, coreRadius: 4, structureTags: ['spaceship', 'warp'], paletteOptions: { accentChance: 0.08 }, soundscape: 'warp-resonance' },
+    { id: 'spaceship_observatory', name: '星間観測ドーム', description: 'パノラミックドームを通して星図を投影する観測層。', palette: { floor: '#0C1F33', wall: '#091423', accent: '#7DE9FF' }, mixin: { normalMixed: 0.2, blockDimMixed: 0.34, tags: ['sf', 'spaceship', 'observatory'] }, style: 'weave', bands: 6, bandWidth: 2, gap: 2, diagonal: true, structureTags: ['spaceship', 'observation'], paletteOptions: { accentChance: 0.11 }, soundscape: 'stellar-pulse' },
+    { id: 'cyber_arena', name: 'シミュレーションアリーナ', description: '層状のホログラム壁が交差する訓練領域。', palette: { floor: '#0A1230', wall: '#1C2461', accent: '#FF43B9' }, mixin: { normalMixed: 0.26, blockDimMixed: 0.4, tags: ['sf', 'cyber', 'arena'] }, style: 'weave', bands: 7, bandWidth: 2, gap: 2, diagonal: true, structureTags: ['cyber', 'arena'], paletteOptions: { accentChance: 0.18 }, soundscape: 'arena-beat' },
+    { id: 'cyber_mirror', name: 'ミラールーム', description: '反射するデータ層が多面体状に連結する領域。', palette: { floor: '#071428', wall: '#1D305A', accent: '#7CFFEE' }, mixin: { normalMixed: 0.21, blockDimMixed: 0.36, tags: ['sf', 'cyber', 'mirror'] }, style: 'cluster', clusters: 10, minRadius: 2, maxRadius: 4, connectors: 8, structureTags: ['cyber', 'mirror'], paletteOptions: { accentChance: 0.12 }, soundscape: 'mirror-chime' },
+    { id: 'future_metro', name: 'ハイパーメトロ網', description: '多層リニアが編み込まれた交通結節点。', palette: { floor: '#142A38', wall: '#1B3C4F', accent: '#54FFE2' }, mixin: { normalMixed: 0.33, blockDimMixed: 0.48, tags: ['sf', 'city', 'metro'] }, style: 'weave', bands: 6, bandWidth: 3, gap: 2, diagonal: true, structureTags: ['future', 'transport'], paletteOptions: { accentChance: 0.13 }, soundscape: 'metro-thunder' },
+    { id: 'future_cloudport', name: 'クラウドポート', description: '浮遊港湾と気流制御塔がクラスタを成す空港域。', palette: { floor: '#12284C', wall: '#152036', accent: '#8DFFFA' }, mixin: { normalMixed: 0.24, blockDimMixed: 0.38, tags: ['sf', 'city', 'cloudport'] }, style: 'cluster', clusters: 9, minRadius: 2, maxRadius: 5, connectors: 7, structureTags: ['future', 'aerial', 'port'], paletteOptions: { accentChance: 0.1 }, soundscape: 'aero-drift' },
+    { id: 'orbital_scrapyard', name: '軌道スクラップ場', description: '廃船残骸を繋ぎ合わせた浮遊修繕帯。', palette: { floor: '#1B1F2C', wall: '#242F3D', accent: '#FF7B42' }, mixin: { normalMixed: 0.27, blockDimMixed: 0.38, tags: ['sf', 'orbital', 'scrap'] }, style: 'cluster', clusters: 11, minRadius: 2, maxRadius: 5, connectors: 9, structureTags: ['orbital', 'scrap'], paletteOptions: { accentChance: 0.08 }, soundscape: 'scrap-grind' },
+    { id: 'orbital_listening', name: 'リスニングステーション', description: '星間通信を受信する放射状アンテナリング。', palette: { floor: '#0E1D2F', wall: '#142A3F', accent: '#4CF2FF' }, mixin: { normalMixed: 0.19, blockDimMixed: 0.32, tags: ['sf', 'orbital', 'listening'] }, style: 'sector', sectors: 8, ringSpacing: 3, corridorWidth: 2, coreRadius: 3, structureTags: ['orbital', 'antenna'], paletteOptions: { accentChance: 0.07 }, soundscape: 'signal-sweep' },
+    { id: 'quantum_flux', name: 'フラックス遷移域', description: '量子層が位相リングで共鳴する遷移コア。', palette: { floor: '#150926', wall: '#26103F', accent: '#FF72ED' }, mixin: { normalMixed: 0.17, blockDimMixed: 0.3, tags: ['sf', 'quantum', 'flux'] }, style: 'sector', sectors: 9, ringSpacing: 2, corridorWidth: 2, coreRadius: 5, structureTags: ['quantum', 'flux'], paletteOptions: { accentChance: 0.15 }, soundscape: 'flux-hum' },
+    { id: 'chrono_archive', name: '時間アーカイブ', description: '時間波形を編み込んだ螺旋書庫。', palette: { floor: '#111C31', wall: '#19273F', accent: '#FF85D6' }, mixin: { normalMixed: 0.15, blockDimMixed: 0.29, tags: ['sf', 'chrono', 'archive'] }, style: 'weave', bands: 6, bandWidth: 2, gap: 2, diagonal: true, structureTags: ['chrono', 'archive'], paletteOptions: { accentChance: 0.12 }, soundscape: 'chronicle-ripple' },
+    { id: 'chrono_fracture', name: '時空断層帯', description: '断層ゲートが群を成し予測不能な分岐を生む領域。', palette: { floor: '#0A1A24', wall: '#121F2C', accent: '#74FFF4' }, mixin: { normalMixed: 0.13, blockDimMixed: 0.28, tags: ['sf', 'chrono', 'fracture'] }, style: 'cluster', clusters: 8, minRadius: 2, maxRadius: 4, connectors: 10, structureTags: ['chrono', 'fracture'], paletteOptions: { accentChance: 0.14 }, soundscape: 'fracture-echo' },
+    { id: 'xeno_hive', name: '異星ハイブ', description: '有機質の胞巣が層を為す生命圏。', palette: { floor: '#132C1C', wall: '#0B1A11', accent: '#83FF5A' }, mixin: { normalMixed: 0.29, blockDimMixed: 0.4, tags: ['sf', 'xeno', 'hive'] }, style: 'cluster', clusters: 9, minRadius: 2, maxRadius: 5, connectors: 8, structureTags: ['xeno', 'hive'], paletteOptions: { accentChance: 0.18 }, soundscape: 'hive-thrum' },
+    { id: 'xeno_reef', name: '星間リーフ', description: '珊瑚状の浮遊骨格が網目状に広がる生態帯。', palette: { floor: '#0C2430', wall: '#16353F', accent: '#5EFFF7' }, mixin: { normalMixed: 0.25, blockDimMixed: 0.36, tags: ['sf', 'xeno', 'reef'] }, style: 'weave', bands: 5, bandWidth: 3, gap: 2, diagonal: false, structureTags: ['xeno', 'reef'], paletteOptions: { accentChance: 0.16 }, soundscape: 'reef-glow' },
+    { id: 'colony_vault', name: '戦略備蓄庫', description: '多重リングで守られた戦略物資の保管庫。', palette: { floor: '#1A1E32', wall: '#242B3F', accent: '#FF9A4F' }, mixin: { normalMixed: 0.2, blockDimMixed: 0.33, tags: ['sf', 'colony', 'vault'] }, style: 'sector', sectors: 6, ringSpacing: 3, corridorWidth: 3, coreRadius: 5, structureTags: ['colony', 'vault'], paletteOptions: { accentChance: 0.08 }, soundscape: 'vault-lock' },
+    { id: 'colony_arcology', name: 'アーコロジースパイン', description: '垂直都市の核を担う立体街区。', palette: { floor: '#101C2A', wall: '#172535', accent: '#4CFFF4' }, mixin: { normalMixed: 0.31, blockDimMixed: 0.46, tags: ['sf', 'colony', 'arcology'] }, style: 'weave', bands: 7, bandWidth: 2, gap: 1, diagonal: true, structureTags: ['colony', 'arcology'], paletteOptions: { accentChance: 0.09 }, soundscape: 'arcology-hum' }
+  ];
+  function createGenerators() {
+    return generatorConfigs.map(def => {
+      const factory = styleFactories[def.style] || createHubAlgorithm;
+      const algorithm = factory(def);
+      const palette = def.palette || { floor: '#1c1c1c', wall: '#101010', accent: '#3fc5ff' };
+      return {
+        id: def.id,
+        name: def.name,
+        description: def.description,
+        mixin: def.mixin,
+        algorithm,
+        meta: {
+          palette,
+          lighting: {
+            floor: palette.floor,
+            wall: brighten(palette.wall || palette.floor, 0.1),
+            accent: brighten(palette.accent || palette.floor, 0.25)
+          },
+          soundscape: def.soundscape || null,
+          addonId: ADDON_ID
+        }
+      };
+    });
+  }
+
+  function createStructures() {
+    return [
+      { id: 'sf_cross_hub', name: 'クロス制御室', pattern: [
+        '#######',
+        '#.....#',
+        '#..#..#',
+        '.......',
+        '#..#..#',
+        '#.....#',
+        '#######'
+      ], tags: ['sf', 'spaceship', 'hub'], allowRotation: true, allowMirror: true },
+      { id: 'sf_reactor_core', name: 'リアクターハート', pattern: [
+        '#######',
+        '#..#..#',
+        '#..#..#',
+        '##...##',
+        '#..#..#',
+        '#..#..#',
+        '#######'
+      ], tags: ['sf', 'spaceship', 'reactor'], allowRotation: true },
+      { id: 'sf_datagrid_cell', name: 'データセル', pattern: [
+        '#####',
+        '#...#',
+        '#.#.#',
+        '#...#',
+        '#####'
+      ], tags: ['sf', 'cyber', 'grid'], allowRotation: true },
+      { id: 'sf_glitch_shard', name: 'グリッチ欠片', pattern: [
+        '#####',
+        '#..##',
+        '#.#.#',
+        '##..#',
+        '#####'
+      ], tags: ['sf', 'cyber', 'chaos'], allowRotation: true, allowMirror: true },
+      { id: 'sf_forum_ring', name: 'フォーラムリング', pattern: [
+        '#######',
+        '#..#..#',
+        '#.....#',
+        '#.#.#.#',
+        '#.....#',
+        '#..#..#',
+        '#######'
+      ], tags: ['sf', 'cyber', 'forum'], allowRotation: true },
+      { id: 'sf_plaza_podium', name: 'ホロポディウム', pattern: [
+        '#######',
+        '#.....#',
+        '#.....#',
+        '#..#..#',
+        '#.....#',
+        '#.....#',
+        '#######'
+      ], tags: ['sf', 'future', 'plaza'], allowRotation: true },
+      { id: 'sf_industrial_line', name: 'コンベアライン', pattern: [
+        '###',
+        '#.#',
+        '#.#',
+        '#.#',
+        '###'
+      ], tags: ['sf', 'future', 'industrial'], allowRotation: true },
+      { id: 'sf_sky_platform', name: '浮遊プラットフォーム', pattern: [
+        '#####',
+        '#...#',
+        '#...#',
+        '#...#',
+        '#####'
+      ], tags: ['sf', 'future', 'aerial'], allowRotation: true },
+      { id: 'sf_residential_quad', name: '住居クアッド', pattern: [
+        '######',
+        '#....#',
+        '#.##.#',
+        '#....#',
+        '######'
+      ], tags: ['sf', 'future', 'residential'], allowRotation: true },
+      { id: 'sf_underworks_loop', name: 'メンテナンスループ', pattern: [
+        '#######',
+        '#.#.#.#',
+        '#.....#',
+        '#.#.#.#',
+        '#.....#',
+        '#.#.#.#',
+        '#######'
+      ], tags: ['sf', 'future', 'maintenance'], allowRotation: true },
+      { id: 'sf_greenhouse_cell', name: '温室セル', pattern: [
+        '######',
+        '#....#',
+        '#.##.#',
+        '#....#',
+        '######'
+      ], tags: ['sf', 'orbital', 'bio'], allowRotation: true },
+      { id: 'sf_command_bridge', name: '管制ブリッジ', pattern: [
+        '#######',
+        '#..#..#',
+        '#.#.#.#',
+        '#..#..#',
+        '#######'
+      ], tags: ['sf', 'orbital', 'command'], allowRotation: true },
+      { id: 'sf_quantum_focus', name: '量子フォーカス', pattern: [
+        '#######',
+        '#..#..#',
+        '#.#.#.#',
+        '#..#..#',
+        '#######'
+      ], tags: ['sf', 'quantum', 'reactor'], allowRotation: true },
+      { id: 'sf_archive_stack', name: '記録スタック', pattern: [
+        '#######',
+        '#.#.#.#',
+        '#.#.#.#',
+        '#.#.#.#',
+        '#######'
+      ], tags: ['sf', 'quantum', 'archive'], allowRotation: true },
+      { id: 'sf_chrono_platform', name: 'クロノホーム', pattern: [
+        '#######',
+        '#.....#',
+        '#.#.#.#',
+        '#.....#',
+        '#######'
+      ], tags: ['sf', 'chrono', 'station'], allowRotation: true },
+      { id: 'sf_xeno_grove', name: '異星グローブ', pattern: [
+        '#######',
+        '#..#..#',
+        '#.....#',
+        '#.....#',
+        '#..#..#',
+        '#######'
+      ], tags: ['sf', 'xeno', 'organic'], allowRotation: true },
+      { id: 'sf_xeno_gate', name: '遺構ゲート', pattern: [
+        '#######',
+        '#.#.#.#',
+        '#.....#',
+        '#.#.#.#',
+        '#######'
+      ], tags: ['sf', 'xeno', 'ruins'], allowRotation: true },
+      { id: 'sf_colony_commons', name: 'コモンズホール', pattern: [
+        '#########',
+        '#.......#',
+        '#.#####.#',
+        '#.#...#.#',
+        '#.#...#.#',
+        '#.#####.#',
+        '#.......#',
+        '#########'
+      ], tags: ['sf', 'colony', 'commons'], allowRotation: true },
+      { id: 'sf_warp_gate', name: 'ワープゲートリング', pattern: [
+        '#######',
+        '#..#..#',
+        '#.#.#.#',
+        '#..#..#',
+        '#######'
+      ], tags: ['sf', 'spaceship', 'warp'], allowRotation: true },
+      { id: 'sf_observatory_grid', name: '観測グリッド', pattern: [
+        '#######',
+        '#..#..#',
+        '#.....#',
+        '#..#..#',
+        '#######'
+      ], tags: ['sf', 'spaceship', 'observation'], allowRotation: true },
+      { id: 'sf_arena_mesh', name: 'アリーナメッシュ', pattern: [
+        '########',
+        '#.#..#.#',
+        '#......#',
+        '#.#..#.#',
+        '########'
+      ], tags: ['sf', 'cyber', 'arena'], allowRotation: true, allowMirror: true },
+      { id: 'sf_metro_cross', name: 'メトロ交差', pattern: [
+        '###.###',
+        '...#...',
+        '###.###'
+      ], tags: ['sf', 'future', 'transport'], allowRotation: true },
+      { id: 'sf_cloud_dock', name: 'クラウドドック', pattern: [
+        '#####',
+        '#...#',
+        '#.#.#',
+        '#...#',
+        '#####'
+      ], tags: ['sf', 'future', 'port'], allowRotation: true },
+      { id: 'sf_scrap_node', name: 'スクラップノード', pattern: [
+        '######',
+        '#.#..#',
+        '#....#',
+        '#..#.#',
+        '######'
+      ], tags: ['sf', 'orbital', 'scrap'], allowRotation: true, allowMirror: true },
+      { id: 'sf_listening_spire', name: 'リスニングスパイア', pattern: [
+        '#######',
+        '#..#..#',
+        '#.#.#.#',
+        '#..#..#',
+        '#######'
+      ], tags: ['sf', 'orbital', 'antenna'], allowRotation: true },
+      { id: 'sf_flux_cell', name: 'フラックスセル', pattern: [
+        '#######',
+        '#.#.#.#',
+        '#..#..#',
+        '#.#.#.#',
+        '#######'
+      ], tags: ['sf', 'quantum', 'flux'], allowRotation: true },
+      { id: 'sf_chrono_stack', name: '時間アーカイブスタック', pattern: [
+        '########',
+        '#......#',
+        '#.####.#',
+        '#......#',
+        '########'
+      ], tags: ['sf', 'chrono', 'archive'], allowRotation: true },
+      { id: 'sf_fracture_node', name: '断層ノード', pattern: [
+        '#####',
+        '#.#.#',
+        '##.##',
+        '#.#.#',
+        '#####'
+      ], tags: ['sf', 'chrono', 'fracture'], allowRotation: true, allowMirror: true },
+      { id: 'sf_hive_chamber', name: 'ハイブチャンバー', pattern: [
+        '#######',
+        '#..#..#',
+        '#.....#',
+        '#..#..#',
+        '#######'
+      ], tags: ['sf', 'xeno', 'hive'], allowRotation: true },
+      { id: 'sf_reef_arc', name: 'リーフアーチ', pattern: [
+        '######',
+        '#....#',
+        '#.##.#',
+        '#....#',
+        '######'
+      ], tags: ['sf', 'xeno', 'reef'], allowRotation: true },
+      { id: 'sf_vault_ring', name: '備蓄リング', pattern: [
+        '#######',
+        '#.#.#.#',
+        '#.....#',
+        '#.#.#.#',
+        '#######'
+      ], tags: ['sf', 'colony', 'vault'], allowRotation: true },
+      { id: 'sf_arcology_core', name: 'アーコロジー核', pattern: [
+        '#########',
+        '#..###..#',
+        '#.......#',
+        '###...###',
+        '#.......#',
+        '#..###..#',
+        '#########'
+      ], tags: ['sf', 'colony', 'arcology'], allowRotation: true }
+    ];
+  }
+  function createBlocks() {
+    const dimensions = [
+      { key: 'sf-deep-orbit', name: 'ディープオービット', baseLevel: 120 },
+      { key: 'sf-cyber-lattice', name: 'サイバーラティス', baseLevel: 150 },
+      { key: 'sf-quantum-fold', name: '量子折り畳み階層', baseLevel: 180 },
+      { key: 'sf-stellar-halo', name: 'ステラーハローベルト', baseLevel: 200 },
+      { key: 'sf-bio-cascade', name: 'バイオカスケード', baseLevel: 135 }
+    ];
+
+    const blocks1 = [
+      { key: 'sf-reactor-floor', name: 'プラズマ反応床', level: +1, size: 0, depth: 0, chest: 'normal', type: 'spaceship_core', weight: 1.2 },
+      { key: 'sf-magnetic-wall', name: '磁束壁板', level: +1, size: 0, depth: 0, chest: 'less', type: 'spaceship_core', weight: 0.8 },
+      { key: 'sf-hab-garden', name: 'ハイドロポニクス床', level: 0, size: 0, depth: 0, chest: 'more', type: 'spaceship_hab', weight: 1.1 },
+      { key: 'sf-ai-server', name: 'AIサーバーパネル', level: +2, size: +1, depth: 0, chest: 'less', type: 'spaceship_ai' },
+      { key: 'sf-grid-node', name: 'グリッドノード床', level: +1, size: 0, depth: 0, chest: 'normal', type: 'cyber_grid' },
+      { key: 'sf-firewall-wall', name: 'ファイアウォール壁', level: +2, size: 0, depth: 0, chest: 'less', type: 'cyber_vault' },
+      { key: 'sf-glitch-tile', name: 'グリッチタイル', level: 0, size: -1, depth: 0, chest: 'less', type: 'cyber_glitch', weight: 0.9 },
+      { key: 'sf-stream-bridge', name: '信号橋梁', level: +1, size: +1, depth: 0, chest: 'normal', type: 'cyber_stream' },
+      { key: 'sf-plaza-holo', name: 'ホログラム床', level: 0, size: 0, depth: 0, chest: 'more', type: 'future_plaza' },
+      { key: 'sf-industrial-conveyor', name: 'メガライン床', level: +2, size: +1, depth: 0, chest: 'normal', type: 'future_industrial' },
+      { key: 'sf-sky-lift', name: '垂直リフト床', level: +1, size: +1, depth: 0, chest: 'less', type: 'future_sky' },
+      { key: 'sf-core-glass', name: '強化監視壁', level: +1, size: 0, depth: 0, chest: 'less', type: 'future_core' },
+      { key: 'sf-medbay-sterile', name: '無菌メディカル床', level: 0, size: 0, depth: 0, chest: 'more', type: 'spaceship_medbay' },
+      { key: 'sf-engineering-grate', name: 'エンジニアリンググレーチング', level: +1, size: 0, depth: 0, chest: 'normal', type: 'spaceship_engineering' },
+      { key: 'sf-forum-stage', name: 'ソーシャルホール舞台床', level: 0, size: -1, depth: 0, chest: 'less', type: 'cyber_forum' },
+      { key: 'sf-subroutine-panel', name: 'サブルーチン診断床', level: +1, size: 0, depth: 0, chest: 'normal', type: 'cyber_subroutine' },
+      { key: 'sf-residential-terrace', name: 'テラスフロア', level: 0, size: 0, depth: 0, chest: 'more', type: 'future_residential' },
+      { key: 'sf-underworks-catwalk', name: 'アンダーワークス猫歩き床', level: +1, size: 0, depth: 0, chest: 'less', type: 'future_underworks' },
+      { key: 'sf-xeno-jungle-floor', name: 'バイオルミ床板', level: +1, size: 0, depth: 0, chest: 'normal', type: 'xeno_jungle' },
+      { key: 'sf-colony-commons-floor', name: 'コモンズ共有床', level: 0, size: 0, depth: 0, chest: 'more', type: 'colony_commons' },
+      { key: 'sf-warp-pad', name: 'ワープパッド床', level: +2, size: 0, depth: 0, chest: 'less', type: 'spaceship_warp', weight: 0.9 },
+      { key: 'sf-observatory-plate', name: '観測ドーム床板', level: +1, size: 0, depth: 0, chest: 'normal', type: 'spaceship_observatory' },
+      { key: 'sf-arena-track', name: 'アリーナトラック床', level: +1, size: 0, depth: 0, chest: 'more', type: 'cyber_arena' },
+      { key: 'sf-mirror-panel', name: 'ミラーパネル壁', level: +1, size: 0, depth: 0, chest: 'less', type: 'cyber_mirror', weight: 0.8 },
+      { key: 'sf-metro-strut', name: 'メトロ支持梁', level: +2, size: +1, depth: 0, chest: 'normal', type: 'future_metro' },
+      { key: 'sf-cloud-dock-floor', name: 'クラウドドック床', level: +1, size: 0, depth: 0, chest: 'normal', type: 'future_cloudport' },
+      { key: 'sf-scrap-plating', name: 'スクラップ装甲板', level: +1, size: 0, depth: 0, chest: 'less', type: 'orbital_scrapyard' },
+      { key: 'sf-listening-array', name: 'リスニングアレイ床', level: +1, size: 0, depth: 0, chest: 'normal', type: 'orbital_listening' },
+      { key: 'sf-reef-trellis', name: 'リーフトレリス床', level: +1, size: 0, depth: 0, chest: 'more', type: 'xeno_reef' },
+      { key: 'sf-hive-pith', name: 'ハイブピス床', level: +2, size: 0, depth: 0, chest: 'less', type: 'xeno_hive', weight: 0.95 },
+      { key: 'sf-arcology-floor', name: 'アーコロジーフロア', level: +2, size: +1, depth: 0, chest: 'normal', type: 'colony_arcology' },
+      { key: 'sf-vault-plate', name: '備蓄庫床板', level: +1, size: 0, depth: 0, chest: 'less', type: 'colony_vault' }
+    ];
+    const blocks2 = [
+      { key: 'sf-orbit-ring-floor', name: '軌道リング床', level: +2, size: +1, depth: +1, chest: 'normal', type: 'orbital_ring' },
+      { key: 'sf-orbit-solar', name: 'ソーラー壁板', level: +2, size: 0, depth: +1, chest: 'less', type: 'orbital_ring' },
+      { key: 'sf-orbit-lab', name: '零G実験床', level: +3, size: 0, depth: +1, chest: 'less', type: 'orbital_lab' },
+      { key: 'sf-orbit-armory', name: '反応装甲床', level: +3, size: +1, depth: +1, chest: 'less', type: 'orbital_armory' },
+      { key: 'sf-quantum-column', name: '量子束柱', level: +4, size: 0, depth: +2, chest: 'less', type: 'quantum_reactor' },
+      { key: 'sf-quantum-phasewall', name: '位相壁', level: +3, size: 0, depth: +2, chest: 'less', type: 'quantum_reactor' },
+      { key: 'sf-quantum-archive', name: '時間結晶棚', level: +2, size: 0, depth: +1, chest: 'normal', type: 'quantum_archive' },
+      { key: 'sf-quantum-anchor', name: '次元アンカー', level: +4, size: +1, depth: +2, chest: 'less', type: 'quantum_void' },
+      { key: 'sf-cyber-cache', name: 'データキャッシュ床', level: +2, size: +1, depth: +1, chest: 'more', type: 'cyber_vault' },
+      { key: 'sf-cyber-wave', name: '波形パネル壁', level: +3, size: 0, depth: +1, chest: 'less', type: 'cyber_stream' },
+      { key: 'sf-future-transit', name: 'リニアトランジット床', level: +3, size: +1, depth: +1, chest: 'normal', type: 'future_core' },
+      { key: 'sf-future-aero', name: 'エアロバリア壁', level: +2, size: 0, depth: +1, chest: 'less', type: 'future_sky' },
+      { key: 'sf-greenhouse-canopy', name: '温室キャノピー床', level: +2, size: +1, depth: +1, chest: 'more', type: 'orbital_greenhouse' },
+      { key: 'sf-command-console', name: '指令コンソール壁', level: +3, size: 0, depth: +1, chest: 'less', type: 'orbital_command' },
+      { key: 'sf-quantum-prism', name: 'プリズム導光床', level: +3, size: 0, depth: +2, chest: 'normal', type: 'quantum_prism' },
+      { key: 'sf-chrono-platform', name: '時間駅プラットフォーム', level: +2, size: +1, depth: +1, chest: 'normal', type: 'chrono_station' },
+      { key: 'sf-loop-gate', name: 'ループゲート壁', level: +3, size: 0, depth: +2, chest: 'less', type: 'chrono_loop' },
+      { key: 'sf-xeno-crystal-spire', name: '結晶尖塔床', level: +2, size: +1, depth: +1, chest: 'normal', type: 'xeno_crystal' },
+      { key: 'sf-xeno-ruins-pillar', name: '遺跡支柱壁', level: +3, size: 0, depth: +1, chest: 'less', type: 'xeno_ruins' },
+      { key: 'sf-colony-foundry-crane', name: '鋳造クレーン床', level: +3, size: +1, depth: +1, chest: 'normal', type: 'colony_foundry' },
+      { key: 'sf-laser-grid', name: 'レーザーグリッド罠', level: +3, size: 0, depth: +1, chest: 'less', type: 'future_core', weight: 0.6, meta: { hazard: 'laser-grid', period: 3 } },
+      { key: 'sf-gravity-inverter', name: '重力反転装置', level: +4, size: 0, depth: +1, chest: 'less', type: 'orbital_ring', weight: 0.5, meta: { hazard: 'gravity-inverter' } },
+      { key: 'sf-data-spike', name: 'データスパイク', level: +3, size: 0, depth: +1, chest: 'less', type: 'cyber_vault', weight: 0.5, meta: { hazard: 'data-spike' } },
+      { key: 'sf-quantum-rift', name: '量子リフト裂け目', level: +4, size: 0, depth: +2, chest: 'less', type: 'quantum_void', weight: 0.4, meta: { hazard: 'quantum-rift' } },
+      { key: 'sf-temporal-loop', name: '時間ループ罠', level: +3, size: 0, depth: +1, chest: 'less', type: 'chrono_loop', weight: 0.6, meta: { hazard: 'temporal-loop' } },
+      { key: 'sf-crystal-resonator', name: '結晶レゾネーター', level: +3, size: 0, depth: +1, chest: 'less', type: 'xeno_crystal', weight: 0.6, meta: { hazard: 'crystal-resonator' } },
+      { key: 'sf-bio-spore', name: '胞子散布床', level: +2, size: 0, depth: +1, chest: 'less', type: 'xeno_jungle', weight: 0.6, meta: { hazard: 'bio-spore' } },
+      { key: 'sf-nanite-surge', name: 'ナナイトサージ', level: +3, size: 0, depth: +1, chest: 'less', type: 'colony_foundry', weight: 0.5, meta: { hazard: 'nanite-surge' } },
+      { key: 'sf-warp-conduit', name: 'ワープ導管柱', level: +3, size: 0, depth: +1, chest: 'less', type: 'spaceship_warp', weight: 0.8 },
+      { key: 'sf-observatory-array', name: '観測アレイ床', level: +2, size: +1, depth: +1, chest: 'normal', type: 'spaceship_observatory' },
+      { key: 'sf-arena-barrier', name: 'アリーナ障壁', level: +3, size: 0, depth: +1, chest: 'less', type: 'cyber_arena', meta: { hazard: 'holo-wall', cycle: 4 } },
+      { key: 'sf-mirror-spire', name: 'ミラースパイア', level: +2, size: 0, depth: +1, chest: 'less', type: 'cyber_mirror' },
+      { key: 'sf-metro-switch', name: 'メトロ分岐床', level: +3, size: +1, depth: +1, chest: 'normal', type: 'future_metro' },
+      { key: 'sf-cloud-anchor', name: '浮遊アンカー', level: +2, size: 0, depth: +1, chest: 'less', type: 'future_cloudport', meta: { hazard: 'wind-gust' } },
+      { key: 'sf-scrap-gantry', name: 'スクラップガントリー', level: +2, size: +1, depth: +1, chest: 'normal', type: 'orbital_scrapyard' },
+      { key: 'sf-listening-dish', name: '傍受ディッシュ', level: +3, size: 0, depth: +1, chest: 'less', type: 'orbital_listening', meta: { hazard: 'signal-pulse' } },
+      { key: 'sf-flux-ribbon', name: 'フラックスリボン床', level: +3, size: 0, depth: +2, chest: 'normal', type: 'quantum_flux' },
+      { key: 'sf-chrono-weave', name: 'クロノ織路', level: +2, size: +1, depth: +1, chest: 'normal', type: 'chrono_archive' },
+      { key: 'sf-fracture-gate', name: '断層ゲート', level: +3, size: 0, depth: +2, chest: 'less', type: 'chrono_fracture', meta: { hazard: 'time-rift' } },
+      { key: 'sf-hive-resonator', name: 'ハイブレゾネーター', level: +2, size: 0, depth: +1, chest: 'less', type: 'xeno_hive', meta: { hazard: 'bio-resonance' } },
+      { key: 'sf-reef-bloom', name: 'リーフブルーム', level: +2, size: +1, depth: +1, chest: 'normal', type: 'xeno_reef' },
+      { key: 'sf-vault-lockdown', name: 'ロックダウン装置', level: +3, size: 0, depth: +1, chest: 'less', type: 'colony_vault', meta: { hazard: 'lockdown' } },
+      { key: 'sf-arcology-bridge', name: 'アーコロジーブリッジ', level: +3, size: +1, depth: +1, chest: 'normal', type: 'colony_arcology' }
+    ];
+    const blocks3 = [
+      { key: 'sf-reactor-heart', name: '炉心安定床', level: +5, size: +2, depth: +2, chest: 'normal', type: 'spaceship_core', bossFloors: [10, 20] },
+      { key: 'sf-ai-overmind', name: 'オーバーマインド核', level: +6, size: +1, depth: +2, chest: 'less', type: 'spaceship_ai', bossFloors: [15] },
+      { key: 'sf-glitch-singularity', name: 'グリッチ特異点', level: +6, size: +1, depth: +3, chest: 'less', type: 'cyber_glitch', bossFloors: [12, 18] },
+      { key: 'sf-vault-guardian', name: 'ICEガーディアン床', level: +5, size: +2, depth: +3, chest: 'less', type: 'cyber_vault', bossFloors: [20] },
+      { key: 'sf-sky-zenith', name: 'ゼニス浮遊床', level: +4, size: +2, depth: +2, chest: 'more', type: 'future_sky', bossFloors: [9, 18] },
+      { key: 'sf-industrial-forge', name: '星鋳炉床', level: +5, size: +2, depth: +2, chest: 'normal', type: 'future_industrial', bossFloors: [14] },
+      { key: 'sf-orbit-guardian', name: '軌道防衛壁', level: +5, size: +1, depth: +2, chest: 'less', type: 'orbital_armory', bossFloors: [16] },
+      { key: 'sf-orbit-null', name: '無重力制御床', level: +5, size: +1, depth: +2, chest: 'normal', type: 'orbital_lab', bossFloors: [12] },
+      { key: 'sf-quantum-core', name: '量子核床', level: +6, size: +2, depth: +3, chest: 'less', type: 'quantum_reactor', bossFloors: [20] },
+      { key: 'sf-quantum-horizon', name: '地平遮蔽壁', level: +6, size: +1, depth: +3, chest: 'less', type: 'quantum_void', bossFloors: [18] },
+      { key: 'sf-cyber-cascade', name: '情報カスケード床', level: +5, size: +1, depth: +2, chest: 'normal', type: 'cyber_stream', bossFloors: [10, 15] },
+      { key: 'sf-plaza-crown', name: '王冠ホロ床', level: +4, size: +2, depth: +2, chest: 'more', type: 'future_plaza', bossFloors: [12] },
+      { key: 'sf-medbay-overseer', name: 'メディカル監督核', level: +5, size: +1, depth: +2, chest: 'less', type: 'spaceship_medbay', bossFloors: [8, 14] },
+      { key: 'sf-engineering-core', name: 'エンジン制御心核', level: +5, size: +2, depth: +3, chest: 'normal', type: 'spaceship_engineering', bossFloors: [16] },
+      { key: 'sf-forum-oracle', name: 'フォーラムオラクル床', level: +6, size: +1, depth: +3, chest: 'less', type: 'cyber_forum', bossFloors: [15] },
+      { key: 'sf-subroutine-kernel', name: 'サブルーチン核壁', level: +5, size: +1, depth: +2, chest: 'less', type: 'cyber_subroutine', bossFloors: [11, 17] },
+      { key: 'sf-chrono-paradox', name: 'パラドックス交差床', level: +6, size: +2, depth: +3, chest: 'normal', type: 'chrono_loop', bossFloors: [13, 19] },
+      { key: 'sf-xeno-elder', name: '異星守護床', level: +5, size: +2, depth: +3, chest: 'less', type: 'xeno_ruins', bossFloors: [18] },
+      { key: 'sf-xeno-maelstrom', name: '潮汐メイルストロム床', level: +5, size: +2, depth: +3, chest: 'normal', type: 'xeno_tide', bossFloors: [10, 20] },
+      { key: 'sf-colony-reactor-heart', name: 'コロニー炉心核', level: +6, size: +2, depth: +3, chest: 'less', type: 'colony_reactor', bossFloors: [20] },
+      { key: 'sf-warp-singularity', name: 'ワープ特異核', level: +6, size: +2, depth: +3, chest: 'less', type: 'spaceship_warp', bossFloors: [18] },
+      { key: 'sf-observatory-core', name: '観測中枢核', level: +5, size: +1, depth: +2, chest: 'normal', type: 'spaceship_observatory', bossFloors: [14] },
+      { key: 'sf-arena-champion', name: 'アリーナチャンピオン床', level: +5, size: +2, depth: +3, chest: 'more', type: 'cyber_arena', bossFloors: [16] },
+      { key: 'sf-mirror-overseer', name: 'ミラーオーバーシア壁', level: +5, size: +1, depth: +2, chest: 'less', type: 'cyber_mirror', bossFloors: [13] },
+      { key: 'sf-metro-command', name: 'メトロ司令床', level: +5, size: +2, depth: +2, chest: 'normal', type: 'future_metro', bossFloors: [15, 22] },
+      { key: 'sf-cloud-throne', name: 'クラウドスローン床', level: +5, size: +2, depth: +2, chest: 'more', type: 'future_cloudport', bossFloors: [12, 19] },
+      { key: 'sf-scrap-overseer', name: 'スクラップ監督核', level: +5, size: +1, depth: +2, chest: 'less', type: 'orbital_scrapyard', bossFloors: [17] },
+      { key: 'sf-listening-core', name: 'リスニング中枢', level: +5, size: +1, depth: +2, chest: 'less', type: 'orbital_listening', bossFloors: [11, 18] },
+      { key: 'sf-flux-heart', name: 'フラックス心核', level: +6, size: +2, depth: +3, chest: 'less', type: 'quantum_flux', bossFloors: [21] },
+      { key: 'sf-chrono-vault', name: 'クロノヴォールト床', level: +5, size: +1, depth: +2, chest: 'normal', type: 'chrono_archive', bossFloors: [13, 20] },
+      { key: 'sf-fracture-core', name: '断層中核', level: +6, size: +1, depth: +3, chest: 'less', type: 'chrono_fracture', bossFloors: [19] },
+      { key: 'sf-hive-queen', name: 'ハイブクイーン床', level: +5, size: +2, depth: +3, chest: 'more', type: 'xeno_hive', bossFloors: [18, 24] },
+      { key: 'sf-reef-titan', name: 'リーフタイタン床', level: +5, size: +2, depth: +2, chest: 'normal', type: 'xeno_reef', bossFloors: [16] },
+      { key: 'sf-vault-command', name: '備蓄指令核', level: +6, size: +1, depth: +2, chest: 'less', type: 'colony_vault', bossFloors: [19] },
+      { key: 'sf-arcology-nexus', name: 'アーコロジーネクサス', level: +6, size: +2, depth: +3, chest: 'normal', type: 'colony_arcology', bossFloors: [22] }
+    ];
+
+    return { dimensions, blocks1, blocks2, blocks3 };
+  }
+  const addon = {
+    id: ADDON_ID,
+    name: ADDON_NAME,
+    version: VERSION,
+    api: '1.0.0',
+    description: '宇宙船・サイバー空間・未来都市・軌道施設・量子/時間研究・異星生態・メガコロニーを網羅し、50タイプと5次元拡張を収録した大規模SFダンジョン生成パック。',
+    blocks: createBlocks(),
+    structures: createStructures(),
+    generators: createGenerators()
+  };
+
+  window.registerDungeonAddon(addon);
+})();


### PR DESCRIPTION
## Summary
- add sector/weave/cluster generator algorithms and expand the SF catalog to 50 dungeon types with additional structures
- extend BlockDim content with new dimensions, 110 blocks, and refreshed hazard metadata while bumping the addon description
- update the SF expansion design document to reflect the larger catalogue, block tables, and algorithm guidance

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d91b6e3174832baa5e55a64526e5f9