### PR TITLE
Improve locale loading for file protocol environments

### DIFF
--- a/index.html
+++ b/index.html
@@ -1571,8 +1571,10 @@
     <script src="js/tools/sandbox.js"></script>
     <script src="js/tools/image-viewer.js"></script>
     <script src="js/achievements.js"></script>
+    <script src="js/i18n/locales/ja.json.js"></script>
+    <script src="js/i18n/locales/en.json.js"></script>
     <script src="js/i18n/index.js"></script>
-    <script type="module" src="main.js"></script>
+    <script src="main.js"></script>
     <script src="js/tools/state-manager.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,5 +1,4 @@
-import './js/i18n/index.js';
-
+(async function () {
 const i18n = window.I18n;
 if (!i18n) {
     throw new Error('I18n module failed to load');
@@ -19277,3 +19276,6 @@ const __addonLoadPromise = loadDungeonAddons()
 if (typeof window !== 'undefined') {
     window.__addonLoadPromise = __addonLoadPromise;
 }
+})().catch((error) => {
+    console.error('[app] Failed to initialize application', error);
+});


### PR DESCRIPTION
## Summary
- preload locale dictionaries via static script tags so they are available when running from file://
- resolve locale asset URLs relative to the i18n bundle and simplify dynamic injection for better offline compatibility

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3b7df8904832b829d827297553809