### PR TITLE
Use i18n keys for SP and status log messages

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -9177,13 +9177,31 @@
           "unlocked": "SP system unlocked!",
           "notUnlocked": "SP hasn't been unlocked yet.",
           "notEnough": "Not enough SP.",
+          "maxIncreased": "SP cap increased to {value}!",
+          "gained": "Gained {amount} SP.",
+          "spent": "Spent {amount} SP.",
           "offerLocked": "You can offer items once the SP system is unlocked.",
           "notUnlockedForItem": "You can't use that until SP is unlocked.",
           "noCapacity": "Your SP cap is 0, so it has no effect.",
           "alreadyFull": "SP is already full."
         },
         "status": {
-          "paralyzed": "You're paralyzed and can't move..."
+          "paralyzed": "You're paralyzed and can't move...",
+          "paralyzedRemaining": "You're paralyzed and can't move... ({turns} turns left)",
+          "cured": {
+            "poison": "The poison wore off.",
+            "paralysis": "You shook off the paralysis.",
+            "abilityUp": "The power-up effect expired.",
+            "abilityDown": "The stat penalty faded.",
+            "levelDown": "Your temporary level drop ended."
+          },
+          "applied": {
+            "poison": "You've been poisoned! ({turns} turns)",
+            "paralysis": "You're paralyzed and can't move! ({turns} turns)",
+            "abilityUp": "Power surges through you! Max HP/ATK/DEF up ({turns} turns)",
+            "abilityDown": "Your stats dropped... Max HP/ATK/DEF down ({turns} turns)",
+            "levelDown": "Your level temporarily decreased! ({turns} turns)"
+          }
         },
         "sandbox": {
           "noExp": "Sandbox mode does not award EXP.",
@@ -9226,6 +9244,8 @@
           "bossGate": "You can't proceed until the boss is down!",
           "enemyMissed": "The enemy missed!",
           "enemyWarped": "Warped by the enemy's teleport attack!",
+          "enemyAttackDamage": "The enemy dealt {amount} damage to you!",
+          "enemyWarpPopup": "Warp",
           "statusResistedByLevel": "Level gap prevented the status ailment!",
           "teleportResistedByLevel": "Level gap let you withstand the warp!",
           "instantDeathResisted": "Level gap nullified the instant-death attack!",
@@ -9251,6 +9271,14 @@
           "throwNoTarget": "Found no target to throw at.",
           "throwIneffective": "The enemy's level is too high; the throw had no effect...",
           "throwNoEffect": "You threw a healing item, but nothing happened.",
+          "autoSatietyRecovered": "Auto item triggered! Satiety recovered by {amount}.",
+          "potionSatietyRecovered": "Ate a potion! Satiety recovered by {amount}.",
+          "autoReversedDamage": "Auto item misfired! Took {amount} damage!",
+          "potionReversedDamage": "The potion reversed and dealt {amount} damage!",
+          "autoHpRecovered": "Auto item triggered! Recovered {amount} HP.",
+          "potionHpRecovered": "Used a potion! Recovered {amount} HP.",
+          "autoNoEffect": "Auto item triggered but nothing happened.",
+          "potionNoEffect": "Used a potion but nothing happened.",
           "hpBoostUsed": "Used a Max HP Boost! Max HP increased by 5!",
           "attackBoostUsed": "Used an Attack Boost! Attack increased by 1!",
           "defenseBoostUsed": "Used a Defense Boost! Defense increased by 1!",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -9177,13 +9177,31 @@
           "unlocked": "SPが解放された！",
           "notUnlocked": "SPが解放されていない。",
           "notEnough": "SPが足りない。",
+          "maxIncreased": "SP上限が{value}に上昇した！",
+          "gained": "SPを{amount}獲得した。",
+          "spent": "SPを{amount}消費した。",
           "offerLocked": "SPシステムが解放されてから捧げられる。",
           "notUnlockedForItem": "SPが解放されていないため使用できない。",
           "noCapacity": "SP上限が0のため効果がない。",
           "alreadyFull": "SPはすでに最大だ。"
         },
         "status": {
-          "paralyzed": "体が痺れて動けない…"
+          "paralyzed": "体が痺れて動けない…",
+          "paralyzedRemaining": "体が痺れて動けない… (残り{turns}ターン)",
+          "cured": {
+            "poison": "毒が治った。",
+            "paralysis": "体の痺れが解けた。",
+            "abilityUp": "能力強化の効果が切れた。",
+            "abilityDown": "能力低下から解放された。",
+            "levelDown": "一時的なレベル低下が解除された。"
+          },
+          "applied": {
+            "poison": "毒に侵された！ ({turns}ターン)",
+            "paralysis": "体が痺れて動けない！ ({turns}ターン)",
+            "abilityUp": "能力が高まった！最大HP/攻撃/防御が上昇 ({turns}ターン)",
+            "abilityDown": "能力が低下した…最大HP/攻撃/防御が下がる ({turns}ターン)",
+            "levelDown": "レベルが一時的に低下した！ ({turns}ターン)"
+          }
         },
         "sandbox": {
           "noExp": "サンドボックスでは経験値は獲得できません。",
@@ -9226,6 +9244,8 @@
           "bossGate": "ボスを倒すまでは進めない！",
           "enemyMissed": "敵は外した！",
           "enemyWarped": "敵の転移攻撃でワープさせられた！",
+          "enemyAttackDamage": "敵はプレイヤーに {amount} のダメージを与えた！",
+          "enemyWarpPopup": "ワープ",
           "statusResistedByLevel": "レベル差で状態異常を防いだ！",
           "teleportResistedByLevel": "レベル差で転移攻撃を耐えた！",
           "instantDeathResisted": "レベル差で即死攻撃を無効化した！",
@@ -9251,6 +9271,14 @@
           "throwNoTarget": "投げつける相手が見つからなかった。",
           "throwIneffective": "敵のレベルが高すぎて投げつけても効果がなかった…",
           "throwNoEffect": "回復アイテムを投げつけたが効果がなかった。",
+          "autoSatietyRecovered": "オートアイテムが発動！満腹度が{amount}回復",
+          "potionSatietyRecovered": "ポーションを食べた！満腹度が{amount}回復",
+          "autoReversedDamage": "オートアイテムが暴発し、{amount}のダメージを受けた！",
+          "potionReversedDamage": "ポーションが反転し、{amount}のダメージを受けた！",
+          "autoHpRecovered": "オートアイテムが発動！HPが{amount}回復",
+          "potionHpRecovered": "ポーションを使用！HPが{amount}回復",
+          "autoNoEffect": "オートアイテムが発動したが体調に変化はなかった。",
+          "potionNoEffect": "ポーションを使用したが体調に変化はなかった。",
           "hpBoostUsed": "最大HP強化アイテムを使用！最大HPが5増加！",
           "attackBoostUsed": "攻撃力強化アイテムを使用！攻撃力が1増加！",
           "defenseBoostUsed": "防御力強化アイテムを使用！防御力が1増加！",


### PR DESCRIPTION
## Summary
- refactor SP, status, enemy attack, and auto item logs to use translation keys with localized fallbacks
- add English and Japanese locale entries for the new gameplay messages and popups

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5b9e8f5a4832b9f351f472c184045