### PR TITLE
Add Multicolor Plains Pack to manifest

### DIFF
--- a/dungeontypes/manifest.json.js
+++ b/dungeontypes/manifest.json.js
@@ -40,5 +40,6 @@ window.DUNGEONTYPE_MANIFEST = [
   { id: 'abyssal_whorl_pack', name: 'Abyssal Whorl Pack', entry: 'dungeontypes/abyssal_whorl.js', version: '1.0.0', author: 'builtin-sample' },
   { id: 'ruined_labyrinth_pack', name: 'Ruined Labyrinth Pack', entry: 'dungeontypes/ruined_labyrinth.js', version: '1.0.0', author: 'builtin-sample' },
   { id: 'ancient_enigma_pack', name: 'Ancient Enigma Excavation Pack', entry: 'dungeontypes/ancient_enigma.js', version: '1.1.0', author: 'builtin-sample' },
-  { id: 'sf_expansion_pack', name: 'SF Expansion Pack', entry: 'dungeontypes/sf_expansion.js', version: '1.0.0', author: 'builtin-sample' }
+  { id: 'sf_expansion_pack', name: 'SF Expansion Pack', entry: 'dungeontypes/sf_expansion.js', version: '1.0.0', author: 'builtin-sample' },
+  { id: 'multicolor_plains_pack', name: 'Multicolor Plains Pack', entry: 'dungeontypes/plains_variations_pack.js', version: '1.0.0', author: 'builtin-sample' }
 ];


### PR DESCRIPTION
## Summary
- add the missing Multicolor Plains Pack entry to the dungeon addon manifest

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd1d9e6fb8832b8c7948eab2e1fd5e