### PR TITLE
Internationalize domain messaging and locale helpers

### DIFF
--- a/games/tester.js
+++ b/games/tester.js
@@ -409,10 +409,13 @@
       name: 'Intlフォーマット',
       description: 'Intl.DateTimeFormatとNumberFormatを検証します。',
       async run() {
-        const dateFmt = new Intl.DateTimeFormat('ja-JP', { dateStyle: 'full', timeStyle: 'medium', timeZone: 'Asia/Tokyo' });
-        const numFmt = new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY' });
+        const i18n = window.I18n;
+        const locale = (i18n?.getLocale?.() || i18n?.getDefaultLocale?.() || 'ja').toString();
+        const dateFmt = new Intl.DateTimeFormat(locale, { dateStyle: 'full', timeStyle: 'medium', timeZone: 'Asia/Tokyo' });
+        const formattedNumber = (typeof i18n?.formatNumber === 'function')
+          ? i18n.formatNumber(123456.789, { style: 'currency', currency: 'JPY' })
+          : new Intl.NumberFormat(locale, { style: 'currency', currency: 'JPY' }).format(123456.789);
         const formattedDate = dateFmt.format(new Date('2023-05-01T12:34:56Z'));
-        const formattedNumber = numFmt.format(123456.789);
         if (!formattedDate.includes('5月')) throw new Error('日付フォーマットが想定外です');
         if (!formattedNumber.includes('￥')) throw new Error('通貨フォーマットが想定外です');
         return `${formattedDate} / ${formattedNumber}`;

--- a/js/achievements.js
+++ b/js/achievements.js
@@ -4,7 +4,7 @@
 
     const VERSION = 2;
     const DIFFICULTY_ORDER = ['Very Easy', 'Easy', 'Normal', 'Second', 'Hard', 'Very Hard'];
-    const numberFormatter = new Intl.NumberFormat('ja-JP');
+    const i18n = global.I18n || null;
     const PLAYTIME_TRACKING_INTERVAL_MS = 1000;
 
     const CATEGORY_DEFINITIONS = [
@@ -472,7 +472,15 @@
 
     function formatNumber(value) {
         if (!Number.isFinite(value)) return '0';
-        return numberFormatter.format(Math.floor(value));
+        const numeric = Math.floor(value);
+        if (i18n && typeof i18n.formatNumber === 'function') {
+            return i18n.formatNumber(numeric);
+        }
+        try {
+            return new Intl.NumberFormat(undefined).format(numeric);
+        } catch (error) {
+            return String(numeric);
+        }
     }
 
     function formatDifficultyLabel(index) {

--- a/js/i18n/index.js
+++ b/js/i18n/index.js
@@ -199,6 +199,24 @@
         }
     }
 
+    function localeCompare(a, b, options) {
+        const primary = activeLocale || DEFAULT_LOCALE;
+        const left = a ?? '';
+        const right = b ?? '';
+        try {
+            if (typeof left.localeCompare === 'function') {
+                return left.localeCompare(right, primary, options);
+            }
+        } catch (error) {
+            // Ignore and fall back below.
+        }
+        try {
+            return String(left).localeCompare(String(right), FALLBACK_LOCALE, options);
+        } catch (error) {
+            return 0;
+        }
+    }
+
     function resolveTranslationRoot(root) {
         if (!root || root === document) {
             return document;
@@ -336,6 +354,7 @@
         formatNumber,
         formatDate,
         formatRelativeTime,
+        localeCompare,
         getLocale,
         getDefaultLocale,
         getSupportedLocales,

--- a/js/i18n/locales/en.json
+++ b/js/i18n/locales/en.json
@@ -13,6 +13,46 @@
         "ja": "Japanese",
         "en": "English"
       }
+    },
+    "runResult": {
+      "title": "Results",
+      "reason": {
+        "gameOver": "Game Over",
+        "clear": "Dungeon Cleared",
+        "retreat": "Dungeon Retreat",
+        "return": "Run Summary"
+      }
+    }
+  },
+  "messages": {
+    "domainCrystal": {
+      "spawn": "A mysterious domain crystal has appeared on this floor...!"
+    },
+    "domainEffect": {
+      "enter": "Entered the influence of domain effect \"{label}\"!",
+      "exit": "Left the domain effect's influence."
+    },
+    "domain": {
+      "poisonNegated": "The domain effect nullified the poison damage!",
+      "poisonReversed": "The poison's pain reversed and restored {amount} HP!",
+      "poisonDamage": "Poison dealt {amount} damage!",
+      "rareChestGuarded": "The golden chest exploded, but the domain effect protected you!",
+      "rareChestReversed": "The golden chest explosion reversed and restored {amount} HP!",
+      "rareChestDamage": "The golden chest exploded! HP decreased by {damage} (timing off by {timing}%).",
+      "rareChestDeath": "Caught in the golden chest explosion... Game over.",
+      "damageBlocked": "The domain effect prevented you from dealing damage...",
+      "enemyHealed": "The domain effect healed the enemy for {amount}!",
+      "poisonFloorNegated": "The domain effect nullified the poison floor's damage!",
+      "poisonFloorReversed": "The poison floor's energy reversed and restored {amount} HP!",
+      "poisonFloorDamage": "The poison floor dealt damage! HP decreased by {amount}.",
+      "poisonFloorDeath": "The poison floor defeated you... Game over.",
+      "bombGuarded": "The domain effect blocked the blast!",
+      "bombReversed": "The blast's force reversed and restored {amount} HP!",
+      "bombDamage": "The bomb exploded! HP decreased by {amount}.",
+      "bombDeath": "Caught in the bomb blast... Game over.",
+      "bombSafe": "The bomb exploded but you took no damage!",
+      "enemyAttackGuarded": "The domain effect protected you from damage!",
+      "enemyAttackReversed": "The domain effect turned the enemy attack into healing! Restored {amount} HP."
     }
   },
   "selection": {

--- a/js/i18n/locales/ja.json
+++ b/js/i18n/locales/ja.json
@@ -13,6 +13,46 @@
         "ja": "日本語",
         "en": "English"
       }
+    },
+    "runResult": {
+      "title": "リザルト",
+      "reason": {
+        "gameOver": "ゲームオーバー",
+        "clear": "ダンジョンクリア",
+        "retreat": "ダンジョン帰還",
+        "return": "冒険結果"
+      }
+    }
+  },
+  "messages": {
+    "domainCrystal": {
+      "spawn": "謎めいた領域クリスタルがこの階に出現した…！"
+    },
+    "domainEffect": {
+      "enter": "領域効果「{label}」の影響下に入った！",
+      "exit": "領域効果の影響から解放された。"
+    },
+    "domain": {
+      "poisonNegated": "領域効果により毒のダメージを無効化した！",
+      "poisonReversed": "毒の痛みが反転し、HPが{amount}回復した！",
+      "poisonDamage": "毒で{amount}のダメージ！",
+      "rareChestGuarded": "黄金の宝箱が爆発したが領域効果で守られた！",
+      "rareChestReversed": "黄金の宝箱の爆発が反転し、HPが{amount}回復した！",
+      "rareChestDamage": "黄金の宝箱が爆発！HPが{damage}減少（タイミングずれ {timing}%）",
+      "rareChestDeath": "黄金の宝箱の爆発に巻き込まれた…ゲームオーバー",
+      "damageBlocked": "領域効果に阻まれてダメージを与えられなかった…",
+      "enemyHealed": "領域効果で敵が{amount}回復してしまった！",
+      "poisonFloorNegated": "領域効果で毒床のダメージを無効化した！",
+      "poisonFloorReversed": "毒床のエネルギーが反転し、HPが{amount}回復した！",
+      "poisonFloorDamage": "毒床がダメージ！HPが{amount}減少",
+      "poisonFloorDeath": "毒床で倒れた…ゲームオーバー",
+      "bombGuarded": "領域効果で爆風を防いだ！",
+      "bombReversed": "爆風の力が反転し、HPが{amount}回復した！",
+      "bombDamage": "爆弾が爆発！HPが{amount}減少",
+      "bombDeath": "爆弾に巻き込まれて倒れた…ゲームオーバー",
+      "bombSafe": "爆弾が爆発したがダメージは受けなかった！",
+      "enemyAttackGuarded": "領域効果に守られ、ダメージを受けなかった！",
+      "enemyAttackReversed": "領域効果で敵の攻撃が回復に変わった！HPが{amount}回復"
     }
   },
   "selection": {


### PR DESCRIPTION
## Summary
- add locale-aware comparison helper to the i18n module and expand locale dictionaries with domain and run result strings
- update core gameplay, achievements, and tooling code to fetch domain-related logs through i18n and rely on localized number formatting
- adjust canvas text measurements to accommodate translated copy lengths and ensure locale-sensitive sorting in UI components

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e35314622c832bb8f7d651195965d9