### PR TITLE
Ensure achievements tab initializes when activated

### DIFF
--- a/main.js
+++ b/main.js
@@ -4299,6 +4299,12 @@ function setupTabs() {
             btn.setAttribute('aria-selected', on ? 'true' : 'false');
             panel.style.display = on ? '' : 'none';
         }
+        if (which === 'achievements') {
+            initAchievementUiOnce();
+            try {
+                window.AchievementSystem?.refresh?.();
+            } catch {}
+        }
     }
     tabBtnNormal.addEventListener('click', () => {
         activateTab('normal');
@@ -4337,8 +4343,6 @@ function setupTabs() {
     if (tabBtnAchievements) {
         tabBtnAchievements.addEventListener('click', () => {
             activateTab('achievements');
-            initAchievementUiOnce();
-            try { window.AchievementSystem?.refresh?.(); } catch {}
         });
     }
     // Lists are click/keyboard driven（render側でバインド済み）


### PR DESCRIPTION
## Summary
- initialize the achievements/statistics UI every time the achievements tab becomes active
- keep the tab button handler simple now that activation performs initialization and refresh

## Testing
- Manually opened the achievements tab in the browser to confirm the lists render

------
https://chatgpt.com/codex/tasks/task_e_68dc85e55c20832b9fbf59df352c81df