### PR TITLE
Add dungeon overlay toggle and auto potion usage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1034,6 +1034,10 @@
         <button id="btn-status">ステータス</button>
         <button id="btn-import">インポート</button>
         <button id="btn-export">エクスポート</button>
+        <label for="toggle-dungeon-name" class="toolbar-toggle">
+            <input type="checkbox" id="toggle-dungeon-name" checked>
+            <span>ダンジョン名を表示する</span>
+        </label>
         <button id="btn-sandbox-menu" class="sandbox-menu-button" type="button" aria-expanded="false" aria-controls="sandbox-interactive-panel" style="display:none;">インタラクティブ</button>
         <button id="btn-god-console" class="god-console-button" type="button" aria-expanded="false" aria-controls="god-console-panel" style="display:none;">創造神コンソール</button>
         <input type="file" id="import-file" accept="application/json" style="display:none" />
@@ -1246,6 +1250,16 @@
                         <button id="throw-potion30" style="display:none;">投げつける</button>
                     </div>
                 </div>
+            <div class="item-row item-row--toggle">
+                <div class="item-row__info">
+                    <span>オートアイテム</span>
+                    <small>HPが30%以下になったとき自動で回復します</small>
+                </div>
+                <label class="item-row__toggle" for="auto-item-toggle">
+                    <input type="checkbox" id="auto-item-toggle">
+                    <span>有効にする</span>
+                </label>
+            </div>
             <div class="item-row">
                 <span>最大HP強化アイテム</span>
                 <span>x <span id="inv-hp-boost">0</span></span>

--- a/main.js
+++ b/main.js
@@ -22,9 +22,11 @@ const dungeonTypeOverlay = document.getElementById('dungeon-type-overlay');
 const dungeonTypeOverlayName = document.getElementById('dungeon-type-overlay-type');
 const dungeonTypeOverlayFeatures = document.getElementById('dungeon-type-overlay-features');
 const dungeonTypeOverlayDescription = document.getElementById('dungeon-type-overlay-description');
+const dungeonNameToggle = document.getElementById('toggle-dungeon-name');
 let dungeonOverlayHoverState = false;
 let dungeonOverlayPlayerZoneState = false;
 let dungeonOverlayLastPointer = null;
+let autoItemCheckScheduled = false;
 const MAX_LOG_LINES = 100;
 const SATIETY_MAX = 100;
 const SATIETY_TICK_PER_TURN = 1;
@@ -68,6 +70,19 @@ function refreshDungeonOverlayPlayerDimState() {
     setDungeonOverlayPlayerZoneState(inTopLeft);
 }
 
+function updateDungeonOverlayVisibility() {
+    if (!dungeonTypeOverlay) return;
+    const visible = !dungeonNameToggle || !!dungeonNameToggle.checked;
+    dungeonTypeOverlay.style.display = visible ? '' : 'none';
+    if (!visible) {
+        setDungeonOverlayHoverState(false);
+        setDungeonOverlayPlayerZoneState(false);
+    } else {
+        refreshDungeonOverlayPlayerDimState();
+        evaluateDungeonOverlayHoverFromPoint(dungeonOverlayLastPointer);
+    }
+}
+
 function evaluateDungeonOverlayHoverFromPoint(point) {
     if (!dungeonTypeOverlay || !point) {
         setDungeonOverlayHoverState(false);
@@ -83,6 +98,26 @@ function evaluateDungeonOverlayHoverFromPoint(point) {
     setDungeonOverlayHoverState(hovered);
 }
 
+function shouldAutoUsePotion(effectiveMaxHp, currentHp) {
+    if (!autoItemToggle || !autoItemToggle.checked) return false;
+    if (!player || !player.inventory || player.inventory.potion30 <= 0) return false;
+    if (!Number.isFinite(effectiveMaxHp) || effectiveMaxHp <= 0) return false;
+    if (!Number.isFinite(currentHp)) return false;
+    return currentHp <= effectiveMaxHp * 0.3;
+}
+
+function requestAutoItemCheck() {
+    if (!autoItemToggle || autoItemCheckScheduled) return;
+    autoItemCheckScheduled = true;
+    setTimeout(() => {
+        autoItemCheckScheduled = false;
+        const effectiveMaxHp = getEffectivePlayerMaxHp();
+        const rawHp = Number.isFinite(player?.hp) ? Math.max(0, player.hp) : effectiveMaxHp;
+        if (!shouldAutoUsePotion(effectiveMaxHp, rawHp)) return;
+        consumePotion30({ reason: 'auto' });
+    }, 0);
+}
+
 if (typeof window !== 'undefined') {
     window.addEventListener('mousemove', (event) => {
         dungeonOverlayLastPointer = { x: event.clientX, y: event.clientY };
@@ -94,6 +129,19 @@ if (typeof window !== 'undefined') {
     window.addEventListener('scroll', reassessOverlayHover, { passive: true });
     window.addEventListener('resize', reassessOverlayHover);
     applyDungeonOverlayDimState();
+}
+
+if (dungeonNameToggle) {
+    dungeonNameToggle.addEventListener('change', updateDungeonOverlayVisibility);
+    updateDungeonOverlayVisibility();
+}
+
+if (autoItemToggle) {
+    autoItemToggle.addEventListener('change', () => {
+        if (autoItemToggle.checked) {
+            requestAutoItemCheck();
+        }
+    });
 }
 
 function escapeHtml(value) {
@@ -122,6 +170,7 @@ const btnImport = document.getElementById('btn-import');
 const btnExport = document.getElementById('btn-export');
 const importFileInput = document.getElementById('import-file');
 const itemsModal = document.getElementById('items-modal');
+const autoItemToggle = document.getElementById('auto-item-toggle');
 const statusModal = document.getElementById('status-modal');
 const skillsModal = document.getElementById('skills-modal');
 const skillsList = document.getElementById('skills-list');
@@ -11552,6 +11601,9 @@ function updateUI() {
         : (Number.isFinite(rawHp) ? rawHp : effectiveMaxHp);
     const hpIsInfinite = !Number.isFinite(currentHp) || !Number.isFinite(effectiveMaxHp);
     const hpPct = hpIsInfinite ? 1 : Math.max(0, Math.min(1, currentHp / Math.max(effectiveMaxHp, 1)));
+    if (!hpIsInfinite && shouldAutoUsePotion(effectiveMaxHp, currentHp)) {
+        requestAutoItemCheck();
+    }
     const expPct = Math.max(0, Math.min(1, Number.isFinite(exp) ? exp / expMax : 1));
     const abilityDownActive = isPlayerStatusActive('abilityDown');
     updatePlayerSpCap({ silent: true });
@@ -13459,6 +13511,50 @@ restartButton.addEventListener('click', () => {
     saveAll();
 });
 
+function consumePotion30({ reason = 'manual' } = {}) {
+    if (!player || !player.inventory || player.inventory.potion30 <= 0) return false;
+    const effectiveMax = getEffectivePlayerMaxHp();
+    const baseHeal = Math.ceil(effectiveMax * 0.3);
+    const result = resolveDomainInteraction({
+        amount: baseHeal,
+        baseEffect: 'healing',
+        attackerType: 'player',
+        defenderType: 'player',
+        attackerPos: { x: player.x, y: player.y },
+        defenderPos: { x: player.x, y: player.y },
+        applyInvincibility: false
+    });
+    player.inventory.potion30 -= 1;
+    const isAuto = reason === 'auto';
+    if (result.effectType === 'damage' && result.amount > 0) {
+        const damage = result.amount;
+        player.hp = Math.max(0, player.hp - damage);
+        recordAchievementEvent('damage_taken', { amount: damage, source: 'reverse-potion' });
+        addMessage(isAuto ? `オートアイテムが暴発し、${damage}のダメージを受けた！` : `ポーションが反転し、${damage}のダメージを受けた！`);
+        addPopup(player.x, player.y, `-${Math.min(damage, 999999999)}${damage>999999999?'+':''}`, '#ff6b6b');
+        playSfx('damage');
+        if (player.hp <= 0) {
+            const deathMessage = isAuto ? 'オートアイテムの暴発で倒れてしまった…ゲームオーバー' : '反転した回復薬で倒れてしまった…ゲームオーバー';
+            handlePlayerDeath(deathMessage);
+        }
+    } else {
+        const beforeHp = player.hp;
+        player.hp = Math.min(effectiveMax, player.hp + result.amount);
+        enforceEffectiveHpCap();
+        const healed = Math.max(0, player.hp - beforeHp);
+        if (healed > 0) {
+            addMessage(isAuto ? `オートアイテムが発動！HPが${healed}回復` : `ポーションを使用！HPが${healed}回復`);
+            addPopup(player.x, player.y, `+${Math.min(healed, 999999999)}${healed>999999999?'+':''}`, '#4dabf7');
+        } else {
+            addMessage(isAuto ? 'オートアイテムが発動したが体調に変化はなかった。' : 'ポーションを使用したが体調に変化はなかった。');
+        }
+        playSfx('pickup');
+    }
+    updateUI();
+    saveAll();
+    return true;
+}
+
 // ゲームの開始
 // UI: モーダル/入出力
 btnItems && btnItems.addEventListener('click', () => { openModal(itemsModal); });
@@ -13499,44 +13595,7 @@ importFileInput && importFileInput.addEventListener('change', async (e) => {
     } catch {}
 });
 usePotion30Btn && usePotion30Btn.addEventListener('click', () => {
-    if (player.inventory.potion30 <= 0) return;
-    const effectiveMax = getEffectivePlayerMaxHp();
-    const baseHeal = Math.ceil(effectiveMax * 0.3);
-    const result = resolveDomainInteraction({
-        amount: baseHeal,
-        baseEffect: 'healing',
-        attackerType: 'player',
-        defenderType: 'player',
-        attackerPos: { x: player.x, y: player.y },
-        defenderPos: { x: player.x, y: player.y },
-        applyInvincibility: false
-    });
-    player.inventory.potion30 -= 1;
-    if (result.effectType === 'damage' && result.amount > 0) {
-        const damage = result.amount;
-        player.hp = Math.max(0, player.hp - damage);
-        recordAchievementEvent('damage_taken', { amount: damage, source: 'reverse-potion' });
-        addMessage(`ポーションが反転し、${damage}のダメージを受けた！`);
-        addPopup(player.x, player.y, `-${Math.min(damage, 999999999)}${damage>999999999?'+':''}`, '#ff6b6b');
-        playSfx('damage');
-        if (player.hp <= 0) {
-            handlePlayerDeath('反転した回復薬で倒れてしまった…ゲームオーバー');
-        }
-    } else {
-        const beforeHp = player.hp;
-        player.hp = Math.min(effectiveMax, player.hp + result.amount);
-        enforceEffectiveHpCap();
-        const healed = Math.max(0, player.hp - beforeHp);
-        if (healed > 0) {
-            addMessage(`ポーションを使用！HPが${healed}回復`);
-            addPopup(player.x, player.y, `+${Math.min(healed, 999999999)}${healed>999999999?'+':''}`, '#4dabf7');
-        } else {
-            addMessage('ポーションを使用したが体調に変化はなかった。');
-        }
-        playSfx('pickup');
-    }
-    updateUI();
-    saveAll();
+    consumePotion30({ reason: 'manual' });
 });
 
 eatPotion30Btn && eatPotion30Btn.addEventListener('click', () => {

--- a/style.css
+++ b/style.css
@@ -1158,6 +1158,22 @@ body.in-game #player-summary { display: none; }
     border: 1px solid rgba(255,255,255,0.2);
 }
 
+.toolbar-toggle {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    color: #1f2937;
+    font-weight: 600;
+    user-select: none;
+}
+
+.toolbar-toggle input[type="checkbox"] {
+    width: 18px;
+    height: 18px;
+    accent-color: #6366f1;
+}
+
 #toolbar button {
     padding: 10px 16px;
     border: none;
@@ -2171,6 +2187,42 @@ body.in-game #player-summary { display: none; }
 .item-row button:hover {
     transform: translateY(-1px);
     box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+}
+
+.item-row--toggle {
+    align-items: flex-start;
+    gap: 16px;
+}
+
+.item-row__info {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    color: #1f2937;
+    font-weight: 600;
+    flex: 1 1 auto;
+}
+
+.item-row__info small {
+    font-size: 12px;
+    color: #64748b;
+    font-weight: 500;
+}
+
+.item-row__toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    font-weight: 600;
+    color: #4338ca;
+    user-select: none;
+}
+
+.item-row__toggle input[type="checkbox"] {
+    width: 20px;
+    height: 20px;
+    accent-color: #6366f1;
 }
 
 .item-section {


### PR DESCRIPTION
## Summary
- add a toolbar checkbox that toggles the dungeon information card during exploration
- add an "auto item" checkbox to auto-use HP potions when health falls below 30% and refactor potion usage into a reusable helper
- style the new toggles to match the existing toolbar and modal aesthetics

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0a8277a14832b883a04dfbe2b9227