### PR TITLE
Fix achievements tab hidden by sandbox panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -929,6 +929,8 @@
                 <p class="sandbox-note small">現在向いている方向の1マス先を編集します。</p>
             </section>
         </div>
+    </div>
+
             <div id="tab-achievements" class="tab-content" style="display:none;" role="tabpanel" aria-labelledby="tab-button-achievements">
                 <div class="row">
                     <div class="achievement-layout">
@@ -941,6 +943,9 @@
                                 <h3>実績</h3>
                                 <p>冒険やツールの利用状況に応じて自動的に更新されます。カテゴリごとの進捗を確認しましょう。</p>
                             </header>
+                            <div id="achievements-fallback" class="achievements-fallback achievements-fallback--info" role="status" aria-live="polite">
+                                実績システムを読み込み中です… この表示が続く場合は再読み込みしてください。
+                            </div>
                             <div id="achievement-category-summary" class="achievement-category-summary" aria-live="polite"></div>
                             <div id="achievement-list" class="achievement-list" aria-live="polite"></div>
                             <section class="custom-achievement-section" aria-labelledby="custom-achievement-title">

--- a/style.css
+++ b/style.css
@@ -209,6 +209,26 @@ body.in-game #game-container {
     color: #2c3e50;
 }
 
+.achievements-fallback {
+    padding: 16px;
+    border-radius: 12px;
+    border: 1px dashed rgba(102,126,234,0.35);
+    background: rgba(102,126,234,0.12);
+    color: #2c3e50;
+    font-weight: 600;
+    text-align: center;
+}
+
+.achievements-fallback--error {
+    border-color: rgba(220, 53, 69, 0.45);
+    background: rgba(220, 53, 69, 0.12);
+    color: #8a1c2b;
+}
+
+.achievements-fallback--info {
+    border-color: rgba(102,126,234,0.35);
+}
+
 .achievement-card-grid {
     display: grid;
     gap: 12px;


### PR DESCRIPTION
## Summary
- close the sandbox interactive panel container before the achievements tab markup so the achievements/statistics UI is no longer wrapped in a hidden dialog

## Testing
- `browser_container.run_playwright_script`


------
https://chatgpt.com/codex/tasks/task_e_68dc85e55c20832b9fbf59df352c81df