### PR TITLE
Add visual fallbacks for addon ambience and textures

### DIFF
--- a/dungeontypes/coral_garden.js
+++ b/dungeontypes/coral_garden.js
@@ -3,6 +3,27 @@
   function algorithm(ctx){
     const { width: W, height: H, map } = ctx;
 
+    const supportsTexture = typeof ctx.setFloorTexture === 'function';
+    const isFloor = (x,y) => map[y] && map[y][x] === 0;
+    const paintFloor = (x,y,color) => { if(isFloor(x,y)) ctx.setFloorColor(x,y,color); };
+
+    const applyTexture = (x,y,variant) => {
+      if(supportsTexture){
+        ctx.setFloorTexture(x,y,variant);
+        return;
+      }
+      const palette = variant === 'sea_anemone'
+        ? ['#ff8fb1', '#ffb3c6', '#ff7096', '#f85f73']
+        : ['#8bd6ff', '#6ac4ff', '#5aa7ff', '#7fd5ff'];
+      paintFloor(x,y, palette[Math.floor(ctx.random()*palette.length)]);
+      if(ctx.random() < 0.4){
+        const swirl = palette[Math.floor(ctx.random()*palette.length)];
+        [[1,0],[-1,0],[0,1],[0,-1]].forEach(([dx,dy]) => {
+          if(ctx.random() < 0.5) paintFloor(x+dx, y+dy, swirl);
+        });
+      }
+    };
+
     for(let y=0;y<H;y++){
       for(let x=0;x<W;x++){
         const edge = x===0 || y===0 || x===W-1 || y===H-1;
@@ -38,7 +59,7 @@
           const green = Math.floor(120 + depthFactor*60);
           ctx.setFloorColor(x,y,`rgb(${80 + Math.floor(depthFactor*40)}, ${green}, ${blue})`);
           if(ctx.random() < 0.06){
-            ctx.setFloorTexture(x,y, ctx.random() < 0.5 ? 'coral_branch' : 'sea_anemone');
+            applyTexture(x,y, ctx.random() < 0.5 ? 'coral_branch' : 'sea_anemone');
           }
         } else {
           const coralHue = 200 + Math.floor(Math.sin(x/2 + y/3)*20);

--- a/dungeontypes/luminescent_glade.js
+++ b/dungeontypes/luminescent_glade.js
@@ -5,6 +5,27 @@
     const H = ctx.height;
     const map = ctx.map;
 
+    const supportsTexture = typeof ctx.setFloorTexture === 'function';
+    const isFloor = (x,y) => map[y] && map[y][x] === 0;
+    const paintFloor = (x,y,color) => { if(isFloor(x,y)) ctx.setFloorColor(x,y,color); };
+
+    const applyGlowPool = (x,y) => {
+      if(supportsTexture){
+        ctx.setFloorTexture(x,y,'glow_pool');
+        return;
+      }
+      const center = `rgba(${120 + Math.floor(ctx.random()*20)}, ${240 + Math.floor(ctx.random()*15)}, ${230 + Math.floor(ctx.random()*20)}, 0.95)`;
+      paintFloor(x,y, center);
+      const ring = [[1,0],[-1,0],[0,1],[0,-1],[1,1],[-1,-1],[1,-1],[-1,1]];
+      ring.forEach(([dx,dy]) => {
+        if(ctx.random() < 0.7){
+          const nx = x+dx, ny = y+dy;
+          const glow = `rgba(${90 + Math.floor(ctx.random()*30)}, ${210 + Math.floor(ctx.random()*25)}, ${200 + Math.floor(ctx.random()*30)}, 0.8)`;
+          paintFloor(nx, ny, glow);
+        }
+      });
+    };
+
     for(let y=0;y<H;y++){
       for(let x=0;x<W;x++){
         const edge = x===0 || y===0 || x===W-1 || y===H-1;
@@ -48,7 +69,7 @@
     for(let i=0;i<Math.floor((W*H)/60);i++){
       const rx = Math.floor(ctx.random()*W);
       const ry = Math.floor(ctx.random()*H);
-      ctx.setFloorTexture(rx, ry, 'glow_pool');
+      if(isFloor(rx, ry)) applyGlowPool(rx, ry);
     }
 
     ctx.ensureConnectivity();


### PR DESCRIPTION
## Summary
- paint amber marsh mist and leaf details manually when ambient or texture APIs are unavailable
- render coral garden decorations and luminescent glade pools with color palettes when textures cannot be set
- simulate starlit canopy fireflies on basic contexts while keeping native ambient effects when supported

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd2bc72150832bb26bfbfc6a06cc45