### PR TITLE
Fix skill charm button event handling for text nodes

### DIFF
--- a/main.js
+++ b/main.js
@@ -15239,7 +15239,10 @@ useSpElixirBtn && useSpElixirBtn.addEventListener('click', () => {
 });
 
 skillCharmList && skillCharmList.addEventListener('click', (event) => {
-    const target = event.target instanceof HTMLElement ? event.target.closest('.skill-charm-use') : null;
+    let origin = event.target instanceof Element
+        ? event.target
+        : (event.target && 'parentElement' in event.target ? event.target.parentElement : null);
+    const target = origin && 'closest' in origin ? origin.closest('.skill-charm-use') : null;
     if (!target) return;
     const effectId = target.dataset.effect;
     if (effectId) {


### PR DESCRIPTION
## Summary
- adjust the skill charm click handler to handle non-Element targets
- resolve the `.skill-charm-use` button even if the original click was on a text node

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e218c87218832b8b0549e814e9a1c8