### PR TITLE
Translate English manual chapters 6-20

### DIFF
--- a/manual/en/appendix.html
+++ b/manual/en/appendix.html
@@ -3,27 +3,39 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>17. Appendix & Further Reading (Translation in Progress)</title>
+    <title>17. Appendix &amp; Further Reading</title>
     <link rel="stylesheet" href="../manual.css">
 </head>
 <body>
     <main>
-        <h1>17. Appendix & Further Reading</h1>
-        <p>
-            The appendix, including external references and advanced notes, is scheduled for translation. Please consult
-            the Japanese materials for the current link collection:
-        </p>
-        <ul>
-            <li><a href="../appendix.html" target="_blank" rel="noopener">Japanese chapter: Appendix</a></li>
-        </ul>
-        <p>
-            The English release will include:
-        </p>
-        <ol>
-            <li>Reference links grouped by topic.</li>
-            <li>Printable checklists and worksheets.</li>
-            <li>Additional resources for educators and modders.</li>
-        </ol>
+        <h1>17. Appendix &amp; Further Reading</h1>
+        <section>
+            <h2>17.1 Helpful Links</h2>
+            <ul>
+                <li><a href="https://developer.mozilla.org/docs/Web" target="_blank" rel="noopener">MDN Web Docs</a> — official
+                    references for HTML, CSS, and JavaScript.</li>
+                <li><a href="https://web.dev/" target="_blank" rel="noopener">web.dev</a> — best practices for modern web
+                    development.</li>
+                <li><a href="https://git-scm.com/book/en/v2" target="_blank" rel="noopener">Pro Git</a> — free online Git
+                    handbook.</li>
+            </ul>
+        </section>
+        <section>
+            <h2>17.2 Sample Changelog Entry</h2>
+            <p>Use a short template when documenting updates:</p>
+<pre><code>## 2024-04-01
+- Added new dungeon "Crimson Gem Tower"
+- Improved Block Dimension weighted random selection
+- Expanded the manual with a Frequently Asked Questions chapter
+</code></pre>
+        </section>
+        <section>
+            <h2>17.3 Next Steps</h2>
+            <p>
+                After finishing the manual, start with a small tweak—rewrite a dungeon description to suit your world, for
+                example. Once you are comfortable, try adding new enemies or items and craft your own adventure.
+            </p>
+        </section>
     </main>
 </body>
 </html>

--- a/manual/en/block-dimension.html
+++ b/manual/en/block-dimension.html
@@ -3,27 +3,119 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>8. Understanding Block Dimensions (Translation in Progress)</title>
+    <title>8. Understanding Block Dimensions</title>
     <link rel="stylesheet" href="../manual.css">
 </head>
 <body>
     <main>
         <h1>8. Understanding Block Dimensions</h1>
-        <p>
-            The English explanation for the Block Dimension mode is in preparation. In the meantime, you can reference
-            the original Japanese material for configuration examples and gameplay rules:
-        </p>
-        <ul>
-            <li><a href="../block-dimension.html" target="_blank" rel="noopener">Japanese chapter: Block Dimensions</a></li>
-        </ul>
-        <p>
-            Planned topics include:
-        </p>
-        <ol>
-            <li>Concept overview and how the grid system differs from standard dungeons.</li>
-            <li>Structure of <code>blockdata.json</code> and key properties.</li>
-            <li>Tips for creating original puzzle layouts.</li>
-        </ol>
+        <section>
+            <h2>8.1 Mode Overview</h2>
+            <p>
+                Block Dimension mode fuses a <strong>Dimension</strong> with three types of <strong>Blocks (1st / 2nd / 3rd)</strong>
+                to generate dungeon parameters. Dimensions cover the letters a–z (automatically padded if data is missing) and
+                each dimension provides a base level in steps of 100. Blocks are loaded from <code>blockdata.json</code> or
+                <code>blockdata.js</code> and supply level modifiers, map sizes, depth, chest bias, and more.
+            </p>
+            <div class="tip">
+                <strong>Focus on combinations</strong>
+                <p>Block Dimension revolves around combining presets, not placing tiles manually. The same selection always
+                    generates the same dungeon, which makes it ideal for repeatable farming routes.</p>
+            </div>
+        </section>
+        <section>
+            <h2>8.2 How to Use the Mode</h2>
+            <ol>
+                <li>Select the <strong>BlockDim</strong> tab on the title screen.</li>
+                <li>Enter a <strong>NESTED</strong> value if needed (1–99,999,999). Every increment raises the recommended level
+                    by 2,600.</li>
+                <li>Pick a dimension and choose entries from the 1st/2nd/3rd block lists. You can change selections with the
+                    mouse or keyboard.</li>
+                <li>Review the level, type, depth, size modifier, chest bias, and boss floors on the preview card to the right.</li>
+                <li>When you are satisfied, press <strong>Launch Gate</strong> to begin the run.</li>
+            </ol>
+            <p class="small-note">History (up to 200 entries) and bookmarks (up to 100) are saved automatically. Click an entry to
+                reapply the configuration. The Random and Weighted Random buttons select blocks automatically.</p>
+        </section>
+        <section>
+            <h2>8.3 Data Sources &amp; Block Properties</h2>
+            <p>
+                On initialisation, the mode tries <code>fetch('blockdata.json')</code>. If that fails it loads
+                <code>blockdata.js</code> as a script. When neither file is available the game generates fallback data (dimension
+                a and dummy blocks).
+            </p>
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Element</th>
+                            <th>Source</th>
+                            <th>Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Dimensions</td>
+                            <td><code>baseLevel</code></td>
+                            <td>Base value for the recommended level (defaults: a = Lv1, b = Lv101, and so on).</td>
+                        </tr>
+                        <tr>
+                            <td>Blocks (blocks1/2/3)</td>
+                            <td><code>level</code>, <code>size</code>, <code>depth</code>, <code>chest</code>, <code>type</code></td>
+                            <td>Provide level modifiers, size multipliers, floor depth, chest bias, and generation type. The
+                                <code>bossFloors</code> array lists candidate boss floors.</td>
+                        </tr>
+                        <tr>
+                            <td>History / Bookmarks</td>
+                            <td>Local storage</td>
+                            <td>Store the seed, level, type, and other details so you can restore a configuration later.</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+        <section>
+            <h2>8.4 Composition Logic</h2>
+            <p>The resulting <strong>ComposedSpec</strong> follows these rules:</p>
+            <ul>
+                <li><strong>Level:</strong> Sum the block <code>level</code> values with the dimension’s <code>baseLevel</code>,
+                    then add 2,600 per NESTED step. Clamp the final result to a minimum of 1.</li>
+                <li><strong>Size factor:</strong> Add all <code>size</code> modifiers and clamp the total to −2 … +2.</li>
+                <li><strong>Depth:</strong> Add the <code>depth</code> values from each block and limit the result to 1–15. The
+                    baseline depth is 1.</li>
+                <li><strong>Chest bias:</strong> Determine the majority of <code>less / normal / more</code>. Ties resolve in the
+                    order normal &gt; more &gt; less.</li>
+                <li><strong>Generation type:</strong> If all blocks share the same <code>type</code>, use it. Otherwise mark the
+                    dungeon as <code>mixed</code> and store the available types in <code>typePool</code>.</li>
+                <li><strong>Boss floors:</strong> Merge the <code>bossFloors</code> arrays and keep only the values within the
+                    final depth.</li>
+            </ul>
+            <p>
+                The selected dimension and blocks produce a deterministic 32-bit seed via <code>seedFromSelection</code>. Each
+                floor derives additional random values with <code>mixSeed</code>, ensuring that identical combinations always
+                recreate the same dungeon layout.
+            </p>
+        </section>
+        <section>
+            <h2>8.5 Random Selection &amp; Management</h2>
+            <p>
+                The <strong>Random</strong> button selects blocks with equal probability. <strong>Weighted Random</strong> applies a
+                Gaussian weight around the target level and type before picking candidates. Completed runs are added to the
+                history automatically. Bookmark an entry to recall it at any time. Each record includes the NESTED value and seed,
+                making it easy to catalogue your favourite builds.
+            </p>
+        </section>
+        <section>
+            <h2>8.6 Related Chapters</h2>
+            <ul>
+                <li><a href="data-files.html" target="manual-content">Chapter 10: Data File Breakdown</a> — structure of
+                    <code>blockdata.json</code> / <code>blockdata.js</code>.</li>
+                <li><a href="customize.html" target="manual-content">Chapter 11: Adding or Modifying Content</a> — how to add
+                    new blocks and dimensions.</li>
+                <li><a href="appendix.html" target="manual-content">Chapter 17: Appendix</a> — links to design documents and
+                    related specs.</li>
+            </ul>
+        </section>
     </main>
 </body>
 </html>

--- a/manual/en/customize.html
+++ b/manual/en/customize.html
@@ -3,27 +3,53 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>11. Adding or Modifying Content (Translation in Progress)</title>
+    <title>11. Adding or Modifying Content</title>
     <link rel="stylesheet" href="../manual.css">
 </head>
 <body>
     <main>
         <h1>11. Adding or Modifying Content</h1>
-        <p>
-            The English rewrite of this chapter is underway. Until it is ready, the Japanese document remains the most
-            detailed guide for changing dungeons, enemies, and UI elements:
-        </p>
-        <ul>
-            <li><a href="../customize.html" target="_blank" rel="noopener">Japanese chapter: Customisation</a></li>
-        </ul>
-        <p>
-            The translation will cover:
-        </p>
-        <ol>
-            <li>Step-by-step walkthrough for duplicating and editing content packs.</li>
-            <li>Guidelines for balancing new encounters.</li>
-            <li>Checklists for testing customised builds.</li>
-        </ol>
+        <section>
+            <h2>11.1 Adding a Dungeon</h2>
+            <ol>
+                <li>Create a new JSON file inside the <code>dungeontypes</code> directory.</li>
+                <li>Follow an existing file and populate fields such as <code>name</code>, <code>description</code>, and
+                    <code>level</code>.</li>
+                <li>Update the loading routine in <code>main.js</code> so it reads the new file.</li>
+                <li>Reload the browser and confirm that the dungeon appears in the list.</li>
+            </ol>
+        </section>
+        <section>
+            <h2>11.2 Tuning Difficulty</h2>
+            <p>
+                Difficulty affects damage multipliers and enemy strength. Adjust the relevant dungeon data and test the result in
+                game to ensure it feels right.
+            </p>
+        </section>
+        <section>
+            <h2>11.3 Customising the Look</h2>
+            <ul>
+                <li>Edit colours or fonts in <code>style.css</code>.</li>
+                <li>Add background images via the <code>background-image</code> property.</li>
+                <li>Change button shapes by tweaking <code>border-radius</code> and <code>box-shadow</code>.</li>
+            </ul>
+            <p class="small-note">
+                To modify exploration badges or domain crystal behaviour, consult
+                <a href="reference-functions.html#domain-and-badge-hooks" target="manual-content">Section 19.5: Domain Effects &amp;
+                    Badge Controls</a> for the relevant hooks and definitions.
+            </p>
+        </section>
+        <div class="tip">
+            <strong>Iterate gradually:</strong> Large changes make debugging harder. Adjust one element at a time, save, and check
+            the result in the browser.
+        </div>
+        <section>
+            <h2>11.4 Embrace Version Control</h2>
+            <p>
+                Use Git or another version-control system when adding content. Record clear commit messages so you can revert to a
+                previous state whenever necessary.
+            </p>
+        </section>
     </main>
 </body>
 </html>

--- a/manual/en/data-files.html
+++ b/manual/en/data-files.html
@@ -3,27 +3,51 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>10. Data File Breakdown (Translation in Progress)</title>
+    <title>10. Data File Breakdown</title>
     <link rel="stylesheet" href="../manual.css">
 </head>
 <body>
     <main>
         <h1>10. Data File Breakdown</h1>
-        <p>
-            The data-file reference is being translated into English. Use the Japanese chapter for authoritative property
-            names and field descriptions until the translation is complete:
-        </p>
-        <ul>
-            <li><a href="../data-files.html" target="_blank" rel="noopener">Japanese chapter: Data Files</a></li>
-        </ul>
-        <p>
-            Planned English coverage:
-        </p>
-        <ol>
-            <li>Overview of each JSON file and its purpose.</li>
-            <li>Key fields for dungeons, enemies, and loot tables.</li>
-            <li>Version control tips for tracking gameplay adjustments.</li>
-        </ol>
+        <section>
+            <h2>10.1 blockdata.json / blockdata.js</h2>
+            <p>
+                These files bundle the configuration used by Block Dimension mode. The data is stored as JSON key–value pairs.
+                When in doubt, open <code>blockdata.json</code> in your editor to review the structure.
+            </p>
+            <h3>Key fields</h3>
+            <ul>
+                <li><strong>name:</strong> Display name of the block.</li>
+                <li><strong>level:</strong> Recommended level modifier.</li>
+                <li><strong>type:</strong> Category such as cave or tower.</li>
+                <li><strong>size:</strong> Size and floor-count information.</li>
+                <li><strong>chest:</strong> Chest quantity and rarity bias.</li>
+            </ul>
+        </section>
+        <section>
+            <h2>10.2 dungeontypes directory</h2>
+            <p>
+                Contains the files that classify worlds and dungeons. In-game descriptions and icons are also stored here. When
+                adding a new dungeon, copy the format from an existing file.
+            </p>
+        </section>
+        <section>
+            <h2>10.3 games directory</h2>
+            <p>
+                Houses the configuration and data for mini-games. Create new files here when adding additional mini-games.
+            </p>
+        </section>
+        <div class="warning">
+            <strong>Always back up your data.</strong> Make a copy before editing to ensure you can revert if something goes wrong.
+        </div>
+        <section>
+            <h2>10.4 JSON Editing Tips</h2>
+            <ul>
+                <li>Check for missing commas or quotation marks.</li>
+                <li>Keep arrays and objects indented consistently to improve readability.</li>
+                <li>Use version control or a diff tool before large changes so that you can compare revisions easily.</li>
+            </ul>
+        </section>
     </main>
 </body>
 </html>

--- a/manual/en/development.html
+++ b/manual/en/development.html
@@ -3,27 +3,50 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>12. JavaScript Architecture (Translation in Progress)</title>
+    <title>12. JavaScript Architecture</title>
     <link rel="stylesheet" href="../manual.css">
 </head>
 <body>
     <main>
         <h1>12. JavaScript Architecture</h1>
-        <p>
-            The English-language walkthrough of the codebase is under construction. For the latest diagrams and
-            explanations, please refer to the Japanese version:
-        </p>
-        <ul>
-            <li><a href="../development.html" target="_blank" rel="noopener">Japanese chapter: JavaScript Overview</a></li>
-        </ul>
-        <p>
-            Planned highlights for the English release include:
-        </p>
-        <ol>
-            <li>Module-by-module tour of the JavaScript files.</li>
-            <li>Event flow diagrams for battles, menus, and save data.</li>
-            <li>Recommended patterns for extending the core systems safely.</li>
-        </ol>
+        <section>
+            <h2>12.1 Role of main.js</h2>
+            <p>
+                <code>main.js</code> powers the interactive elements after the page loads. It queries DOM nodes and attaches the
+                click handlers for tabs, buttons, and other UI widgets.
+            </p>
+        </section>
+        <section>
+            <h2>12.2 Loading Data</h2>
+            <p>
+                The script uses the Fetch API to load JSON files and build the dungeon list. If you are new to Promises, review
+                the basics of <code>async/await</code> first—it makes the code easier to follow.
+            </p>
+        </section>
+        <section>
+            <h2>12.3 Frequently Used Functions</h2>
+            <ul>
+                <li><strong>renderWorldButtons()</strong>: Creates the world buttons.</li>
+                <li><strong>renderDungeonDetails()</strong>: Populates the detail card for the selected dungeon.</li>
+                <li><strong>setupTabs()</strong>: Initialises tab switching behaviour.</li>
+            </ul>
+        </section>
+        <section>
+            <h2>12.4 Suggested Reading Order</h2>
+            <ol>
+                <li>Start with the constants defined at the top of <code>main.js</code>.</li>
+                <li>Review where event listeners are registered.</li>
+                <li>Step into the functions that those listeners call.</li>
+            </ol>
+        </section>
+        <section>
+            <h2>12.5 Debugging Tips</h2>
+            <ul>
+                <li>Use <code>console.log()</code> to inspect variable values.</li>
+                <li>Set breakpoints to trace execution flow.</li>
+                <li>Adopt a linter to catch issues early.</li>
+            </ul>
+        </section>
     </main>
 </body>
 </html>

--- a/manual/en/faq.html
+++ b/manual/en/faq.html
@@ -3,27 +3,48 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>15. Frequently Asked Questions (Translation in Progress)</title>
+    <title>15. Frequently Asked Questions</title>
     <link rel="stylesheet" href="../manual.css">
 </head>
 <body>
     <main>
         <h1>15. Frequently Asked Questions</h1>
-        <p>
-            The FAQ chapter is being translated. Until then, the Japanese FAQ contains the latest troubleshooting steps and
-            support contacts:
-        </p>
-        <ul>
-            <li><a href="../faq.html" target="_blank" rel="noopener">Japanese chapter: FAQ</a></li>
-        </ul>
-        <p>
-            The English version will include:
-        </p>
-        <ol>
-            <li>Quick answers for common setup problems.</li>
-            <li>Guidance for reporting bugs or requesting features.</li>
-            <li>Links to community resources and support tools.</li>
-        </ol>
+        <section>
+            <h2>Q1. The screen looks wrong. What should I do?</h2>
+            <p>Cached assets may be interfering. Reload the page (Windows: <code>Ctrl + F5</code>, Mac: <code>Cmd + Shift + R</code>).</p>
+        </section>
+        <section>
+            <h2>Q2. I edited data and now the game throws errors.</h2>
+            <p>Most issues come from missing commas or closing quotes in JSON. Use your editor’s syntax checker to catch them.</p>
+        </section>
+        <section>
+            <h2>Q3. Can I play on mobile?</h2>
+            <p>Yes. The UI is responsive, though rotating the device to landscape mode improves usability on smaller screens.</p>
+        </section>
+        <section>
+            <h2>Q4. My file changes do not appear.</h2>
+            <p>Make sure you saved the file and cleared the cache. After saving, refresh the browser. If nothing changes, open the
+                developer tools to check for errors.</p>
+        </section>
+        <section>
+            <h2>Q5. SP and skills are unavailable.</h2>
+            <p>SP unlocks at player level 100. After that, movement, enemy defeats, MiniExp rewards, and offering recovery items all
+                add SP. Some skills are disabled in dungeons that exceed your level by 8 or more—read the descriptions in the skill
+                modal before activating them.</p>
+        </section>
+        <section>
+            <h2>Q6. I keep dying to hunger damage.</h2>
+            <p>In dungeons with a recommended level of 300 or more, satiety drops every turn. At 0 you take hunger damage based on max
+                HP. When the gauge falls below 30%, either head back early or enable auto-use in the status modal so potions switch
+                to the “Eat” action at 40% or less. If you plan to continue exploring, return to the selection screen to refill
+                satiety once damage starts ticking.</p>
+        </section>
+        <section>
+            <h2>Q7. Where can I review passive orbs?</h2>
+            <p>Passive orbs drop from high-score MiniExp rewards or challenging bosses. They equip automatically, stacking up to three
+                per type for bonuses such as damage reduction and ailment resistance. Review their effects at the bottom of the
+                status modal (“Passive Effects”) or via the icons below the status card during exploration.</p>
+        </section>
     </main>
 </body>
 </html>

--- a/manual/en/glossary.html
+++ b/manual/en/glossary.html
@@ -3,27 +3,30 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>16. Glossary (Translation in Progress)</title>
+    <title>16. Glossary</title>
     <link rel="stylesheet" href="../manual.css">
 </head>
 <body>
     <main>
         <h1>16. Glossary</h1>
-        <p>
-            We are compiling an English glossary aligned with the upcoming style guide. For now, the Japanese glossary
-            provides the authoritative definitions:
-        </p>
-        <ul>
-            <li><a href="../glossary.html" target="_blank" rel="noopener">Japanese chapter: Glossary</a></li>
-        </ul>
-        <p>
-            The English glossary will feature:
-        </p>
-        <ol>
-            <li>Official translations for UI elements, skills, and stats.</li>
-            <li>Usage notes that match the English manual’s tone.</li>
-            <li>Cross-links to relevant chapters and external resources.</li>
-        </ol>
+        <dl>
+            <dt>DOM</dt>
+            <dd>The document object model—a tree of HTML nodes that JavaScript can manipulate.</dd>
+            <dt>SP</dt>
+            <dd>Skill Points unlocked at level 100. Earned through movement, defeating enemies, MiniExp rewards, and offering recovery items.</dd>
+            <dt>Skill modal</dt>
+            <dd>The dialog opened via the toolbar’s “Skills” button. Displays remaining SP, available skills, and durations.</dd>
+            <dt>JSON</dt>
+            <dd>A key–value data format that is easy for both humans and computers to read.</dd>
+            <dt>Responsive design</dt>
+            <dd>A layout approach that adapts automatically to the screen width—handy for phones and tablets.</dd>
+            <dt>Tab UI</dt>
+            <dd>A navigation component that switches between multiple views when clicked.</dd>
+            <dt>Seed value</dt>
+            <dd>The starting point for random number generation. Using the same seed in Block Dimension reproduces the same structure.</dd>
+            <dt>Event listener</dt>
+            <dd>A callback that runs in response to interactions such as button clicks.</dd>
+        </dl>
     </main>
 </body>
 </html>

--- a/manual/en/how-to-play.html
+++ b/manual/en/how-to-play.html
@@ -3,27 +3,308 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>7. How to Play (Translation in Progress)</title>
+    <title>7. How to Play</title>
     <link rel="stylesheet" href="../manual.css">
 </head>
 <body>
     <main>
         <h1>7. How to Play</h1>
-        <p>
-            We are preparing the full play guide in English. While the translation is underway, please review the
-            Japanese source chapter for detailed mechanics and strategy tips:
-        </p>
-        <ul>
-            <li><a href="../how-to-play.html" target="_blank" rel="noopener">Japanese chapter: How to Play</a></li>
-        </ul>
-        <p>
-            Upcoming sections for the English chapter will include:
-        </p>
-        <ol>
-            <li>Core loop overview from dungeon selection to victory.</li>
-            <li>Combat basics, damage calculation, and recovery options.</li>
-            <li>Progression systems such as levels, skills, and unlocks.</li>
-        </ol>
+        <section>
+            <h2>7.1 Core Play Cycle</h2>
+            <p>
+                Yu Roguelike is a turn-based dungeon crawler. Choose your destination from the selection screen, challenge
+                the dungeon, and aim for the staircase on the lowest floor. The map layout and enemy placement change every
+                run, so each attempt offers a fresh route and encounter table.
+            </p>
+            <p>
+                When you enter a dungeon with a recommended level of 300 or higher the <strong>Satiety system</strong>
+                activates. The gauge decreases each time you act. While satiety is at least 1, automatic recovery at the start
+                of a turn only triggers when your HP is below 70% <em>and</em> your satiety is 20 or higher. The gauge is
+                consumed before HP is healed. At 0 satiety you take <strong>hunger damage</strong> every turn, based on your
+                maximum HP. Prepare food or switch potions to the “Eat” action to stay safe.
+            </p>
+            <ol>
+                <li>Select a <strong>difficulty</strong>, <strong>world</strong>, and <strong>dungeon</strong> on the selection
+                    screen, then review the recommended level and features on the detail card.</li>
+                <li>Press <strong>Enter Dungeon</strong> to begin. You move one tile at a time and attack adjacent enemies.</li>
+                <li>Open treasure chests and watch out for hazards such as poison and ice tiles while heading for the stairs.</li>
+                <li>Advance to the next floor at the staircase. Reaching the final floor automatically returns you to the
+                    selection screen with fully restored HP.</li>
+                <li>All stats and items are saved automatically and carry over to your next run.</li>
+            </ol>
+        </section>
+        <section>
+            <h2>7.2 Control Cheat Sheet</h2>
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Action</th>
+                            <th>PC</th>
+                            <th>Mobile / Tablet</th>
+                            <th>Notes</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Navigate menus</td>
+                            <td>Mouse click / Enter / Space / Arrow keys</td>
+                            <td>Tap / Swipe</td>
+                            <td>Used on the title screen, status panel, and other menus</td>
+                        </tr>
+                        <tr>
+                            <td>Move</td>
+                            <td>Arrow keys</td>
+                            <td>Virtual pad / Flick</td>
+                            <td>Walk forward, backward, left, or right inside dungeons</td>
+                        </tr>
+                        <tr>
+                            <td>Attack</td>
+                            <td>Space key</td>
+                            <td>Tap the attack button</td>
+                            <td>Attack in the facing direction; stepping onto an enemy tile also attacks</td>
+                        </tr>
+                        <tr>
+                            <td>Inspect enemy</td>
+                            <td>Click the enemy</td>
+                            <td>Tap the enemy</td>
+                            <td>Displays predicted damage and opens the enemy status modal</td>
+                        </tr>
+                        <tr>
+                            <td>Use item</td>
+                            <td>Click <em>Items</em> on the toolbar → Use button in the modal</td>
+                            <td>Tap the toolbar icon → Use button in the modal</td>
+                            <td>Consumes one item and triggers the effect immediately</td>
+                        </tr>
+                        <tr>
+                            <td>Check status / Leave run</td>
+                            <td>Click <em>Status</em> / <em>Return</em> on the toolbar</td>
+                            <td>Tap the matching toolbar icon</td>
+                            <td><em>Return</em> brings you back to the selection screen and pauses the run</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+            <p class="small-note">Esc and number-key shortcuts are not implemented in the current version. Close modals with the
+                “×” button in the corner.</p>
+            <p class="small-note">See <a href="ui.html" target="manual-content">Chapter 6: Screen Layout &amp; Controls</a> for a
+                full UI map.</p>
+        </section>
+        <section>
+            <h2>7.3 Dungeon Progression</h2>
+            <h3>Preparation</h3>
+            <ul>
+                <li>Use the status card at the bottom of the selection screen to check your current level, HP, attack, defence,
+                    and stored experience.</li>
+                <li>The dungeon detail card lists the recommended level and damage multiplier. When visiting a new area, start
+                    with dungeons close to your level.</li>
+                <li>Your game is saved automatically, so any items or upgrades earned in previous runs remain available.</li>
+            </ul>
+            <h3>Exploration</h3>
+            <ol>
+                <li>Players and enemies act in turns. Move one tile at a time—stepping into an enemy’s tile automatically
+                    attacks it.</li>
+                <li>If you challenge a dungeon that is at least five levels below your own, environmental hazards do not trigger:
+                    poison, ice, bomb, conveyor, one-way, vertical-only, and horizontal-only tiles all behave like safe tiles.
+                    Within four levels, hazards become active: poison inflicts damage over time, ice makes you slide, and bomb
+                    tiles explode for a percentage of max HP (100% / 80% / 50% / 25% / 10% depending on the level gap, with 0%
+                    when you exceed the recommendation by five levels).</li>
+                <li>Treasure chests contain recovery items or permanent stat boosters. All loot is logged in the message history.</li>
+                <li>Click or tap an enemy to see detailed information, including estimated damage dealt and taken.</li>
+                <li>In dungeons with a recommended level of 300 or higher, satiety drops by 1 per turn. At 0 you take hunger
+                    damage equal to 10% of your max HP each turn, so replenish your gauge once it falls below 30%.</li>
+            </ol>
+            <h4>Treasure Events and Golden Chests</h4>
+            <p>
+                Standard chests spawn randomly on each floor but stop appearing once you are five levels above the
+                recommendation, ensuring runs do not become overly safe. Eight percent of chests are promoted to
+                <strong>Golden Chests</strong>, which trigger a timing mini-game when opened. The four chests around the boss
+                room use the same promotion rate.
+            </p>
+            <p>
+                When a Golden Chest appears, the log announces “It’s a Golden Chest! Time your stop bar.” Opening the chest
+                launches a dedicated modal.
+            </p>
+            <p>
+                The timing bar sends a pointer back and forth across the lane—roughly 1.35 lane widths per second. Stopping the
+                pointer within ±10% of the centre counts as a success. The closer you are to the edges when you fail, the
+                higher the explosion damage shown in the preview.
+            </p>
+            <ul>
+                <li><strong>PC:</strong> Click the Stop button or press Space / Enter to freeze the pointer.</li>
+                <li><strong>Mobile / Tablet:</strong> Tap the Stop button or tap the bar itself.</li>
+                <li>The enemy turn pauses during the mini-game and resumes after the result.</li>
+            </ul>
+            <p>
+                Success opens the chest safely. You either receive a rare reward (50% chance) or an enhanced version of the
+                normal chest loot (50%). Failure causes an explosion dealing damage based on <strong>effective max HP × 0.5</strong>.
+                If the dungeon’s recommended level exceeds your own, the damage increases by 10% per level gap. If you are
+                higher, it decreases by 8% per level (to a minimum of 25%). Raising your level therefore reduces the risk.
+                Domain crystal effects such as shields or damage inversion can nullify the blast or convert it into healing.
+            </p>
+            <div class="table-container">
+                <table>
+                    <caption>Golden Chest Reward Categories</caption>
+                    <thead>
+                        <tr>
+                            <th>Category</th>
+                            <th>Contents</th>
+                            <th>Main Benefit / Notes</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Major Enhancers</td>
+                            <td>One permanent boost: Max HP +25, Attack +10, or Defence +10.</td>
+                            <td>40% chance. Consumed immediately for a permanent upgrade—ideal before boss fights.</td>
+                        </tr>
+                        <tr>
+                            <td>Skill Amulets</td>
+                            <td>Gain one amulet that auto-activates a chosen skill for 10 turns.</td>
+                            <td>35% chance. Added to the <em>Special</em> tab in the item modal and can be saved for later runs.</td>
+                        </tr>
+                        <tr>
+                            <td>SP Elixir</td>
+                            <td>Receive one custom SP elixir that greatly restores SP.</td>
+                            <td>25% chance. A powerful option when SP is low; offering it boosts MiniExp rewards.</td>
+                        </tr>
+                        <tr>
+                            <td>Passive Orb Roll</td>
+                            <td>10% chance to roll in addition to any of the above rewards.</td>
+                            <td>Provides permanent bonuses such as damage reduction or status resistances. Effects stack when duplicated.</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+            <div class="tip">
+                <strong>Tips for Golden Chests</strong>
+                <ul>
+                    <li>A subtle highlight marks the centre of the bar—prepare to press or tap just before the pointer reaches it.</li>
+                    <li>Explosions scale with max HP, so refill satiety and recovery options before attempting the mini-game.</li>
+                    <li>If domain crystal badges such as <code>Shield</code> or <code>⇆</code> are active, the blast can be nullified
+                        or inverted into healing. Open the chest while these protections are up.</li>
+                </ul>
+                <p class="small-note">You can rehearse the timing by opening the in-game “Golden Chest” help popup and cancelling
+                    before committing.</p>
+            </div>
+            <p class="small-note">Poison tiles deal 10% of your max HP when the dungeon matches your level and scale by ×1.5 per
+                level gap in the enemy’s favour (e.g., 15% at a one-level deficit, 22.5% at two levels). Conveyor tiles move you
+                one tile in the arrow direction. One-way tiles block movement against the arrow, while vertical-only /
+                horizontal-only tiles restrict movement to that axis. All of these hazards are disabled when you exceed the
+                recommendation by five levels.</p>
+            <h3>Return</h3>
+            <ul>
+                <li>Reaching the final floor shows the message “Dungeon cleared!” and returns you to the selection screen with
+                    fully restored HP.</li>
+                <li>At the end of a run, a <strong>result overlay</strong> summarises your <em>Level (Start → End ±Δ)</em>,
+                    <em>Total EXP Gained</em>, <em>Total Damage Taken</em>, and <em>Items Used</em>. If you were defeated, the
+                    cause is displayed at the top.</li>
+                <li>Use <strong>Return to Base</strong> to go back to the selection screen. When the requirements are met, a
+                    <strong>Retry</strong> button appears so you can jump back into the same dungeon. The Esc key performs the
+                    same action as Return to Base. You can also press Enter / Space while the button is focused.</li>
+                <li>Pressing <strong>Return</strong> on the toolbar ends the expedition early and takes you back to the selection
+                    screen with restored HP.</li>
+                <li>If satiety drops below 20%, consider heading back before repeated hunger damage puts you at risk. Switching
+                    potions to the Eat action ahead of time is another safe option.</li>
+                <li>On defeat you can restart immediately with the same stats using the Retry button.</li>
+            </ul>
+            <p class="small-note">All values shown on the result overlay are auto-saved and exported under
+                <code>achievements.stats.core</code> (e.g., total damage taken, total items used). See
+                <a href="ui.html#result-overlay" target="manual-content">Section 6.9</a> for a detailed UI breakdown.</p>
+        </section>
+        <section>
+            <h2>7.4 Combat &amp; Growth Tips</h2>
+            <h3>Understanding Your Stats</h3>
+            <p>
+                The status card and modal list your level, HP, attack, defence, and experience. HP at 0 results in a game over,
+                so heal promptly after taking large hits. Attack determines your outgoing damage; defence reduces incoming
+                damage.
+            </p>
+            <h3>Making the Most of Items</h3>
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Item</th>
+                            <th>Main Effect</th>
+                            <th>Action Options</th>
+                            <th>Auto-Use Condition</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>HP 30% Potion</td>
+                            <td>Restores 30% of max HP. Satiety +15.</td>
+                            <td>
+                                <ul>
+                                    <li><strong>Drink:</strong> Recovers HP immediately.</li>
+                                    <li><strong>Offer:</strong> Converts the potion into SP and MiniExp multipliers.</li>
+                                    <li><strong>Eat:</strong> Restores HP and satiety simultaneously. Unlocked from recommended level 300.</li>
+                                </ul>
+                            </td>
+                            <td>Default: Drink when HP ≤ 50%. Eat when HP ≤ 70% &amp; Satiety ≤ 30% (after unlocking).</td>
+                        </tr>
+                        <tr>
+                            <td>Full Recovery Potion</td>
+                            <td>Restores HP to 100%. Satiety +30.</td>
+                            <td>
+                                <ul>
+                                    <li><strong>Drink:</strong> Emergency heal.</li>
+                                    <li><strong>Offer:</strong> Large SP boost and MiniExp bonus.</li>
+                                    <li><strong>Eat:</strong> Full recovery plus satiety refill. Available from recommended level 300.</li>
+                                </ul>
+                            </td>
+                            <td>Drink at HP ≤ 25%. Eat at HP ≤ 50% &amp; Satiety ≤ 20% (after unlocking).</td>
+                        </tr>
+                        <tr>
+                            <td>Stat Seeds</td>
+                            <td>Permanently boost Max HP / Attack / Defence by a small amount.</td>
+                            <td>
+                                <ul>
+                                    <li><strong>Use:</strong> Apply the permanent upgrade.</li>
+                                    <li><strong>Offer:</strong> Convert to SP and MiniExp multipliers.</li>
+                                </ul>
+                            </td>
+                            <td>No auto-use. Manage them manually before boss fights.</td>
+                        </tr>
+                        <tr>
+                            <td>MiniExp Tickets</td>
+                            <td>Instantly grant MiniExp rewards such as skill unlocks.</td>
+                            <td>
+                                <ul>
+                                    <li><strong>Use:</strong> Claim the reward immediately.</li>
+                                    <li><strong>Offer:</strong> Bonus SP and higher MiniExp multiplier.</li>
+                                </ul>
+                            </td>
+                            <td>Never auto-used. Suitable for planned growth between floors.</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+            <p>
+                Auto-use thresholds can be edited from the status modal. Adjust them to match your risk tolerance—setting a
+                higher HP threshold keeps you topped up, while lower values conserve items for emergencies.
+            </p>
+            <h3>Levelling &amp; SP Management</h3>
+            <ul>
+                <li>Experience is earned from defeating enemies, clearing floors, and offering items. Levelling increases HP,
+                    attack, and defence automatically.</li>
+                <li>SP powers your skills. Move regularly, finish encounters efficiently, and donate surplus potions to keep the
+                    gauge charged.</li>
+                <li>Unlock new skills through MiniExp rewards and achievements. Review unlocked skills in the MiniExp tab on the
+                    title screen.</li>
+            </ul>
+        </section>
+        <section>
+            <h2>7.5 Managing Satiety</h2>
+            <ul>
+                <li>Satiety drains faster when you spend multiple turns in place. Keep moving to balance your consumption.</li>
+                <li>Offering food items grants SP and boosts the MiniExp multiplier, but it does not refill satiety—ensure you
+                    keep a spare potion for emergencies.</li>
+                <li>When satiety falls below 20%, switch your recovery items to the Eat action or plan an early return.</li>
+                <li>Satiety values carry over between floors. Use downtime after clearing enemies to refill the gauge.</li>
+            </ul>
+        </section>
     </main>
 </body>
 </html>

--- a/manual/en/minigame-guide.html
+++ b/manual/en/minigame-guide.html
@@ -3,27 +3,115 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>9. Mini-game Tour (Translation in Progress)</title>
+    <title>9. Mini-game Tour</title>
     <link rel="stylesheet" href="../manual.css">
 </head>
 <body>
     <main>
         <h1>9. Mini-game Tour</h1>
-        <p>
-            An English introduction to every built-in mini-game is being drafted. For full rules and reward tables right
-            now, please read the Japanese documentation:
-        </p>
-        <ul>
-            <li><a href="../minigame-guide.html" target="_blank" rel="noopener">Japanese chapter: Mini-game Guide</a></li>
-        </ul>
-        <p>
-            The upcoming English sections will highlight:
-        </p>
-        <ol>
-            <li>Available mini-games and their unlock conditions.</li>
-            <li>Reward types and how they support dungeon runs.</li>
-            <li>Recommended practice routines before high-difficulty expeditions.</li>
-        </ol>
+        <section>
+            <h2>9.1 Where to Play</h2>
+            <p>
+                Mini-games are available from the <strong>MiniExp</strong> tab on the title screen or the <strong>Arcade</strong>
+                inside the hub. Each game is designed for short sessions and awards materials, currency, and experience bonuses
+                based on your score.
+            </p>
+            <ol>
+                <li>The MiniExp tab displays game cards grouped by category.</li>
+                <li>Select a card to read the overview, rules, and recommended control scheme.</li>
+                <li>Press <strong>Play</strong> to load the game in a separate iframe window.</li>
+            </ol>
+            <p class="small-note">High scores are stored in your browser’s local storage. Switching devices resets them.</p>
+        </section>
+        <section>
+            <h2>9.2 Recommendations by Goal</h2>
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Goal</th>
+                            <th>Recommended Titles</th>
+                            <th>Why It Works</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Earn money quickly</td>
+                            <td>Gamble Hall / SameGame</td>
+                            <td>Bonus multipliers stack during streaks, letting you multiply your starting funds within 10 minutes.</td>
+                        </tr>
+                        <tr>
+                            <td>Sharpen reflexes</td>
+                            <td>Invader-style Shooter / Falling Shooter</td>
+                            <td>Enemy patterns escalate step by step, training evasion and shooting simultaneously.</td>
+                        </tr>
+                        <tr>
+                            <td>Boost logic skills</td>
+                            <td>Sudoku / River Crossing Puzzle</td>
+                            <td>Deliberate play yields high bonus EXP and doubles as practice for Block Dimension planning.</td>
+                        </tr>
+                        <tr>
+                            <td>Creative break</td>
+                            <td>Paint Tool / Music Player</td>
+                            <td>Creative utilities help you reset and jot down ideas between development sessions.</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+        <section>
+            <h2>9.3 Category Highlights</h2>
+            <h3>Action &amp; Shooting</h3>
+            <ul>
+                <li><strong>Invader-style Shooter:</strong> Enemies change with each wave—master lateral movement and bullet dodging.</li>
+                <li><strong>Snake:</strong> Classic growth management. Zig-zag routes create safe pockets for future turns.</li>
+                <li><strong>Top-down Racing:</strong> Optimise racing lines and boost timing. Rankings are based on lap times.</li>
+            </ul>
+            <div class="tip">
+                <strong>If the pace feels overwhelming</strong>
+                <p>Lower the game speed to 80% in the options menu to learn enemy layouts and track routes.</p>
+            </div>
+            <h3>Puzzle &amp; Logic</h3>
+            <ul>
+                <li><strong>Sudoku:</strong> Apply basic candidate elimination (line and box strategies).</li>
+                <li><strong>SameGame:</strong> Save large clusters for the end to maximise points. Plan ahead to preserve colours.</li>
+                <li><strong>Sliding Puzzle:</strong> Clearing edges from the outside in keeps the solution stable.</li>
+            </ul>
+            <h3>Utilities &amp; Support</h3>
+            <ul>
+                <li><strong>Spreadsheet Exceller:</strong> Great for tracking drop rates and EXP tables.</li>
+                <li><strong>Pomodoro Timer:</strong> Maintain focus during development or dungeon grinding. Alert sounds are customisable.</li>
+                <li><strong>Notepad Utility:</strong> Record your progress in a lightweight to-do list.</li>
+            </ul>
+        </section>
+        <section>
+            <h2>9.4 Making the Most of MiniExp Rewards</h2>
+            <p>
+                MiniExp scores convert not only to in-game currency but also to special materials and title points. Increasing the
+                difficulty raises the reward multiplier, yet failing midway reduces the bonus. Work up from a level you can clear
+                consistently.
+            </p>
+            <p>
+                From level 100 onward, 1% of the experience earned via MiniExp automatically converts into SP, helping you charge
+                skill gauges for dungeon runs. The score screen and dungeon HUD display your SP total, making it easy to grind
+                until you reach the desired amount. High-score rewards also include passive orbs that grant damage reduction or
+                status resistances, up to three per category.
+            </p>
+            <ul>
+                <li><strong>EXP Boost:</strong> Consecutive plays build combo multipliers that add EXP to the main game.</li>
+                <li><strong>Material Tickets:</strong> Earn random crafting materials at specific score thresholds—useful for Block
+                    Dimension builds and gear upgrades.</li>
+                <li><strong>Title Tasks:</strong> Complete game-specific challenges to unlock title panels and permanent bonuses.</li>
+            </ul>
+        </section>
+        <section>
+            <h2>9.5 Learn More</h2>
+            <p>
+                Detailed specifications, entry points, and data structures for each mini-game are documented in
+                <a href="reference-minigames.html" target="manual-content">Chapter 20: MiniExp Module Catalog</a>. For authoring
+                tips, see <a href="minigames.html" target="manual-content">Chapter 13: Mini-games &amp; Tools</a>.
+            </p>
+        </section>
     </main>
 </body>
 </html>

--- a/manual/en/minigames.html
+++ b/manual/en/minigames.html
@@ -3,27 +3,275 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>13. Mini-games & Tools (Translation in Progress)</title>
+    <title>13. Mini-games &amp; Tools</title>
     <link rel="stylesheet" href="../manual.css">
 </head>
 <body>
     <main>
-        <h1>13. Mini-games & Tools</h1>
-        <p>
-            We are compiling an English guide for creator utilities and optional modes. Refer to the Japanese chapter for
-            the complete catalogue until the translation is published:
-        </p>
-        <ul>
-            <li><a href="../minigames.html" target="_blank" rel="noopener">Japanese chapter: Mini-games & Tools</a></li>
-        </ul>
-        <p>
-            The English chapter will cover:
-        </p>
-        <ol>
-            <li>Descriptions of each utility and how they interact with dungeon data.</li>
-            <li>Integration tips for bundling custom tools.</li>
-            <li>Maintenance checklist for keeping optional content up to date.</li>
-        </ol>
+        <h1>13. Mini-games &amp; Tools</h1>
+        <section>
+            <h2>13.1 Managing Mini-games</h2>
+            <p>
+                The project ships with numerous mini-games and idea notebooks. Browse the samples in the <code>games</code>
+                directory when adding your own creations—they serve as templates for structure and assets.
+            </p>
+            <p class="small-note">
+                Detailed specs, difficulty settings, and entry points for each bundled module are listed in
+                <a href="reference-minigames.html" target="manual-content">Chapter 20: MiniExp Module Catalog</a>.
+            </p>
+        </section>
+        <section>
+            <h2>13.2 The Tools Tab</h2>
+            <p>
+                The Tools tab provides utilities useful during development, such as block-data editors. Some tools are still in
+                progress, so check the changelog to follow updates.
+            </p>
+            <p class="small-note">
+                To customise domain hazards and status badges on the dungeon overlay, see
+                <a href="reference-functions.html#domain-and-badge-hooks" target="manual-content">Section 19.5</a> for the
+                relevant hooks.
+            </p>
+        </section>
+        <section>
+            <h2>13.3 Integration Tips</h2>
+            <ul>
+                <li>Create a shared data-management module if you want mini-game results to influence the main game.</li>
+                <li>Provide common CSS classes to keep UI styling consistent.</li>
+            </ul>
+        </section>
+        <section>
+            <h2>13.4 Mini-game &amp; Tool Directory</h2>
+            <p class="small-note">Every mini-game and utility listed below runs entirely in the browser. Use this section as a quick
+                reference for controls and best practices.</p>
+            <h3 id="game-electro-instrument">Electro Instrument</h3>
+            <ul>
+                <li><strong>Goal:</strong> Play notes on a virtual keyboard.</li>
+                <li><strong>Controls:</strong> Use the mouse or keyboard keys to trigger pitches.</li>
+                <li><strong>Tip:</strong> Ideal for chord checks and testing sound effects during development.</li>
+            </ul>
+            <h3 id="game-exceler">Spreadsheet Exceller</h3>
+            <ul>
+                <li><strong>Goal:</strong> Organise and calculate values in a lightweight spreadsheet.</li>
+                <li><strong>Controls:</strong> Click cells to enter data or formulas.</li>
+                <li><strong>Tip:</strong> Record dungeon-balance adjustments so you can track your changes.</li>
+            </ul>
+            <h3 id="game-falling-shooter">Falling Shooter</h3>
+            <ul>
+                <li><strong>Goal:</strong> Shoot descending enemies to earn points.</li>
+                <li><strong>Controls:</strong> Move with the arrow keys and fire with Space.</li>
+                <li><strong>Tip:</strong> Observe the descent speed and weave movement with attacks.</li>
+            </ul>
+            <h3 id="game-flappy-bird">Flappy-style Flight</h3>
+            <ul>
+                <li><strong>Goal:</strong> Fly through pipe gaps to extend your distance.</li>
+                <li><strong>Controls:</strong> Tap Space or click to flap.</li>
+                <li><strong>Tip:</strong> Use short taps instead of holding the key to fine-tune altitude.</li>
+            </ul>
+            <h3 id="game-gamble-hall">Gamble Hall</h3>
+            <ul>
+                <li><strong>Goal:</strong> A collection of simple wagering games that increase your points.</li>
+                <li><strong>Controls:</strong> Choose bet amounts and outcomes via mouse clicks.</li>
+                <li><strong>Tip:</strong> Start with small wagers to avoid running out of points.</li>
+            </ul>
+            <h3 id="game-go">Go Lite</h3>
+            <ul>
+                <li><strong>Goal:</strong> Capture territory in a streamlined version of Go.</li>
+                <li><strong>Controls:</strong> Click intersections to place stones.</li>
+                <li><strong>Tip:</strong> Watch for liberties and surround opposing stones.</li>
+            </ul>
+            <h3 id="game-invaders">Invader-style Shooter</h3>
+            <ul>
+                <li><strong>Goal:</strong> Defeat each wave of descending aliens.</li>
+                <li><strong>Controls:</strong> Move left/right with the arrow keys and fire with Space.</li>
+                <li><strong>Tip:</strong> Hide behind barriers and clear columns one at a time.</li>
+            </ul>
+            <h3 id="game-math-lab">Math Lab</h3>
+            <ul>
+                <li><strong>Goal:</strong> Solve arithmetic drills to build fundamentals.</li>
+                <li><strong>Controls:</strong> Enter answers and submit them for grading.</li>
+                <li><strong>Tip:</strong> Combine mental math with quick notes when a timer is active.</li>
+            </ul>
+            <h3 id="game-match3">Match-3 Puzzle</h3>
+            <ul>
+                <li><strong>Goal:</strong> Align three or more identical icons to clear them and reach the target score.</li>
+                <li><strong>Controls:</strong> Swap adjacent tiles by dragging or clicking.</li>
+                <li><strong>Tip:</strong> Prioritise moves that can cascade into combos.</li>
+            </ul>
+            <h3 id="game-minesweeper">Minesweeper</h3>
+            <ul>
+                <li><strong>Goal:</strong> Reveal all safe tiles without triggering mines.</li>
+                <li><strong>Controls:</strong> Left-click to open, right-click to flag.</li>
+                <li><strong>Tip:</strong> Use the numbers to deduce where mines are located.</li>
+            </ul>
+            <h3 id="game-music-player">Music Player</h3>
+            <ul>
+                <li><strong>Goal:</strong> Preview BGM and sound effects.</li>
+                <li><strong>Controls:</strong> Choose a track from the playlist and scrub with the seek bar.</li>
+                <li><strong>Tip:</strong> Loop tracks while fine-tuning volume levels.</li>
+            </ul>
+            <h3 id="game-notepad">Notepad Utility</h3>
+            <ul>
+                <li><strong>Goal:</strong> Save quick text notes.</li>
+                <li><strong>Controls:</strong> Type in the editor area and click Save to store locally.</li>
+                <li><strong>Tip:</strong> Keep it open to jot down tasks or test results instantly.</li>
+            </ul>
+            <h3 id="game-othello">Othello</h3>
+            <ul>
+                <li><strong>Goal:</strong> Flip discs by enclosing your opponent and finish with the majority.</li>
+                <li><strong>Controls:</strong> Click a square to place a disc.</li>
+                <li><strong>Tip:</strong> Prioritise corner control to stabilise the board.</li>
+            </ul>
+            <h3 id="game-pacman">Pac-Man Homage</h3>
+            <ul>
+                <li><strong>Goal:</strong> Eat every dot in the maze while evading ghosts.</li>
+                <li><strong>Controls:</strong> Move with the arrow keys.</li>
+                <li><strong>Tip:</strong> Grab power pellets at the right time to reverse the chase.</li>
+            </ul>
+            <h3 id="game-paint">Paint Tool</h3>
+            <ul>
+                <li><strong>Goal:</strong> Draw quick pixel art or diagrams.</li>
+                <li><strong>Controls:</strong> Drag on the canvas and pick colours or brush sizes.</li>
+                <li><strong>Tip:</strong> Save frequently—layers are not available.</li>
+            </ul>
+            <h3 id="game-physics-sandbox">Physics Sandbox</h3>
+            <ul>
+                <li><strong>Goal:</strong> Experiment with physics simulations.</li>
+                <li><strong>Controls:</strong> Spawn objects and tweak gravity or collision settings.</li>
+                <li><strong>Tip:</strong> Prototype gameplay ideas and record the values that feel best.</li>
+            </ul>
+            <h3 id="game-pong">Pong</h3>
+            <ul>
+                <li><strong>Goal:</strong> Rally the ball into your opponent’s goal.</li>
+                <li><strong>Controls:</strong> Move the paddle with the arrow keys or W/S.</li>
+                <li><strong>Tip:</strong> Aim for different paddle positions to vary the rebound angle.</li>
+            </ul>
+            <h3 id="game-pomodoro">Pomodoro Timer</h3>
+            <ul>
+                <li><strong>Goal:</strong> Maintain focus with 25-minute work sessions and 5-minute breaks.</li>
+                <li><strong>Controls:</strong> Start the timer and follow the alerts.</li>
+                <li><strong>Tip:</strong> Great for scheduling reading or implementation sprints.</li>
+            </ul>
+            <h3 id="game-puyo">Puyo-style Puzzle</h3>
+            <ul>
+                <li><strong>Goal:</strong> Connect four blobs of the same colour to clear them and chain combos.</li>
+                <li><strong>Controls:</strong> Move and rotate with the arrow keys; press Down to drop faster.</li>
+                <li><strong>Tip:</strong> Practise staircase or key stacking to build reliable chains.</li>
+            </ul>
+            <h3 id="game-river-crossing">River Crossing Puzzle</h3>
+            <ul>
+                <li><strong>Goal:</strong> Ferry everyone across safely while respecting restrictions.</li>
+                <li><strong>Controls:</strong> Choose passengers and press the move button.</li>
+                <li><strong>Tip:</strong> Double-check forbidden combinations before each trip.</li>
+            </ul>
+            <h3 id="game-same">SameGame</h3>
+            <ul>
+                <li><strong>Goal:</strong> Clear connected groups of the same colour for high scores.</li>
+                <li><strong>Controls:</strong> Click a group to remove it.</li>
+                <li><strong>Tip:</strong> Wait for large clusters and finish with chain reactions.</li>
+            </ul>
+            <h3 id="game-sliding-puzzle">Sliding Puzzle</h3>
+            <ul>
+                <li><strong>Goal:</strong> Arrange shuffled tiles into the correct order.</li>
+                <li><strong>Controls:</strong> Click tiles adjacent to the blank space.</li>
+                <li><strong>Tip:</strong> Solve rows and columns sequentially, leaving the final 2×2 for last.</li>
+            </ul>
+            <h3 id="game-snake">Snake</h3>
+            <ul>
+                <li><strong>Goal:</strong> Eat food, extend your body, and avoid collisions.</li>
+                <li><strong>Controls:</strong> Change direction with the arrow keys.</li>
+                <li><strong>Tip:</strong> Plan wide turns and weave to create safe corridors as you grow.</li>
+            </ul>
+            <h3 id="game-steady-wire">Steady Wire</h3>
+            <ul>
+                <li><strong>Goal:</strong> Guide the cursor along a wire without touching the edges.</li>
+                <li><strong>Controls:</strong> Move the mouse carefully along the path.</li>
+                <li><strong>Tip:</strong> Lower mouse sensitivity for finer control.</li>
+            </ul>
+            <h3 id="game-stone-board-games">Stone Board Game Pack</h3>
+            <ul>
+                <li><strong>Goal:</strong> Samples of stone-based board games such as Go and Gomoku.</li>
+                <li><strong>Controls:</strong> Click squares according to each rule set.</li>
+                <li><strong>Tip:</strong> Keep the rule notes open to avoid mixing up mechanics.</li>
+            </ul>
+            <h3 id="game-stopwatch">Stopwatch</h3>
+            <ul>
+                <li><strong>Goal:</strong> Measure elapsed time.</li>
+                <li><strong>Controls:</strong> Use the start, stop, and reset buttons.</li>
+                <li><strong>Tip:</strong> Track speedrun attempts to spot improvement opportunities.</li>
+            </ul>
+            <h3 id="game-sudoku">Sudoku</h3>
+            <ul>
+                <li><strong>Goal:</strong> Fill a 9×9 grid with digits 1–9 without repetition.</li>
+                <li><strong>Controls:</strong> Click a cell and enter a number.</li>
+                <li><strong>Tip:</strong> Pencil in candidates per row, column, and box to find certainties.</li>
+            </ul>
+            <h3 id="game-ten-ten">Ten-Ten Puzzle</h3>
+            <ul>
+                <li><strong>Goal:</strong> Combine numbers to make 10 and tidy the board.</li>
+                <li><strong>Controls:</strong> Place numbered blocks; completed lines vanish.</li>
+                <li><strong>Tip:</strong> Check block shapes beforehand to avoid stray remainders.</li>
+            </ul>
+            <h3 id="game-tester">Tester Tool</h3>
+            <ul>
+                <li><strong>Goal:</strong> Rapidly verify mini-game behaviour.</li>
+                <li><strong>Controls:</strong> Choose a test case and run it.</li>
+                <li><strong>Tip:</strong> Execute these checks after adding new features to catch regressions early.</li>
+            </ul>
+            <h3 id="game-tetris">Tetris-style</h3>
+            <ul>
+                <li><strong>Goal:</strong> Prevent the stack from reaching the top by clearing lines.</li>
+                <li><strong>Controls:</strong> Move/rotate with the arrows, press Down to soft drop, Space to hard drop.</li>
+                <li><strong>Tip:</strong> Decide when to use Hold and practise techniques such as T-Spins.</li>
+            </ul>
+            <h3 id="game-timer">Timer</h3>
+            <ul>
+                <li><strong>Goal:</strong> Run a simple countdown.</li>
+                <li><strong>Controls:</strong> Set minutes and seconds, then start.</li>
+                <li><strong>Tip:</strong> Useful for tracking breaks or event countdowns.</li>
+            </ul>
+            <h3 id="game-todo-list">To-do List</h3>
+            <ul>
+                <li><strong>Goal:</strong> Organise tasks and progress.</li>
+                <li><strong>Controls:</strong> Enter tasks, add them, and tick them off when done.</li>
+                <li><strong>Tip:</strong> Break large goals into smaller tasks for more frequent wins.</li>
+            </ul>
+            <h3 id="game-triomino-columns">Triomino Columns</h3>
+            <ul>
+                <li><strong>Goal:</strong> Drop triomino blocks to complete columns.</li>
+                <li><strong>Controls:</strong> Move and rotate with the arrow keys.</li>
+                <li><strong>Tip:</strong> Reorder colours mid-air to set up monochrome columns.</li>
+            </ul>
+            <h3 id="game-trump-games">Card Game Collection</h3>
+            <ul>
+                <li><strong>Goal:</strong> Play assorted card games such as solitaire.</li>
+                <li><strong>Controls:</strong> Drag and drop cards according to each rule set.</li>
+                <li><strong>Tip:</strong> Read the in-game help to memorise each mode’s sequence.</li>
+            </ul>
+            <h3 id="game-ultimate-ttt">Ultimate Tic-Tac-Toe</h3>
+            <ul>
+                <li><strong>Goal:</strong> Win on a large board made of nine mini tic-tac-toe grids.</li>
+                <li><strong>Controls:</strong> Place a mark in the instructed sub-board.</li>
+                <li><strong>Tip:</strong> Anticipate the opponent’s destination and prioritise lines on the main board.</li>
+            </ul>
+            <h3 id="game-video-player">Video Player</h3>
+            <ul>
+                <li><strong>Goal:</strong> Review tutorial or reference videos.</li>
+                <li><strong>Controls:</strong> Select a video and use playback controls.</li>
+                <li><strong>Tip:</strong> Speed up playback to learn more efficiently.</li>
+            </ul>
+            <h3 id="game-whack-a-mole">Whack-a-Mole</h3>
+            <ul>
+                <li><strong>Goal:</strong> Hit moles as they pop out to score points.</li>
+                <li><strong>Controls:</strong> Click moles the moment they appear.</li>
+                <li><strong>Tip:</strong> Learn spawn patterns and limit unnecessary eye movement.</li>
+            </ul>
+            <h3 id="game-wording">Wording Tool</h3>
+            <ul>
+                <li><strong>Goal:</strong> Assist with phrasing and vocabulary gathering.</li>
+                <li><strong>Controls:</strong> Enter text to receive suggestions or replacements.</li>
+                <li><strong>Tip:</strong> Use it while drafting descriptions or event dialogue.</li>
+            </ul>
+        </section>
     </main>
 </body>
 </html>

--- a/manual/en/reference-api.html
+++ b/manual/en/reference-api.html
@@ -3,27 +3,223 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>18. API Reference (Translation in Progress)</title>
+    <title>18. API Reference</title>
     <link rel="stylesheet" href="../manual.css">
 </head>
 <body>
     <main>
         <h1>18. API Reference</h1>
-        <p>
-            An English API reference is being prepared. For now, the Japanese documentation lists every available method
-            and parameter:
-        </p>
-        <ul>
-            <li><a href="../reference-api.html" target="_blank" rel="noopener">Japanese chapter: API Reference</a></li>
-        </ul>
-        <p>
-            The English version will provide:
-        </p>
-        <ol>
-            <li>Detailed signatures and usage examples.</li>
-            <li>Notes on asynchronous behaviour and event hooks.</li>
-            <li>Migration guides for future API updates.</li>
-        </ol>
+        <section>
+            <h2>18.1 Global Public APIs</h2>
+            <p>
+                The following APIs are exposed to the main game, MiniExp modules, and add-ons. When calling them from the UI,
+                reference the functions and objects exported to the <code>window</code> global.
+            </p>
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>API</th>
+                            <th>Description</th>
+                            <th>Key Properties / Args</th>
+                            <th>Defined In</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><code>window.SandboxBridge</code></td>
+                            <td>Utility for sandboxed execution. Provides min/max map sizes and validation helpers.</td>
+                            <td><code>minSize</code>, <code>maxSize</code>, <code>maxLevel</code>, <code>computePlayerStats()</code>,
+                                <code>sanitize()</code>, <code>validate()</code>, <code>start()</code>, <code>isActive()</code></td>
+                            <td><code>main.js</code> lines 400–419</td>
+                        </tr>
+                        <tr>
+                            <td><code>window.registerMiniGame(def)</code></td>
+                            <td>Registers a MiniExp mod. Pass a definition with <code>id</code> and a <code>create</code> implementation.</td>
+                            <td><code>def.id</code> (required), <code>def.create(root, awardXp, options)</code>, optional metadata</td>
+                            <td><code>main.js</code> lines 6669–6693</td>
+                        </tr>
+                        <tr>
+                            <td><code>window.showTransientPopupAt(x, y, text, opts)</code></td>
+                            <td>Draws a floating popup over the MiniExp container.</td>
+                            <td><code>opts.variant</code> (<code>'info'</code> / <code>'warning'</code> / <code>'combo'</code>, etc.),
+                                <code>opts.duration</code></td>
+                            <td><code>main.js</code> lines 6761–6783</td>
+                        </tr>
+                        <tr>
+                            <td><code>window.showMiniExpBadge(text, opts)</code></td>
+                            <td>Displays an EXP badge on the MiniExp HUD. Use <code>opts.tone</code> and <code>opts.variant</code> to adjust the
+                                styling.</td>
+                            <td><code>opts.variant</code> (e.g., <code>'combo'</code>), <code>opts.level</code>, <code>opts.tone</code> (supports
+                                <code>'loss'</code>)</td>
+                            <td><code>main.js</code> lines 6735–6760</td>
+                        </tr>
+                        <tr>
+                            <td><code>window.getMiniExpBalance()</code></td>
+                            <td>Returns the cumulative EXP gained during the current session (MiniExp tab).</td>
+                            <td>Return value: number</td>
+                            <td><code>main.js</code> lines 6824–6827</td>
+                        </tr>
+                        <tr>
+                            <td><code>window.registerDungeonAddon(def)</code></td>
+                            <td>Registers dungeon-generation add-ons, extending generators, structures, and BlockDim tables.</td>
+                            <td><code>def.id</code> (required), <code>def.generators</code>, <code>def.blocks</code>, <code>def.structures</code></td>
+                            <td><code>main.js</code> lines 7480–7512</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+        <section>
+            <h2>18.2 MiniExp Module Lifecycle</h2>
+            <p>
+                After a module calls <code>registerMiniGame</code>, the player’s launch action invokes its <code>create()</code>
+                function. Implement the following signature and return a runtime controller:
+            </p>
+<pre><code>function create(rootElement, awardXp, options) {
+    // Required: build DOM under rootElement
+    // Required: call awardXp(delta) to grant EXP
+    // options.difficulty and options.shortcuts are provided
+    return {
+        start(),   // Begin the game
+        stop(),    // Pause or handle shutdown
+        destroy(), // Clean up resources
+        getScore() // Return a number for best-score tracking
+    };
+}</code></pre>
+            <p>
+                When the game ends, the runtime is called in order: <code>stop()</code> → <code>getScore()</code> →
+                <code>destroy()</code>. Records update through <code>startSelectedMiniGame()</code> and
+                <code>quitMiniGame()</code>.
+            </p>
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Context</th>
+                            <th>Details</th>
+                            <th>Reference</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><code>options.difficulty</code></td>
+                            <td>Value from the UI difficulty selector (<code>EASY</code> / <code>NORMAL</code> / <code>HARD</code>, etc.).</td>
+                            <td><code>main.js</code> lines 11620–11634</td>
+                        </tr>
+                        <tr>
+                            <td><code>options.shortcuts</code></td>
+                            <td>Shortcut controller that toggles key bindings. Provides <code>enableKey()</code>, <code>disableKey()</code>, and more.</td>
+                            <td><code>main.js</code> lines 161–188</td>
+                        </tr>
+                        <tr>
+                            <td><code>options.player</code></td>
+                            <td>Player-control API (v0.3+). Offers HP/SP/inventory updates and <code>getState()</code> snapshots.</td>
+                            <td><code>main.js</code> lines 11610–11634</td>
+                        </tr>
+                        <tr>
+                            <td><code>awardXp(amount, meta)</code></td>
+                            <td>Callback for granting EXP. Updates the MiniExp HUD and internal balance.</td>
+                            <td><code>main.js</code> lines 11544–11580</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+        <section>
+            <h2>18.3 Player Control API</h2>
+            <p>
+                <code>options.player</code> lets MiniExp modules interact with the player state safely. It is undefined on host
+                versions prior to v0.3, so check for availability before use. Major methods include:</p>
+            <ul>
+                <li><code>getState()</code>: Returns a snapshot containing level, HP, SP, and inventory.</li>
+                <li><code>awardItems()</code> / <code>adjustItems()</code>: Apply an item-id map and return the actual delta.</li>
+                <li><code>adjustHp()</code> / <code>healHp()</code> / <code>damageHp()</code>: Modify HP with caps handled automatically.</li>
+                <li><code>adjustSp()</code> / <code>fillSp()</code>: Change SP or refill to the maximum.</li>
+            </ul>
+            <p class="small-note">All operations trigger UI updates and saving on the host side. Use options such as
+                <code>opts.silent</code> or <code>opts.allowNegative</code> when provided.</p>
+            <h2>18.4 Shortcut Controller API</h2>
+            <p>
+                <code>options.shortcuts</code> is created by <code>createMiniShortcutController()</code>. It enables each mini-game
+                to manage keyboard shortcuts independently.
+            </p>
+            <ul>
+                <li><code>setGlobal(enabled)</code> / <code>setAll(enabled)</code>: Toggle all shortcuts at once.</li>
+                <li><code>enableKey(key)</code> / <code>disableKey(key)</code>: Control individual keys.</li>
+                <li><code>isKeyEnabled(key)</code>: Check the current state.</li>
+                <li><code>reset()</code>: Restore the defaults.</li>
+            </ul>
+            <p class="small-note">Implementation lives in <code>main.js</code> lines 132–188 and integrates with MiniExp shortcuts
+                (P = pause, R = restart).</p>
+        </section>
+        <section>
+            <h2>18.5 Dungeon Add-on API</h2>
+            <p>
+                Add-ons registered via <code>registerDungeonAddon()</code> receive a context object from
+                <code>makeGenContext()</code>. Generation helpers include:
+            </p>
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Method</th>
+                            <th>Description</th>
+                            <th>Reference</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><code>ctx.set(x, y, solid)</code></td>
+                            <td>Toggle tiles between wall and floor. Neighbour metadata adjusts automatically.</td>
+                            <td><code>main.js</code> lines 7514–7549</td>
+                        </tr>
+                        <tr>
+                            <td><code>ctx.ensureConnectivity()</code></td>
+                            <td>Creates corridors to eliminate isolated regions.</td>
+                            <td><code>main.js</code> lines 7534–7537</td>
+                        </tr>
+                        <tr>
+                            <td><code>ctx.structures.place(id, x, y, options)</code></td>
+                            <td>Places registered structures by pattern ID or inline definition.</td>
+                            <td><code>main.js</code> lines 7376–7416</td>
+                        </tr>
+                        <tr>
+                            <td><code>ctx.fixedMaps.apply(floor)</code></td>
+                            <td>Applies fixed layouts supplied by the add-on.</td>
+                            <td><code>main.js</code> lines 3203–3240</td>
+                        </tr>
+                        <tr>
+                            <td><code>ctx.setFloorColor(x, y, cssColor)</code></td>
+                            <td>Overrides floor colour. <code>setWallColor()</code> and <code>setFloorType()</code> are also available.</td>
+                            <td><code>main.js</code> lines 8911–8922</td>
+                        </tr>
+                        <tr>
+                            <td><code>ctx.setFloorType(x, y, type[, options])</code></td>
+                            <td>Configures floor behaviour. Valid <code>type</code> values:
+                                <code>'ice' | 'poison' | 'bomb' | 'conveyor' | 'one-way' | 'vertical' | 'horizontal'</code>. For conveyor and
+                                one-way floors, supply <code>options.direction</code> or call <code>ctx.setFloorDirection()</code> with
+                                <code>'up'|'down'|'left'|'right'</code>.</td>
+                            <td><code>main.js</code> lines 8924–8951</td>
+                        </tr>
+                        <tr>
+                            <td><code>ctx.setFloorDirection(x, y, dir)</code></td>
+                            <td>Sets the direction for conveyor or one-way floors (<code>dir</code> = <code>'up'|'down'|'left'|'right'</code>).</td>
+                            <td><code>main.js</code> lines 8952–8964</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+            <p>
+                Conveyor and one-way floors act as normal tiles if no direction is assigned. Vertical-only and horizontal-only floors
+                restrict movement to the specified axis, making them useful for directing players and enemies. When a dungeon’s
+                recommended level is five or more below the player, floor hazards are disabled automatically.
+            </p>
+            <p>
+                Each context provides <code>ctx.random</code>, a deterministic RNG. Use it instead of <code>Math.random()</code> to
+                keep generation reproducible.
+            </p>
+        </section>
     </main>
 </body>
 </html>

--- a/manual/en/reference-functions.html
+++ b/manual/en/reference-functions.html
@@ -3,26 +3,235 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>19. Function Reference (Translation in Progress)</title>
+    <title>19. Function Reference</title>
     <link rel="stylesheet" href="../manual.css">
 </head>
 <body>
     <main>
         <h1>19. Function Reference</h1>
         <p>
-            We are preparing an English mapping of important functions. Please refer to the Japanese list for now:
+            This chapter summarises the main functions—primarily from <code>main.js</code>—to serve as a reading roadmap when you
+            dive into the source.
         </p>
-        <ul>
-            <li><a href="../reference-functions.html" target="_blank" rel="noopener">Japanese chapter: Function Reference</a></li>
-        </ul>
-        <p>
-            The upcoming translation will include:
-        </p>
-        <ol>
-            <li>Function signatures and return values.</li>
-            <li>Dependencies between modules.</li>
-            <li>Examples for extending or overriding behaviour.</li>
-        </ol>
+        <section>
+            <h2>19.1 Screen Flow &amp; Layout</h2>
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Function</th>
+                            <th>Role</th>
+                            <th>Key Arguments</th>
+                            <th>Location</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><code>updateMapSize()</code></td>
+                            <td>Recomputes map width/height from depth and BlockDim size modifiers.</td>
+                            <td>—</td>
+                            <td><code>main.js</code> lines 456–474</td>
+                        </tr>
+                        <tr>
+                            <td><code>resizeCanvasToStage()</code></td>
+                            <td>Resizes the canvas to match the stage element for responsive rendering.</td>
+                            <td>—</td>
+                            <td><code>main.js</code> lines 477–483</td>
+                        </tr>
+                        <tr>
+                            <td><code>enterInGameLayout()</code> / <code>leaveInGameLayout()</code></td>
+                            <td>Applies layout classes when entering the game view, adjusts toolbar height, and cleans up afterward.</td>
+                            <td>—</td>
+                            <td><code>main.js</code> lines 505–522</td>
+                        </tr>
+                        <tr>
+                            <td><code>showSelectionScreen(opts)</code></td>
+                            <td>Common handler for returning from exploration to the selection screen. Refills HP and restores modes.</td>
+                            <td><code>opts.stopLoop</code>, <code>opts.refillHp</code>, etc.</td>
+                            <td><code>main.js</code> lines 538–571</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+        <section>
+            <h2>19.2 BlockDim UI &amp; Selection</h2>
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Function</th>
+                            <th>Role</th>
+                            <th>Notes</th>
+                            <th>Location</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><code>initBlockDimUI()</code></td>
+                            <td>Initialises the BlockDim tab—renders lists and sets up keyboard handling.</td>
+                            <td>Restores the previous selection and calls <code>renderHistoryAndBookmarks()</code>.</td>
+                            <td><code>main.js</code> lines 1095–1121</td>
+                        </tr>
+                        <tr>
+                            <td><code>onBlockDimChanged()</code></td>
+                            <td>Rebuilds the spec and refreshes the preview when lists or the NESTED value change.</td>
+                            <td>Works with <code>composeSpec()</code> and <code>seedFromSelection()</code>.</td>
+                            <td><code>main.js</code> lines 1123–1148</td>
+                        </tr>
+                        <tr>
+                            <td><code>randomizeBdimBlocks()</code></td>
+                            <td>Randomly picks 1st/2nd/3rd blocks and updates the preview immediately.</td>
+                            <td>Supports the <code>preserveScroll</code> option to keep list position.</td>
+                            <td><code>main.js</code> lines 1150–1168</td>
+                        </tr>
+                        <tr>
+                            <td><code>weightedRandomizeBdimBlocks(target, type)</code></td>
+                            <td>Performs weighted random selection based on total level and preferred type.</td>
+                            <td>Uses Gaussian weighting and up to 64 trials to find a candidate.</td>
+                            <td><code>main.js</code> lines 1171–1233</td>
+                        </tr>
+                        <tr>
+                            <td><code>renderHistoryAndBookmarks()</code></td>
+                            <td>Draws the history/bookmark lists, binding events for reuse and deletion.</td>
+                            <td>Limits visible rows via <code>setScrollableList()</code>.</td>
+                            <td><code>main.js</code> lines 1250–1300</td>
+                        </tr>
+                        <tr>
+                            <td><code>applyBdimSelection(entry)</code></td>
+                            <td>Applies a saved preset to the UI and triggers <code>onBlockDimChanged()</code>.</td>
+                            <td>Shared by both history and bookmarks.</td>
+                            <td><code>main.js</code> lines 1325–1333</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+        <section>
+            <h2>19.3 MiniExp UI &amp; Lifecycle</h2>
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Function</th>
+                            <th>Role</th>
+                            <th>Notes</th>
+                            <th>Location</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><code>renderMiniExpCategories(manifest)</code></td>
+                            <td>Generates category buttons and manages selection state.</td>
+                            <td>Automatically deselects games not in the active category.</td>
+                            <td><code>main.js</code> lines 6534–6562</td>
+                        </tr>
+                        <tr>
+                            <td><code>renderMiniExpList(manifest)</code></td>
+                            <td>Switches between card/list layouts based on the view mode and wires up selection.</td>
+                            <td>Works with category filters and invokes <code>renderMiniExpRecords()</code>.</td>
+                            <td><code>main.js</code> lines 6571–6620</td>
+                        </tr>
+                        <tr>
+                            <td><code>initMiniExpUI()</code></td>
+                            <td>Initialises the manifest and renders categories, lists, and placeholders.</td>
+                            <td>Updates the placeholder instantly when a game is preselected.</td>
+                            <td><code>main.js</code> lines 6622–6642</td>
+                        </tr>
+                        <tr>
+                            <td><code>startSelectedMiniGame()</code></td>
+                            <td>Loads the selected MiniExp module and starts its runtime.</td>
+                            <td>Validates the <code>create()</code> return value, resets buttons and shortcuts.</td>
+                            <td><code>main.js</code> lines 6829–6861</td>
+                        </tr>
+                        <tr>
+                            <td><code>quitMiniGame()</code></td>
+                            <td>Handles shutdown (<code>stop()</code> → <code>getScore()</code> → <code>destroy()</code>) and updates records.</td>
+                            <td>Resets UI state and refreshes EXP badges and records.</td>
+                            <td><code>main.js</code> lines 6863–6905</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+        <section>
+            <h2>19.4 Mod Maker Helpers</h2>
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Function</th>
+                            <th>Role</th>
+                            <th>Related Work</th>
+                            <th>Location</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><code>renderModMaker()</code></td>
+                            <td>Renders the entire module UI and syncs metadata, structures, and generators.</td>
+                            <td>Calls <code>ensureModMakerDefaults()</code>, <code>renderStructureGrid()</code>,
+                                <code>buildModMakerOutput()</code>.</td>
+                            <td><code>main.js</code> lines 2404–2529</td>
+                        </tr>
+                        <tr>
+                            <td><code>buildModMakerOutput()</code></td>
+                            <td>Builds JSON compatible with <code>registerDungeonAddon()</code> and validates it.</td>
+                            <td>Checks for duplicate structure IDs and anchor ranges.</td>
+                            <td><code>main.js</code> lines 2532–2555</td>
+                        </tr>
+                        <tr>
+                            <td><code>createBlockField(label, value, onChange, options)</code></td>
+                            <td>Generates form elements that re-render the UI automatically on change.</td>
+                            <td>Supports <code>options.multiline</code> and <code>options.deferRender</code>.</td>
+                            <td><code>main.js</code> lines 2381–2402</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+        <section id="domain-and-badge-hooks">
+            <h2>19.5 Domain Effects &amp; Badge Hooks</h2>
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Target</th>
+                            <th>Role</th>
+                            <th>Adjustment Tips</th>
+                            <th>Location</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><code>DOMAIN_EFFECT_DEFINITIONS</code></td>
+                            <td>Configuration for domain crystal icons, colours, damage modifiers, and status effects.</td>
+                            <td>Edit multipliers or flags such as <code>reverseDamage</code> and <code>allowPotionThrow</code> to customise behaviour.</td>
+                            <td><code>main.js</code> lines 4851–5004</td>
+                        </tr>
+                        <tr>
+                            <td><code>getDomainEffectAggregate(targetType, x, y)</code></td>
+                            <td>Combines overlapping domain crystals to calculate attack/defence modifiers and status auras.</td>
+                            <td>Modify radius or aggregation logic as needed. Returns values including <code>allowPotionThrow</code>
+                                and <code>statusAilments</code>.</td>
+                            <td><code>main.js</code> lines 5179–5287</td>
+                        </tr>
+                        <tr>
+                            <td><code>refreshGeneratorHazardSuppression()</code></td>
+                            <td>Evaluates suppression thresholds for darkness, poison mist, and noise, updating UI state.</td>
+                            <td>Adjust level thresholds or behaviour; call <code>updateDungeonTypeOverlay()</code> afterward.</td>
+                            <td><code>main.js</code> lines 6764–6788</td>
+                        </tr>
+                        <tr>
+                            <td><code>updateDungeonTypeOverlay()</code></td>
+                            <td>Renders the top-right dungeon overlay with hazard and generator badges.</td>
+                            <td>Edit labels or CSS classes here. Suppression uses the <code>dungeon-overlay__badge--suppressed</code> class.</td>
+                            <td><code>main.js</code> lines 6940–7042</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
     </main>
 </body>
 </html>

--- a/manual/en/reference-minigames.html
+++ b/manual/en/reference-minigames.html
@@ -3,27 +3,756 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>20. MiniExp Module Catalog (Translation in Progress)</title>
+    <title>20. MiniExp Module Catalog</title>
     <link rel="stylesheet" href="../manual.css">
 </head>
 <body>
     <main>
         <h1>20. MiniExp Module Catalog</h1>
-        <p>
-            The English catalogue of MiniExp modules and data entries is under development. For complete schema
-            definitions, consult the Japanese documentation:
-        </p>
-        <ul>
-            <li><a href="../reference-minigames.html" target="_blank" rel="noopener">Japanese chapter: MiniExp Modules</a></li>
-        </ul>
-        <p>
-            The translated edition will provide:
-        </p>
-        <ol>
-            <li>Module summaries and dependencies.</li>
-            <li>Configuration examples and default parameter values.</li>
-            <li>Advice on creating original MiniExp integrations.</li>
-        </ol>
+        <section>
+            <h2>20.1 Manifest Overview</h2>
+            <p>
+                MiniExp module metadata is supplied through <code>games/manifest.json.js</code>. Inside
+                <code>loadMiniManifestOnce()</code>, <code>main.js</code> loads the manifest using the following priority:
+            </p>
+            <ol>
+                <li>If <code>window.MINIEXP_MANIFEST</code> already exists, use it.</li>
+                <li>Load <code>games/manifest.json.js</code> as a script (works for <code>file://</code> environments).</li>
+                <li>On HTTP servers, fetch <code>games/manifest.json</code>.</li>
+                <li>If all methods fail, fall back to the built-in array bundled with the source.</li>
+            </ol>
+            <p class="small-note">See <code>main.js</code> lines 6439–6491 for the implementation. Each module defines its ID,
+                name, entry file, version, category, and EXP rules.</p>
+        </section>
+        <section>
+            <h2>20.2 Modules by Category</h2>
+            <p>All bundled MiniExp mods are grouped below. IDs match the values passed to <code>registerMiniGame()</code>; load the
+                script listed in the Entry column to mount the module.</p>
+        </section>
+        <!-- CATEGORY: Action -->
+        <section>
+            <h3>Action</h3>
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Name</th>
+                            <th>Version</th>
+                            <th>Entry</th>
+                            <th>Author</th>
+                            <th>Highlights / EXP Rules</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><code>topdown_race</code></td>
+                            <td>Aurora Circuit</td>
+                            <td>0.1.0</td>
+                            <td><code>games/topdown_race.js</code></td>
+                            <td>mod</td>
+                            <td>Top-down circuit racer. Earn EXP from lap times and placement.</td>
+                        </tr>
+                        <tr>
+                            <td><code>pinball_xp</code></td>
+                            <td>XP Pinball</td>
+                            <td>0.1.0</td>
+                            <td><code>games/pinball.js</code></td>
+                            <td>mod</td>
+                            <td>3D-inspired pinball table—bumpers and lanes grant EXP.</td>
+                        </tr>
+                        <tr>
+                            <td><code>steady_wire</code></td>
+                            <td>Steady Wire</td>
+                            <td>0.1.0</td>
+                            <td><code>games/steady_wire.js</code></td>
+                            <td>mod</td>
+                            <td>A new course every run. Reach the goal without leaving the wire loop.</td>
+                        </tr>
+                        <tr>
+                            <td><code>snake</code></td>
+                            <td>Snake</td>
+                            <td>0.1.0</td>
+                            <td><code>games/snake.js</code></td>
+                            <td>builtin</td>
+                            <td>Gain +1 EXP for each piece of food.</td>
+                        </tr>
+                        <tr>
+                            <td><code>dino_runner</code></td>
+                            <td>Dino Runner</td>
+                            <td>0.1.0</td>
+                            <td><code>games/dino_runner.js</code></td>
+                            <td>mod</td>
+                            <td>Jump obstacles as a dinosaur—distance grants EXP.</td>
+                        </tr>
+                        <tr>
+                            <td><code>pseudo3d_race</code></td>
+                            <td>Highway Chaser</td>
+                            <td>0.1.0</td>
+                            <td><code>games/pseudo3d_race.js</code></td>
+                            <td>mod</td>
+                            <td>Pass traffic on a pseudo-3D highway. Distance +0.5, overtakes +4, section clears +25.</td>
+                        </tr>
+                        <tr>
+                            <td><code>pacman</code></td>
+                            <td>Pac-Man Tribute</td>
+                            <td>0.1.0</td>
+                            <td><code>games/pacman.js</code></td>
+                            <td>builtin</td>
+                            <td>Pellets +0.5 EXP; clear the board for +100.</td>
+                        </tr>
+                        <tr>
+                            <td><code>pong</code></td>
+                            <td>Pong</td>
+                            <td>0.1.0</td>
+                            <td><code>games/pong.js</code></td>
+                            <td>builtin</td>
+                            <td>Match win EXP: EASY +1 / NORMAL +5 / HARD +25.</td>
+                        </tr>
+                        <tr>
+                            <td><code>flappy_bird</code></td>
+                            <td>Flappy-style</td>
+                            <td>0.1.0</td>
+                            <td><code>games/flappy_bird.js</code></td>
+                            <td>mod</td>
+                            <td>Earn EXP for each pipe; streaks add bonuses.</td>
+                        </tr>
+                        <tr>
+                            <td><code>breakout</code></td>
+                            <td>Breakout</td>
+                            <td>0.1.0</td>
+                            <td><code>games/breakout.js</code></td>
+                            <td>builtin</td>
+                            <td>+1 EXP per brick destroyed.</td>
+                        </tr>
+                        <tr>
+                            <td><code>breakout_k</code></td>
+                            <td>Breakout (Keyboard)</td>
+                            <td>0.1.0</td>
+                            <td><code>games/breakout_keyboard.js</code></td>
+                            <td>builtin</td>
+                            <td>Keyboard-only paddle controls.</td>
+                        </tr>
+                        <tr>
+                            <td><code>whack_a_mole</code></td>
+                            <td>Whack-a-Mole</td>
+                            <td>0.1.0</td>
+                            <td><code>games/whack_a_mole.js</code></td>
+                            <td>builtin</td>
+                            <td>Hits award EXP; streaks add bonuses.</td>
+                        </tr>
+                        <tr>
+                            <td><code>dodge_race</code></td>
+                            <td>Dodge Race</td>
+                            <td>0.1.0</td>
+                            <td><code>games/dodge_race.js</code></td>
+                            <td>builtin</td>
+                            <td>Gain small EXP from distance, +5 per checkpoint.</td>
+                        </tr>
+                        <tr>
+                            <td><code>river_crossing</code></td>
+                            <td>River Crossing</td>
+                            <td>0.1.0</td>
+                            <td><code>games/river_crossing.js</code></td>
+                            <td>builtin</td>
+                            <td>+1 per step, +50 on arrival.</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+        <!-- CATEGORY: Gambling -->
+        <section>
+            <h3>Gambling</h3>
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Name</th>
+                            <th>Version</th>
+                            <th>Entry</th>
+                            <th>Author</th>
+                            <th>Highlights / EXP Rules</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><code>gamble_hall</code></td>
+                            <td>Gamble Hall</td>
+                            <td>0.1.0</td>
+                            <td><code>games/gamble_hall.js</code></td>
+                            <td>mod</td>
+                            <td>Combo of EXP roulette and pachinko slot mini-games.</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+        <!-- CATEGORY: Shooting -->
+        <section>
+            <h3>Shooting</h3>
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Name</th>
+                            <th>Version</th>
+                            <th>Entry</th>
+                            <th>Author</th>
+                            <th>Highlights / EXP Rules</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><code>invaders</code></td>
+                            <td>Invader-style</td>
+                            <td>0.1.0</td>
+                            <td><code>games/invaders.js</code></td>
+                            <td>builtin</td>
+                            <td>+1 per enemy, +50 for clearing the wave.</td>
+                        </tr>
+                        <tr>
+                            <td><code>aim</code></td>
+                            <td>Target Practice</td>
+                            <td>0.1.0</td>
+                            <td><code>games/aim.js</code></td>
+                            <td>builtin</td>
+                            <td>1–3 EXP per hit plus streak bonuses.</td>
+                        </tr>
+                        <tr>
+                            <td><code>falling_shooter</code></td>
+                            <td>Falling Shooter</td>
+                            <td>0.1.0</td>
+                            <td><code>games/falling_shooter.js</code></td>
+                            <td>builtin</td>
+                            <td>Larger blocks grant more EXP when destroyed.</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+        <!-- CATEGORY: Skill -->
+        <section>
+            <h3>Skill</h3>
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Name</th>
+                            <th>Version</th>
+                            <th>Entry</th>
+                            <th>Author</th>
+                            <th>Highlights / EXP Rules</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><code>typing</code></td>
+                            <td>Typing Challenge</td>
+                            <td>0.1.0</td>
+                            <td><code>games/typing.js</code></td>
+                            <td>mod</td>
+                            <td>60-second typing test scored on accuracy and speed.</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+        <!-- CATEGORY: Toy -->
+        <section>
+            <h3>Toy</h3>
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Name</th>
+                            <th>Version</th>
+                            <th>Entry</th>
+                            <th>Author</th>
+                            <th>Highlights / EXP Rules</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><code>graphics_tester</code></td>
+                            <td>3D Graphics Tester</td>
+                            <td>0.1.0</td>
+                            <td><code>games/graphics_tester.js</code></td>
+                            <td>mod</td>
+                            <td>Tech demo with ray-tracing-style rendering benchmarks.</td>
+                        </tr>
+                        <tr>
+                            <td><code>memo_studio</code></td>
+                            <td>Memory Studio</td>
+                            <td>0.1.0</td>
+                            <td><code>games/memory_app.js</code></td>
+                            <td>mod</td>
+                            <td>Flashcard trainer with spaced repetition.</td>
+                        </tr>
+                        <tr>
+                            <td><code>electro_instrument</code></td>
+                            <td>Electro Instrument Studio</td>
+                            <td>0.1.0</td>
+                            <td><code>games/electro_instrument.js</code></td>
+                            <td>mod</td>
+                            <td>Play a piano keyboard with multiple timbres—notes award EXP.</td>
+                        </tr>
+                        <tr>
+                            <td><code>physics_sandbox</code></td>
+                            <td>Physics Sandbox</td>
+                            <td>0.1.0</td>
+                            <td><code>games/physics_sandbox.js</code></td>
+                            <td>mod</td>
+                            <td>Combine fire, water, vines, lightning, and circuits in a toy sandbox.</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+        <!-- CATEGORY: Puzzle -->
+        <section>
+            <h3>Puzzle</h3>
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Name</th>
+                            <th>Version</th>
+                            <th>Entry</th>
+                            <th>Author</th>
+                            <th>Highlights / EXP Rules</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><code>ten_ten</code></td>
+                            <td>1010 Puzzle</td>
+                            <td>0.1.0</td>
+                            <td><code>games/ten_ten.js</code></td>
+                            <td>builtin</td>
+                            <td>EXP per line; cross clears double the reward.</td>
+                        </tr>
+                        <tr>
+                            <td><code>game2048</code></td>
+                            <td>2048</td>
+                            <td>0.1.0</td>
+                            <td><code>games/2048.js</code></td>
+                            <td>builtin</td>
+                            <td>EXP equals the log2 of merges; reaching 2048 grants +777.</td>
+                        </tr>
+                        <tr>
+                            <td><code>sliding_puzzle</code></td>
+                            <td>Sliding Puzzle</td>
+                            <td>0.1.0</td>
+                            <td><code>games/sliding_puzzle.js</code></td>
+                            <td>mod</td>
+                            <td>Supports 8/15/24-tile boards based on difficulty.</td>
+                        </tr>
+                        <tr>
+                            <td><code>same</code></td>
+                            <td>SameGame</td>
+                            <td>0.1.0</td>
+                            <td><code>games/same.js</code></td>
+                            <td>builtin</td>
+                            <td>Group clears ×0.5 EXP.</td>
+                        </tr>
+                        <tr>
+                            <td><code>tetris</code></td>
+                            <td>Tetris-style</td>
+                            <td>0.1.0</td>
+                            <td><code>games/tetris.js</code></td>
+                            <td>builtin</td>
+                            <td>REN × 1.5ⁿ and T-Spin bonuses.</td>
+                        </tr>
+                        <tr>
+                            <td><code>triomino_columns</code></td>
+                            <td>Triomino Columns</td>
+                            <td>0.1.0</td>
+                            <td><code>games/triomino_columns.js</code></td>
+                            <td>mod</td>
+                            <td>Inspired by Trio Toss DX—line sparks and hold support.</td>
+                        </tr>
+                        <tr>
+                            <td><code>sudoku</code></td>
+                            <td>Sudoku</td>
+                            <td>0.1.0</td>
+                            <td><code>games/sudoku.js</code></td>
+                            <td>mod</td>
+                            <td>Earn EXP per correct entry plus a clear bonus.</td>
+                        </tr>
+                        <tr>
+                            <td><code>bubble_shooter</code></td>
+                            <td>Bubble Shooter</td>
+                            <td>0.1.0</td>
+                            <td><code>games/bubble_shooter.js</code></td>
+                            <td>mod</td>
+                            <td>Shoot bubbles to match three; floating bubbles drop as a group.</td>
+                        </tr>
+                        <tr>
+                            <td><code>falling_puyos</code></td>
+                            <td>Puyo-style</td>
+                            <td>0.1.0</td>
+                            <td><code>games/puyo.js</code></td>
+                            <td>mod</td>
+                            <td>Match four of the same colour; chains multiply the payout.</td>
+                        </tr>
+                        <tr>
+                            <td><code>minesweeper</code></td>
+                            <td>Minesweeper</td>
+                            <td>0.1.0</td>
+                            <td><code>games/minesweeper.js</code></td>
+                            <td>builtin</td>
+                            <td>Tiles opened ×0.1; clear bonus 25/200/1600 depending on size.</td>
+                        </tr>
+                        <tr>
+                            <td><code>match3</code></td>
+                            <td>Match-3</td>
+                            <td>0.1.0</td>
+                            <td><code>games/match3.js</code></td>
+                            <td>builtin</td>
+                            <td>Three: +1, four: +3, five: +10; combos ×1.5.</td>
+                        </tr>
+                        <tr>
+                            <td><code>calc_combo</code></td>
+                            <td>Calc Combo</td>
+                            <td>0.1.0</td>
+                            <td><code>games/calc_combo.js</code></td>
+                            <td>mod</td>
+                            <td>Rapid-fire arithmetic up to two digits—maintain combos for EXP.</td>
+                        </tr>
+                        <tr>
+                            <td><code>sichuan</code></td>
+                            <td>Sichuan Puzzle</td>
+                            <td>0.1.0</td>
+                            <td><code>games/sichuan.js</code></td>
+                            <td>mod</td>
+                            <td>Connect matching mahjong tiles; chain clears add bonus EXP.</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+        <!-- CATEGORY: Board -->
+        <section>
+            <h3>Board</h3>
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Name</th>
+                            <th>Version</th>
+                            <th>Entry</th>
+                            <th>Author</th>
+                            <th>Highlights / EXP Rules</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><code>othello</code></td>
+                            <td>Othello</td>
+                            <td>0.1.0</td>
+                            <td><code>games/othello.js</code></td>
+                            <td>builtin</td>
+                            <td>Flips ×0.5 plus a win bonus.</td>
+                        </tr>
+                        <tr>
+                            <td><code>connect6</code></td>
+                            <td>Connect Six</td>
+                            <td>0.1.0</td>
+                            <td><code>games/stone_board_games.js</code></td>
+                            <td>mod</td>
+                            <td>Place +1, threat +10, victory grants high EXP.</td>
+                        </tr>
+                        <tr>
+                            <td><code>xiangqi</code></td>
+                            <td>Xiangqi</td>
+                            <td>0.1.0</td>
+                            <td><code>games/xiangqi.js</code></td>
+                            <td>mod</td>
+                            <td>Capture pieces, deliver checks, and mate for rewards.</td>
+                        </tr>
+                        <tr>
+                            <td><code>ultimate_ttt</code></td>
+                            <td>Ultimate Tic-Tac-Toe</td>
+                            <td>0.1.0</td>
+                            <td><code>games/ultimate_ttt.js</code></td>
+                            <td>mod</td>
+                            <td>Small-board wins +25; placements +1; threats +10; big-board victory bonus.</td>
+                        </tr>
+                        <tr>
+                            <td><code>chess</code></td>
+                            <td>Chess</td>
+                            <td>0.1.0</td>
+                            <td><code>games/chess.js</code></td>
+                            <td>mod</td>
+                            <td>Classic chess with EXP for captures and checks.</td>
+                        </tr>
+                        <tr>
+                            <td><code>checkers</code></td>
+                            <td>Checkers</td>
+                            <td>0.1.0</td>
+                            <td><code>games/checkers.js</code></td>
+                            <td>mod</td>
+                            <td>Jump captures and crown promotions award EXP.</td>
+                        </tr>
+                        <tr>
+                            <td><code>trump_games</code></td>
+                            <td>Card Selection</td>
+                            <td>0.1.0</td>
+                            <td><code>games/trump_games.js</code></td>
+                            <td>mod</td>
+                            <td>Hub for memory, blackjack, and old maid.</td>
+                        </tr>
+                        <tr>
+                            <td><code>go</code></td>
+                            <td>Go</td>
+                            <td>0.1.0</td>
+                            <td><code>games/go.js</code></td>
+                            <td>mod</td>
+                            <td>Placement +1, capture bonuses, victory EXP.</td>
+                        </tr>
+                        <tr>
+                            <td><code>gomoku</code></td>
+                            <td>Gomoku</td>
+                            <td>0.1.0</td>
+                            <td><code>games/stone_board_games.js</code></td>
+                            <td>mod</td>
+                            <td>Placement +1, threat +10, win bonus.</td>
+                        </tr>
+                        <tr>
+                            <td><code>tic_tac_toe</code></td>
+                            <td>Tic-Tac-Toe</td>
+                            <td>0.1.0</td>
+                            <td><code>games/stone_board_games.js</code></td>
+                            <td>mod</td>
+                            <td>Placement +1, threat +10, simple win bonus.</td>
+                        </tr>
+                        <tr>
+                            <td><code>mancala</code></td>
+                            <td>Mancala</td>
+                            <td>0.1.0</td>
+                            <td><code>games/mancala.js</code></td>
+                            <td>mod</td>
+                            <td>Kalah-style mancala with sowing, captures, and margin-based EXP.</td>
+                        </tr>
+                        <tr>
+                            <td><code>connect4</code></td>
+                            <td>Connect Four</td>
+                            <td>0.1.0</td>
+                            <td><code>games/stone_board_games.js</code></td>
+                            <td>mod</td>
+                            <td>Drop +1, threat +10.</td>
+                        </tr>
+                        <tr>
+                            <td><code>shogi</code></td>
+                            <td>Shogi</td>
+                            <td>0.1.0</td>
+                            <td><code>games/shogi.js</code></td>
+                            <td>mod</td>
+                            <td>Traditional shogi—captures, promotions, and checks provide EXP.</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+        <!-- CATEGORY: Utility -->
+        <section>
+            <h3>Utility</h3>
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Name</th>
+                            <th>Version</th>
+                            <th>Entry</th>
+                            <th>Author</th>
+                            <th>Highlights / EXP Rules</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><code>tester</code></td>
+                            <td>JS Tester</td>
+                            <td>0.1.0</td>
+                            <td><code>games/tester.js</code></td>
+                            <td>mod</td>
+                            <td>CPU benchmarks and block-adventure prototyping tools.</td>
+                        </tr>
+                        <tr>
+                            <td><code>todo_list</code></td>
+                            <td>To-do List</td>
+                            <td>0.1.0</td>
+                            <td><code>games/todo_list.js</code></td>
+                            <td>mod</td>
+                            <td>Earn configured EXP by completing tasks.</td>
+                        </tr>
+                        <tr>
+                            <td><code>wording</code></td>
+                            <td>Wording</td>
+                            <td>0.1.0</td>
+                            <td><code>games/wording.js</code></td>
+                            <td>mod</td>
+                            <td>Word processor: edit +1, format +2, save +6 EXP.</td>
+                        </tr>
+                        <tr>
+                            <td><code>counter_pad</code></td>
+                            <td>Counter Pad</td>
+                            <td>0.1.0</td>
+                            <td><code>games/counter.js</code></td>
+                            <td>mod</td>
+                            <td>Multi-counter that auto-saves adjustments.</td>
+                        </tr>
+                        <tr>
+                            <td><code>system</code></td>
+                            <td>System Info</td>
+                            <td>0.1.0</td>
+                            <td><code>games/system.js</code></td>
+                            <td>mod</td>
+                            <td>Inspect PC, OS, browser, and IP data.</td>
+                        </tr>
+                        <tr>
+                            <td><code>stopwatch</code></td>
+                            <td>Stopwatch</td>
+                            <td>0.1.0</td>
+                            <td><code>games/stopwatch.js</code></td>
+                            <td>mod</td>
+                            <td>Lap tracking with EXP for operations.</td>
+                        </tr>
+                        <tr>
+                            <td><code>diagram_maker</code></td>
+                            <td>Diagram Maker</td>
+                            <td>0.1.0</td>
+                            <td><code>games/diagram_maker.js</code></td>
+                            <td>mod</td>
+                            <td>Exports draw.io XML and PNG/JPG/BMP diagrams.</td>
+                        </tr>
+                        <tr>
+                            <td><code>timer</code></td>
+                            <td>Timer</td>
+                            <td>0.1.0</td>
+                            <td><code>games/timer.js</code></td>
+                            <td>mod</td>
+                            <td>Countdown and stopwatch modes for time management.</td>
+                        </tr>
+                        <tr>
+                            <td><code>blockcode</code></td>
+                            <td>Blockcode Lab</td>
+                            <td>0.1.0</td>
+                            <td><code>games/blockcode.js</code></td>
+                            <td>mod</td>
+                            <td>Scratch-like visual programming environment for MiniExp APIs.</td>
+                        </tr>
+                        <tr>
+                            <td><code>paint</code></td>
+                            <td>Paint</td>
+                            <td>0.1.0</td>
+                            <td><code>games/paint.js</code></td>
+                            <td>mod</td>
+                            <td>Draw +1, fill +3, save +8 EXP.</td>
+                        </tr>
+                        <tr>
+                            <td><code>pomodoro</code></td>
+                            <td>Pomodoro Timer</td>
+                            <td>0.1.0</td>
+                            <td><code>games/pomodoro.js</code></td>
+                            <td>mod</td>
+                            <td>Gain EXP each time you complete a focus/break cycle.</td>
+                        </tr>
+                        <tr>
+                            <td><code>music_player</code></td>
+                            <td>Music Player</td>
+                            <td>0.1.0</td>
+                            <td><code>games/music_player.js</code></td>
+                            <td>mod</td>
+                            <td>Play local audio with visualisers and EQ; playback/import grant EXP.</td>
+                        </tr>
+                        <tr>
+                            <td><code>notepad</code></td>
+                            <td>Notepad</td>
+                            <td>0.1.0</td>
+                            <td><code>games/notepad.js</code></td>
+                            <td>mod</td>
+                            <td>Open +5, edit +1, save +5 EXP.</td>
+                        </tr>
+                        <tr>
+                            <td><code>clock_hub</code></td>
+                            <td>Clock Hub</td>
+                            <td>0.1.0</td>
+                            <td><code>games/clock_hub.js</code></td>
+                            <td>mod</td>
+                            <td>Multiple clocks and time info with milestone EXP.</td>
+                        </tr>
+                        <tr>
+                            <td><code>math_lab</code></td>
+                            <td>Math Lab</td>
+                            <td>0.1.0</td>
+                            <td><code>games/math_lab.js</code></td>
+                            <td>mod</td>
+                            <td>Advanced functions, conversions, graphs, and tetration tools.</td>
+                        </tr>
+                        <tr>
+                            <td><code>calculator</code></td>
+                            <td>Calculator</td>
+                            <td>0.1.0</td>
+                            <td><code>games/calculator.js</code></td>
+                            <td>mod</td>
+                            <td>Utility calculator: number entry +1, confirmed calculation +5 EXP.</td>
+                        </tr>
+                        <tr>
+                            <td><code>video_player</code></td>
+                            <td>Video Player</td>
+                            <td>0.1.0</td>
+                            <td><code>games/video_player.js</code></td>
+                            <td>mod</td>
+                            <td>Watch local files and YouTube videos to earn EXP.</td>
+                        </tr>
+                        <tr>
+                            <td><code>exceler</code></td>
+                            <td>Exceler Spreadsheet</td>
+                            <td>0.1.0</td>
+                            <td><code>games/exceler.js</code></td>
+                            <td>mod</td>
+                            <td>Lightweight spreadsheet with XLSX import/export and core functions.</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+        <!-- CATEGORY: Rhythm -->
+        <section>
+            <h3>Rhythm</h3>
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Name</th>
+                            <th>Version</th>
+                            <th>Entry</th>
+                            <th>Author</th>
+                            <th>Highlights / EXP Rules</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><code>piano_tiles</code></td>
+                            <td>Rhythm Tiles</td>
+                            <td>0.1.0</td>
+                            <td><code>games/piano_tiles.js</code></td>
+                            <td>mod</td>
+                            <td>Four-lane piano tile charts with taps and holds—build combos for more EXP.</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
     </main>
 </body>
 </html>

--- a/manual/en/ui.html
+++ b/manual/en/ui.html
@@ -3,27 +3,131 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>6. Screen Layout & Controls (Translation in Progress)</title>
+    <title>6. Screen Layout &amp; Controls</title>
     <link rel="stylesheet" href="../manual.css">
 </head>
 <body>
     <main>
-        <h1>6. Screen Layout & Controls</h1>
-        <p>
-            The full English translation for this chapter is currently in progress. You can consult the original Japanese
-            version for complete details:
-        </p>
-        <ul>
-            <li><a href="../ui.html" target="_blank" rel="noopener">Open Japanese chapter in a new tab</a></li>
-        </ul>
-        <p>
-            Planned coverage for the English edition:
-        </p>
-        <ol>
-            <li>Breakdown of each interface section and tooltip.</li>
-            <li>Keyboard, mouse, and touch input reference tables.</li>
-            <li>Accessibility tips and layout customisation pointers.</li>
-        </ol>
+        <h1>6. Screen Layout &amp; Controls</h1>
+        <section>
+            <h2>6.1 Title Screen</h2>
+            <p>
+                The top of the title screen shows the game logo and a large selection card. Use the card to choose the
+                <strong>difficulty</strong>, <strong>world</strong>, and <strong>dungeon</strong> in that order before you begin your
+                run.
+            </p>
+        </section>
+        <section>
+            <h2>6.2 Tab Overview</h2>
+            <ul>
+                <li><strong>Standard:</strong> Pick from the regular catalogue of dungeons.</li>
+                <li><strong>Block Dimension:</strong> Assemble dungeons from multiple block presets.</li>
+                <li><strong>MiniExp:</strong> Review the elements you have unlocked through mini-games.</li>
+                <li><strong>Tools:</strong> Open supporting utilities for developers and testers.</li>
+            </ul>
+        </section>
+        <section>
+            <h2>6.3 Dungeon Detail Card</h2>
+            <p>
+                After you select a world and dungeon, a detail card appears on the right. It lists the damage multiplier,
+                recommended level, and a short description. When you are ready, press <strong>Enter Dungeon</strong> to start
+                exploring.
+            </p>
+        </section>
+        <section>
+            <h2>6.4 Block Dimension Screen</h2>
+            <p>
+                The Block Dimension tab lets you type a <strong>NESTED</strong> value and choose blocks from several lists.
+                Your selections appear in the preview panel at the bottom. When you are unsure which layout to try, use the
+                randomise button to shuffle the candidates.
+            </p>
+        </section>
+        <section>
+            <h2>6.5 Exploration Toolbar</h2>
+            <p>
+                The exploration screen displays a toolbar across the top. From left to right the buttons are
+                <em>Return</em>, <em>Items</em>, <em>Skills</em>, <em>Status</em>, <em>Import</em>, and <em>Export</em>.
+                Once the SP system is unlocked, the <strong>Skills</strong> button lights up and opens a panel where you can
+                check your current SP and skill list. On mobile the toolbar supports horizontal scrolling—swipe left or right
+                if you cannot see a button you need.
+            </p>
+            <ul>
+                <li><strong>Skills button:</strong> Opens and closes the skill modal. Use it to review available skills, the
+                    remaining SP, and active durations.</li>
+                <li><strong>Items button:</strong> Opens the item modal for consuming or offering healing and enhancement items.
+                    The auto-item toggle in the top-right corner of the modal enables automatic use of the configured
+                    potion or food whenever the conditions are met.</li>
+                <li><strong>Status button:</strong> Shows your current attributes, status ailments, and active skill effects.
+                    The card overlay indicates whether auto-use is on or off so that you can confirm the configuration during
+                    a run.</li>
+            </ul>
+        </section>
+        <section>
+            <h2>6.6 Status Card and SP / Satiety Bars</h2>
+            <p>
+                The card on the left-hand side of the exploration screen displays your core stats—HP, experience, attack, and
+                defence—alongside the SP gauge unlocked at level 100 and the satiety gauge that appears in dungeons with a
+                recommended level of 300 or higher. The SP bar is purple, the satiety bar is yellow, and both shrink as the
+                value decreases. Their numerical values are shown at the bottom of the card.
+            </p>
+            <p>
+                You gain SP by moving, defeating enemies, earning MiniExp rewards, or offering recovery items. The maximum SP
+                is 100 at level 100, 150 at level 250, 200 at level 500, and increases by 50 every additional 500 levels. The
+                satiety gauge decreases by 1 each turn. When it reaches 0 you take hunger damage based on your maximum HP. If
+                you enable auto-use from the status modal, configured potions automatically switch to the “Eat” action and
+                keep you topped up once the gauge falls below the threshold.
+            </p>
+            <p>
+                Both the status card and the status modal display <strong>status badges</strong> for domain crystals, skill
+                effects, and ailments. The badge colour and icon are consistent—for example, <code>ATK↑</code> indicates an
+                attack buff and <code>⇆</code> denotes damage inversion. Multiple badges are shown in the order the effects
+                were applied, making it easier to decide which one to cleanse first.
+            </p>
+            <p>
+                The <strong>Dungeon Overlay</strong> in the top-right corner shows hazard badges. When darkness, poison mist,
+                or noise are active the overlay lights up with a dedicated label. If you tackle a dungeon at least five levels
+                above the recommendation, the label adds “(Suppressed)” and the badge becomes semi-transparent. Visual glitch
+                effects only occur while the noise hazard is active and end immediately once suppression succeeds.
+            </p>
+        </section>
+        <section>
+            <h2>6.7 Keyboard Shortcuts</h2>
+            <ul>
+                <li><strong>Tab:</strong> Move between input fields.</li>
+                <li><strong>Enter:</strong> Activate the focused button.</li>
+                <li><strong>Esc:</strong> Close the current dialog if it supports keyboard dismissal.</li>
+            </ul>
+        </section>
+        <section>
+            <h2>6.8 Accessibility Notes</h2>
+            <p>
+                All buttons and lists are fully keyboard-accessible and include ARIA attributes for screen-reader support.
+                When customising the style, make sure the contrast ratio and focus outlines remain easy to distinguish.
+            </p>
+        </section>
+        <section id="result-overlay">
+            <h2>6.9 Result Overlay</h2>
+            <p>
+                When a run ends, the centre of the screen shows a translucent backdrop with a result card. The top of the card
+                displays a badge for the outcome (clear, defeated, and so on), the title, and—when applicable—the cause of
+                failure so you can review what happened at a glance.
+            </p>
+            <ul>
+                <li><strong>Level:</strong> Shows the level at the start and end of the run as <code>Start → End (+/-Δ)</code>.</li>
+                <li><strong>Total EXP Gained:</strong> Lists the net experience earned during the expedition.</li>
+                <li><strong>Total Damage Taken / Items Used:</strong> Summarises all damage received and how many recovery items
+                    you consumed.</li>
+            </ul>
+            <p>
+                The bottom of the card offers the primary actions. <strong>Return to Base</strong> sends you back to the
+                selection screen. When conditions are met, a <strong>Retry</strong> button appears to the right so you can jump
+                straight into the same dungeon. Keyboard focus defaults to Return to Base. Press Enter or Space to confirm, or
+                Esc to trigger the same behaviour. On touch devices, simply tap the buttons.
+            </p>
+            <p class="small-note">All statistics displayed in the result overlay are added to the Achievements &amp; Statistics
+                tracker and can be reviewed in exported saves under <code>achievements.stats.core</code>. For the gameplay
+                flow, refer to <a href="how-to-play.html" target="manual-content">7. How to Play</a>.</p>
+        </section>
     </main>
 </body>
 </html>

--- a/manual/en/workflow.html
+++ b/manual/en/workflow.html
@@ -3,27 +3,45 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>14. Development Workflow (Translation in Progress)</title>
+    <title>14. Development Workflow</title>
     <link rel="stylesheet" href="../manual.css">
 </head>
 <body>
     <main>
         <h1>14. Development Workflow</h1>
-        <p>
-            The full workflow guide is being localised. For sprint templates, review schedules, and collaboration tips,
-            please see the Japanese source chapter:
-        </p>
-        <ul>
-            <li><a href="../workflow.html" target="_blank" rel="noopener">Japanese chapter: Development Workflow</a></li>
-        </ul>
-        <p>
-            The English edition will provide:
-        </p>
-        <ol>
-            <li>Phase breakdowns for translation, review, and QA cycles.</li>
-            <li>Suggested roles and communication routines for team projects.</li>
-            <li>Checklists for preparing releases and follow-up updates.</li>
-        </ol>
+        <section>
+            <h2>14.1 Basic Cycle</h2>
+            <ol>
+                <li>Write down the task you want to tackle.</li>
+                <li>Back up the files you plan to edit.</li>
+                <li>Make small changes and test them in the browser.</li>
+                <li>When the behaviour stabilises, document the changes in your notes or Git history.</li>
+            </ol>
+        </section>
+        <section>
+            <h2>14.2 Git Quick Reference</h2>
+            <ul>
+                <li><code>git status</code>: Review modified files.</li>
+                <li><code>git add .</code>: Stage the changes.</li>
+                <li><code>git commit -m "message"</code>: Record a snapshot.</li>
+                <li><code>git log</code>: Inspect past commits.</li>
+            </ul>
+        </section>
+        <section>
+            <h2>14.3 Tips for Team Collaboration</h2>
+            <ul>
+                <li>Divide responsibilities and share which files are being edited.</li>
+                <li>Update the README or manual with notable changes.</li>
+                <li>Capture screenshots to communicate visual updates.</li>
+            </ul>
+        </section>
+        <section>
+            <h2>14.4 Encourage Reviews</h2>
+            <p>
+                For team projects, use pull requests to conduct reviews and maintain quality. Share feedback in the comments and
+                verify the fixes after revisions to keep the process smooth.
+            </p>
+        </section>
     </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- localize chapters 6 through 20 of the English manual with full gameplay guidance, UI explanations, and development references
- document Block Dimension data flow, MiniExp manifest/catalog details, and developer APIs for add-ons and MiniExp integrations
- provide complete tables for mini-games, utility modules, and glossary entries to match the Japanese source

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e3b918dbd8832b97158f9697bd0ddb