### PR TITLE
Close modals when using skill charms

### DIFF
--- a/main.js
+++ b/main.js
@@ -13139,12 +13139,19 @@ function useSkillCharm(effectId) {
         return false;
     }
     incrementSkillCharm(effectId, -1);
-    activateSkillEffect(effectId, SKILL_CHARM_DURATION_TURNS, { silent: true });
     const label = SKILL_EFFECT_DEFS[effectId]?.label || effectId;
-    addMessage(`${label}の護符が発動！効果は${SKILL_CHARM_DURATION_TURNS}ターン持続する。`);
-    playSfx('pickup');
     updateUI();
     saveAll();
+    closeModal(itemsModal);
+    closeModal(skillsModal);
+    const delay = Math.max(0, Number(SKILL_EXECUTION_DELAY_MS) || 0);
+    setTimeout(() => {
+        activateSkillEffect(effectId, SKILL_CHARM_DURATION_TURNS, { silent: true });
+        addMessage(`${label}の護符が発動！効果は${SKILL_CHARM_DURATION_TURNS}ターン持続する。`);
+        playSfx('pickup');
+        updateUI();
+        saveAll();
+    }, delay);
     return true;
 }
 


### PR DESCRIPTION
## Summary
- close the items and skills modals automatically when a skill charm is consumed
- delay the activation of the skill charm effect by the shared skill execution delay so the effect fires 0.5 seconds later

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e21dfa5ef8832b81b865ae1fd891b3