### PR TITLE
Fix locale path sanitization regex

### DIFF
--- a/js/i18n/index.js
+++ b/js/i18n/index.js
@@ -20,7 +20,7 @@
                     return new URL('locales/', directory);
                 }
             }
-            const sanitizedPath = LOCALE_PATH.replace(/^\.\//, '').replace(/\/+$, '');
+            const sanitizedPath = LOCALE_PATH.replace(/^\.\//, '').replace(/\/+$/, '');
             return new URL(`${sanitizedPath}/`, document.baseURI);
         } catch (error) {
             console.warn('[i18n] Failed to resolve locale base URL:', error);


### PR DESCRIPTION
## Summary
- correct the sanitized path regex in the locale base URL resolver so trailing slashes are removed properly

## Testing
- not run (requires loading the game via file:// in a browser)

------
https://chatgpt.com/codex/tasks/task_e_68e3bd5b21cc832ba9646ba5e1545ab8