### PR TITLE
Enable sandbox interactive domain crystal placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -465,6 +465,7 @@
                                             <button type="button" class="sandbox-brush" data-brush="start" aria-pressed="false">開始位置</button>
                                             <button type="button" class="sandbox-brush" data-brush="stairs" aria-pressed="false">階段</button>
                                             <button type="button" class="sandbox-brush" data-brush="enemy" aria-pressed="false">敵配置</button>
+                                            <button type="button" class="sandbox-brush" data-brush="domain" aria-pressed="false">領域</button>
                                         </div>
                                         <p id="sandbox-selected-cell" class="sandbox-selected-cell" aria-live="polite">セルをクリックして編集します。</p>
                                         <div class="sandbox-brush-options" aria-labelledby="sandbox-brush-options-title">
@@ -539,6 +540,14 @@
                                         </div>
                                         <div id="sandbox-enemy-list" class="sandbox-enemy-list" aria-live="polite"></div>
                                         <p class="sandbox-note">敵を選択し「敵配置」ブラシでマップ上の位置を更新できます。</p>
+                                    </section>
+                                    <section class="sandbox-section" aria-labelledby="sandbox-domain-title">
+                                        <div class="sandbox-section-header">
+                                            <h4 id="sandbox-domain-title">領域効果クリスタル</h4>
+                                            <button type="button" id="sandbox-add-domain">+ クリスタルを追加</button>
+                                        </div>
+                                        <div id="sandbox-domain-list" class="sandbox-domain-list" aria-live="polite"></div>
+                                        <p class="sandbox-note">クリスタルを選択し「領域」ブラシでマップ上の位置と効果範囲を設定します。</p>
                                     </section>
                                 </div>
                                 <div class="sandbox-map-wrapper">
@@ -885,6 +894,7 @@
                         <option value="stairs">階段を設置</option>
                         <option value="start">開始位置を移動</option>
                         <option value="erase">床に戻す</option>
+                        <option value="domain">領域クリスタルを配置</option>
                     </select>
                 </label>
                 <label>床タイプ
@@ -906,6 +916,11 @@
                         <option value="right">→ 右</option>
                         <option value="down">↓ 下</option>
                         <option value="left">← 左</option>
+                    </select>
+                </label>
+                <label>領域クリスタル
+                    <select id="sandbox-tool-domain">
+                        <option value="">配置可能なクリスタルなし</option>
                     </select>
                 </label>
                 <div class="sandbox-interactive-actions">
@@ -1001,9 +1016,10 @@
                         <div class="bar-label">SP <span id="stat-sp-text">0/0</span></div>
                         <div class="bar-track"><div id="sp-bar" class="bar-fill"></div></div>
                     </div>
-                    <div class="status-badges" id="stat-status-effects" aria-live="polite"></div>
-                </div>
+                <div class="status-badges" id="stat-status-effects" aria-live="polite"></div>
+                <div class="status-badges status-badges--domain" id="stat-domain-effects" aria-live="polite"></div>
             </div>
+        </div>
             <div id="message-log"></div>
         </div>
         <!-- 右側ポップアップ用の常時空白スペース -->
@@ -1038,12 +1054,13 @@
             <div class="item-row">
                 <span>HP30%回復ポーション</span>
                 <span>x <span id="inv-potion30">0</span></span>
-                <div class="item-actions">
-                    <button id="use-potion30">使用</button>
-                    <button id="eat-potion30" style="display:none;">食べる</button>
-                    <button id="offer-potion30" style="display:none;">捧げる</button>
+                    <div class="item-actions">
+                        <button id="use-potion30">使用</button>
+                        <button id="eat-potion30" style="display:none;">食べる</button>
+                        <button id="offer-potion30" style="display:none;">捧げる</button>
+                        <button id="throw-potion30" style="display:none;">投げつける</button>
+                    </div>
                 </div>
-            </div>
             <div class="item-row">
                 <span>最大HP強化アイテム</span>
                 <span>x <span id="inv-hp-boost">0</span></span>

--- a/style.css
+++ b/style.css
@@ -1367,6 +1367,17 @@ body.in-game #player-summary { display: none; }
     min-height: 20px;
 }
 
+.status-badges--domain {
+    gap: 4px;
+    margin-top: 6px;
+}
+
+.status-badges--domain .status-badge {
+    background: rgba(99, 102, 241, 0.18);
+    border-color: rgba(99, 102, 241, 0.35);
+    color: #e0e7ff;
+}
+
 .status-badge {
     font-size: 12px;
     font-weight: 600;
@@ -2657,6 +2668,98 @@ h1 {
     flex-direction: column;
     gap: 4px;
     color: #475569;
+}
+
+.sandbox-domain-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    max-height: 320px;
+    overflow: auto;
+}
+
+.sandbox-domain-card {
+    border: 1px solid rgba(129, 140, 248, 0.4);
+    border-radius: 10px;
+    padding: 10px;
+    background: #f8fafc;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.sandbox-domain-card.selected {
+    border-color: #4f46e5;
+    box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
+}
+
+.sandbox-domain-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.sandbox-domain-header h5 {
+    margin: 0;
+    font-size: 15px;
+    color: #312e81;
+}
+
+.sandbox-domain-actions {
+    display: flex;
+    gap: 8px;
+}
+
+.sandbox-domain-actions button {
+    appearance: none;
+    border: none;
+    border-radius: 6px;
+    padding: 6px 10px;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.sandbox-domain-actions button.select {
+    background: rgba(79, 70, 229, 0.12);
+    color: #4338ca;
+}
+
+.sandbox-domain-actions button.select:hover {
+    background: rgba(79, 70, 229, 0.22);
+}
+
+.sandbox-domain-actions button.delete {
+    background: rgba(248, 113, 113, 0.2);
+    color: #b91c1c;
+}
+
+.sandbox-domain-actions button.delete:hover {
+    background: rgba(248, 113, 113, 0.35);
+}
+
+.sandbox-domain-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+    gap: 8px;
+}
+
+.sandbox-domain-grid label {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 12px;
+    color: #1f2937;
+}
+
+.sandbox-domain-grid input,
+.sandbox-domain-grid select {
+    padding: 4px 6px;
+    border-radius: 6px;
+    border: 1px solid rgba(148, 163, 184, 0.6);
+    font-size: 12px;
 }
 
 .sandbox-enemy-grid input,


### PR DESCRIPTION
## Summary
- add a sandbox interactive tool option and dropdown to pick domain crystals while editing
- populate the domain crystal list in interactive mode and wire the tool to place or move crystals, updating runtime state and UI
- keep sandbox-generated domain crystals linked to their configuration entries for interactive updates

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dbf292c4e4832bac42411e438bb31d