### PR TITLE
feat: unlock Anos godhood sandbox console

### DIFF
--- a/index.html
+++ b/index.html
@@ -892,6 +892,7 @@
         <button id="btn-import">インポート</button>
         <button id="btn-export">エクスポート</button>
         <button id="btn-sandbox-menu" class="sandbox-menu-button" type="button" aria-expanded="false" aria-controls="sandbox-interactive-panel" style="display:none;">インタラクティブ</button>
+        <button id="btn-god-console" class="god-console-button" type="button" aria-expanded="false" aria-controls="god-console-panel" style="display:none;">創造神コンソール</button>
         <input type="file" id="import-file" accept="application/json" style="display:none" />
         <div id="floor-indicator">1F</div>
     </div>
@@ -991,6 +992,27 @@
                 </div>
                 <p class="sandbox-note small">現在向いている方向の1マス先を編集します。</p>
             </section>
+        </div>
+    </div>
+
+    <div id="god-console-panel" class="god-console-panel" role="dialog" aria-modal="false" aria-hidden="true" tabindex="-1">
+        <div class="god-console-header">
+            <h3>創造神コンソール</h3>
+            <button id="god-console-close" type="button" aria-label="閉じる">×</button>
+        </div>
+        <div class="god-console-body">
+            <p class="god-console-hint">NESTED 99999999 を攻略した創造神だけがアクセスできます。提供される <code>context</code> を使ってゲームの状態やコードを書き換えましょう。</p>
+            <div class="god-console-mode">
+                <button id="god-console-toggle-sandbox" type="button">サンドボックスモードに入る</button>
+                <span id="god-console-mode-label">現在: 探索モード</span>
+            </div>
+            <label class="god-console-label" for="god-console-input">スクリプト</label>
+            <textarea id="god-console-input" spellcheck="false" placeholder="// context.player.attack = 99999;\n// context.utils.updateUI();"></textarea>
+            <div class="god-console-actions">
+                <button id="god-console-run" type="button">コードを適用</button>
+                <button id="god-console-clear" type="button">入力をリセット</button>
+            </div>
+            <div id="god-console-status" class="god-console-status" role="status" aria-live="polite"></div>
         </div>
     </div>
 

--- a/style.css
+++ b/style.css
@@ -1133,6 +1133,15 @@ body.in-game #player-summary { display: none; }
     box-shadow: 0 4px 14px rgba(56,189,248,0.4);
 }
 
+.god-console-button {
+    background: linear-gradient(135deg, #f97316, #facc15);
+}
+
+.god-console-button[aria-expanded="true"] {
+    background: linear-gradient(135deg, #fb923c, #fde047);
+    box-shadow: 0 4px 14px rgba(251,191,36,0.45);
+}
+
 .sandbox-interactive-panel {
     position: fixed;
     top: calc(var(--toolbar-height, 72px) + 16px);
@@ -1153,6 +1162,186 @@ body.in-game #player-summary { display: none; }
 
 .sandbox-interactive-panel[aria-hidden="false"] {
     display: flex;
+}
+
+.god-console-panel {
+    position: fixed;
+    right: 24px;
+    bottom: 24px;
+    width: min(420px, 92vw);
+    max-height: calc(100vh - 160px);
+    display: none;
+    flex-direction: column;
+    gap: 0;
+    background: rgba(17, 24, 39, 0.94);
+    color: #f8fafc;
+    border-radius: 18px;
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.5);
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    z-index: 170;
+    backdrop-filter: blur(14px);
+}
+
+.god-console-panel[aria-hidden="false"] {
+    display: flex;
+}
+
+.god-console-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 18px;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.28);
+}
+
+.god-console-header h3 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 700;
+}
+
+#god-console-close {
+    background: transparent;
+    border: none;
+    color: #f8fafc;
+    font-size: 20px;
+    cursor: pointer;
+    transition: transform 0.2s ease;
+}
+
+#god-console-close:hover {
+    transform: scale(1.1);
+}
+
+.god-console-body {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 18px 20px 20px;
+    overflow-y: auto;
+}
+
+.god-console-hint {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.6;
+    background: rgba(30, 41, 59, 0.7);
+    padding: 10px 12px;
+    border-radius: 10px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.god-console-mode {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+#god-console-toggle-sandbox {
+    padding: 8px 14px;
+    border-radius: 8px;
+    border: none;
+    cursor: pointer;
+    font-weight: 600;
+    background: linear-gradient(135deg, #22d3ee, #3b82f6);
+    color: #0f172a;
+    transition: all 0.2s ease;
+}
+
+#god-console-toggle-sandbox:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(56,189,248,0.35);
+}
+
+#god-console-mode-label {
+    font-size: 13px;
+    font-weight: 600;
+    color: rgba(241, 245, 249, 0.9);
+}
+
+.god-console-label {
+    font-weight: 600;
+    font-size: 14px;
+}
+
+#god-console-input {
+    min-height: 160px;
+    width: 100%;
+    resize: vertical;
+    border-radius: 12px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    background: rgba(15, 23, 42, 0.85);
+    color: #e2e8f0;
+    font-family: 'Fira Code', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+    padding: 12px;
+    line-height: 1.5;
+    font-size: 13px;
+}
+
+#god-console-input:focus {
+    outline: none;
+    border-color: rgba(129, 140, 248, 0.8);
+    box-shadow: 0 0 0 2px rgba(129, 140, 248, 0.25);
+}
+
+.god-console-actions {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.god-console-actions button {
+    padding: 10px 18px;
+    border-radius: 10px;
+    border: none;
+    cursor: pointer;
+    font-weight: 700;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    background: linear-gradient(135deg, #6366f1, #8b5cf6);
+    color: #f8fafc;
+}
+
+.god-console-actions button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(99,102,241,0.35);
+}
+
+.god-console-actions button:nth-child(2) {
+    background: linear-gradient(135deg, #64748b, #475569);
+}
+
+.god-console-status {
+    min-height: 20px;
+    font-size: 13px;
+    padding: 10px 12px;
+    border-radius: 10px;
+    background: rgba(30, 41, 59, 0.65);
+    border: 1px solid rgba(148, 163, 184, 0.22);
+}
+
+.god-console-status[data-tone="success"] {
+    border-color: rgba(74, 222, 128, 0.55);
+    background: rgba(22, 163, 74, 0.25);
+    color: #bbf7d0;
+}
+
+.god-console-status[data-tone="error"] {
+    border-color: rgba(248, 113, 113, 0.6);
+    background: rgba(248, 113, 113, 0.25);
+    color: #fecaca;
+}
+
+.god-console-status[data-tone="warning"] {
+    border-color: rgba(251, 191, 36, 0.6);
+    background: rgba(251, 191, 36, 0.22);
+    color: #fef3c7;
+}
+
+.god-console-status[data-tone="info"] {
+    border-color: rgba(129, 140, 248, 0.45);
+    background: rgba(99, 102, 241, 0.25);
+    color: #e0e7ff;
 }
 
 .sandbox-interactive-header {


### PR DESCRIPTION
## Summary
- track an Anos godhood flag unlocked by clearing a NESTED 99999999 BlockDim dungeon and persist it in saves
- add the creation-god console UI with a script runner and sandbox mode toggle once godhood is awakened
- relax sandbox privilege checks for gods so they can freely switch between exploration and sandbox editing in any dungeon

## Testing
- manual via local http server

------
https://chatgpt.com/codex/tasks/task_e_68dcac0b252c832b8dcb211fdc078d85