### PR TITLE
Defer dungeon overlay initialization until player is ready

### DIFF
--- a/main.js
+++ b/main.js
@@ -134,7 +134,6 @@ if (typeof window !== 'undefined') {
 
 if (dungeonNameToggle) {
     dungeonNameToggle.addEventListener('change', updateDungeonOverlayVisibility);
-    updateDungeonOverlayVisibility();
 }
 
 if (autoItemToggle) {
@@ -4346,6 +4345,10 @@ const player = {
     },
     statusEffects: createInitialStatusEffects()
 };
+
+if (dungeonNameToggle) {
+    updateDungeonOverlayVisibility();
+}
 
 function ensureInventoryContainer() {
     if (!player.inventory || typeof player.inventory !== 'object') {


### PR DESCRIPTION
## Summary
- defer the initial dungeon overlay visibility update until after the player object exists
- keep the dungeon name toggle change handler intact so runtime toggles continue to work

## Testing
- python -m http.server 8000 & (manual inspection via Playwright)


------
https://chatgpt.com/codex/tasks/task_e_68e0b2223d1c832b8f226dc156db6141