### PR TITLE
Fix dungeon addon regressions causing infinite loops and runtime errors

### DIFF
--- a/dungeontypes/churning_karst.js
+++ b/dungeontypes/churning_karst.js
@@ -1,5 +1,6 @@
 // Addon: Churning Karst - cascading subterranean rivers eroding limestone chambers
 (function(){
+
   function carveCircle(ctx, cx, cy, r, color){
     for(let y=cy-r; y<=cy+r; y++){
       for(let x=cx-r; x<=cx+r; x++){
@@ -13,7 +14,7 @@
   }
 
   function floodPath(ctx, start, flowLength, palette){
-    const { random, inBounds, set, setFloorColor, setFloorType } = ctx;
+    const { random, inBounds, set, setFloorColor } = ctx;
     let [x,y] = start;
     let dir = [0,1];
     for(let i=0;i<flowLength;i++){
@@ -22,7 +23,6 @@
       const mix = i/Math.max(1,flowLength-1);
       const color = palette[Math.min(palette.length-1, Math.floor(mix*(palette.length)))];
       setFloorColor(x,y,color);
-      setFloorType(x,y,'karst_stream');
       if(random()<0.35){
         const turn = random()<0.5 ? [dir[1], -dir[0]] : [-dir[1], dir[0]];
         dir = turn;
@@ -109,7 +109,6 @@
           carvePath(path,1);
           path.forEach(p => {
             setFloorColor(p.x,p.y,'#93c5fd');
-            setFloorType(p.x,p.y,'stream_channel');
           });
         } else {
           const steps = Math.max(Math.abs(a.x-b.x), Math.abs(a.y-b.y));
@@ -119,7 +118,6 @@
             if(inBounds(x,y)){
               set(x,y,0);
               setFloorColor(x,y,'#93c5fd');
-              setFloorType(x,y,'stream_channel');
             }
           }
         }
@@ -130,7 +128,6 @@
       const x = Math.floor(random()*W);
       const y = Math.floor(random()*H);
       if(inBounds(x,y)){
-        setFloorType(x,y,'karst_bubble');
         if(random()<0.5) setFloorColor(x,y,'#bae6fd');
       }
     }

--- a/dungeontypes/geometric_structures.js
+++ b/dungeontypes/geometric_structures.js
@@ -168,8 +168,16 @@
     const W=ctx.width,H=ctx.height; const cx=W>>1, cy=H>>1; const R=Math.min(W,H)/2-3|0; circle(ctx,cx,cy,R,1,true);
     const parts=4+Math.floor(ctx.random()*4);
     for(let i=0;i<parts;i++){
-      const a=ctx.random()*Math.PI*2; const x1=cx+Math.cos(a)*(R-2)|0, y1=cy+Math.sin(a)*(R-2)|0; const x2=cx-Math.cos(a)*(R-2)|0, y2=cy-Math.sin(a)*(R-2)|0; // wall chord
+      const angle = ctx.random()*Math.PI*2;
+      const startX = cx+Math.cos(angle)*(R-2)|0;
+      const startY = cy+Math.sin(angle)*(R-2)|0;
+      const endX = cx-Math.cos(angle)*(R-2)|0;
+      const endY = cy-Math.sin(angle)*(R-2)|0; // wall chord
       // draw wall (set 1) but punch doors later
+      let x1 = startX;
+      let y1 = startY;
+      const x2 = endX;
+      const y2 = endY;
       let dx=Math.abs(x2-x1),sx=x1<x2?1:-1; let dy=-Math.abs(y2-y1),sy=y1<y2?1:-1; let err=dx+dy, e2;
       for(;;){ if(inC(ctx,x1,y1)) setW(ctx,x1,y1); if(x1===x2&&y1===y2) break; e2=2*err; if(e2>=dy){err+=dy;x1+=sx;} if(e2<=dx){err+=dx;y1+=sy;} }
     }

--- a/dungeontypes/western_frontier.js
+++ b/dungeontypes/western_frontier.js
@@ -106,6 +106,14 @@
     }
   }
 
+  function ensureForwardProgress(current, desired, cap, exitValue){
+    const bounded = Math.min(desired, cap);
+    if(bounded <= current){
+      return exitValue;
+    }
+    return bounded;
+  }
+
   function tintLine(ctx, x0, y0, x1, y1, thickness = 1, color){
     if(!Number.isFinite(x0) || !Number.isFinite(y0) || !Number.isFinite(x1) || !Number.isFinite(y1)){
       return;
@@ -730,7 +738,7 @@
     let x = 2;
     let y = Math.floor(H * 0.32);
     while(x < W - 2){
-      const nx = Math.min(W - 3, x + 5);
+      const nx = ensureForwardProgress(x, x + 5, W - 3, W - 2);
       const ny = clamp(y + jitter(random, 0, 4) - 2, 2, H - 3);
       tintLine(ctx, x, y, nx, ny, 3, '#4f98a7');
       x = nx;
@@ -740,7 +748,7 @@
     x = 2;
     y = Math.floor(H * 0.62);
     while(x < W - 2){
-      const nx = Math.min(W - 3, x + 5);
+      const nx = ensureForwardProgress(x, x + 5, W - 3, W - 2);
       const ny = clamp(y + jitter(random, 0, 4) - 2, 2, H - 3);
       tintLine(ctx, x, y, nx, ny, 4, '#377b8d');
       x = nx;


### PR DESCRIPTION
## Summary
- prevent the Western Frontier pack from stalling river tinting loops by guaranteeing forward progress
- avoid reassigning constants in the geometric structures circular tower generator
- rely on palette-driven floor colours in the Churning Karst addon so generation only uses base APIs

## Testing
- node --check dungeontypes/western_frontier.js
- node --check dungeontypes/geometric_structures.js
- node --check dungeontypes/churning_karst.js

------
https://chatgpt.com/codex/tasks/task_e_68e08b2d2bdc832b931e4ff7c0660f35