### PR TITLE
Fix addon context set to use lexical ctx

### DIFF
--- a/main.js
+++ b/main.js
@@ -19162,7 +19162,7 @@ function makeGenContext() {
         random: Math.random,
         inBounds(x,y){ return x>=1 && x<MAP_WIDTH-1 && y>=1 && y<MAP_HEIGHT-1; },
         set(x,y,v){
-            if (!this.inBounds(x,y)) return;
+            if (!ctx.inBounds(x,y)) return;
             map[y][x] = v ? 1 : 0;
             if (v) {
                 const meta = getTileMeta(x, y);


### PR DESCRIPTION
## Summary
- ensure `makeGenContext().set()` uses the lexical `ctx.inBounds()` guard so destructured calls keep working

## Testing
- node - <<'NODE'
const fs = require('fs');
const vm = require('vm');
const file = fs.readFileSync('main.js','utf8');
const start = file.indexOf('function makeGenContext()');
let depth = 0, end = -1;
for (let i = start; i < file.length; i++) {
  const ch = file[i];
  if (ch === '{') depth++;
  else if (ch === '}') { depth--; if (depth === 0) { end = i + 1; break; } }
}
const funcCode = file.slice(start, end);
const sandbox = {
  MAP_WIDTH: 8,
  MAP_HEIGHT: 8,
  map: Array.from({length:8},()=>Array(8).fill(1)),
  tileMeta: Array.from({length:8},()=>Array(8).fill(null)),
  dungeonLevel: 3,
  Math,
  console,
};
sandbox.getMaxFloor = () => 10;
sandbox.getTileMeta = (x,y) => sandbox.tileMeta?.[y]?.[x] || null;
sandbox.ensureTileMeta = (x,y) => {
  if (y<0||y>=sandbox.MAP_HEIGHT||x<0||x>=sandbox.MAP_WIDTH) return null;
  if (!sandbox.tileMeta[y][x]) sandbox.tileMeta[y][x] = {};
  return sandbox.tileMeta[y][x];
};
sandbox.normalizeFloorType = (type) => type ?? sandbox.FLOOR_TYPE_NORMAL;
sandbox.normalizeFloorDirection = (dir) => dir ? String(dir) : null;
sandbox.floorTypeNeedsDirection = (type) => type === 'needs-dir';
sandbox.FLOOR_TYPE_NORMAL = 'normal';
sandbox.FLOOR_TYPE_SET = new Set(['normal','needs-dir','other']);
sandbox.ensureConnectivity = () => {};
sandbox.digPath = () => {};
sandbox.aStarPath = () => ['ok'];
sandbox.makeStructureApi = () => ({ list: () => [], place: () => {} });
vm.createContext(sandbox);
vm.runInContext(funcCode, sandbox);
const ctx = sandbox.makeGenContext();
const { set } = ctx;
const meta = sandbox.tileMeta[2][2] = { floorType: 'needs-dir', floorColor: 'red', floorDir: 'N', wallColor: 'blue' };
set(2,2,1);
if ('floorType' in meta || 'floorColor' in meta || 'floorDir' in meta) throw new Error('meta cleanup failed');
set(2,2,0);
if (sandbox.map[2][2] !== 0) throw new Error('set did not clear');
set(3,3,1);
if (sandbox.map[3][3] !== 1) throw new Error('destructured set failed');
console.log('makeGenContext set() lexical binding test passed');
NODE

------
https://chatgpt.com/codex/tasks/task_e_68e3c5a09718832bb7b9a2c029df928d