### PR TITLE
Localize board game mini-game interfaces

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -8246,6 +8246,23 @@
     },
 
     "minigame": {
+      "checkers": {
+        "hud": {
+          "turn": {
+            "playerPrompt": "Your turn - select a piece to move",
+            "aiThinking": "AI thinking..."
+          },
+          "expHint": "Move: +1 EXP / Capture: +6 EXP per piece / Promotion: +12 EXP"
+        },
+        "overlay": {
+          "defaultTitle": "Game Over",
+          "restartHint": "Press R to restart",
+          "result": {
+            "win": "Victory!",
+            "loss": "Defeat..."
+          }
+        }
+      },
       "othello": {
         "hud": {
           "status": {
@@ -8265,6 +8282,139 @@
         },
         "popup": {
           "movePreview": "{flips} flips / approx +{xp} EXP"
+        }
+      },
+      "connect6": {
+        "hud": {
+          "status": {
+            "ended": "Game Over",
+            "playerTurn": "Your turn",
+            "aiTurn": "AI turn"
+          }
+        },
+        "overlay": {
+          "title": "Game Over",
+          "restartHint": "Press R to reset",
+          "result": {
+            "win": "You win!",
+            "draw": "Draw",
+            "loss": "AI wins..."
+          }
+        },
+        "popups": {
+          "defense": "Countered",
+          "checkmate": "Checkmate threat",
+          "winning": "Winning move",
+          "pressured": "Pressured move",
+          "chasing": "Chasing move"
+        }
+      },
+      "gomoku": {
+        "hud": {
+          "status": {
+            "ended": "Game Over",
+            "playerTurn": "Your turn",
+            "aiTurn": "AI turn"
+          }
+        },
+        "overlay": {
+          "title": "Game Over",
+          "restartHint": "Press R to reset",
+          "result": {
+            "win": "You win!",
+            "draw": "Draw",
+            "loss": "AI wins..."
+          }
+        },
+        "popups": {
+          "defense": "Countered",
+          "checkmate": "Checkmate threat",
+          "winning": "Winning move",
+          "pressured": "Pressured move",
+          "chasing": "Chasing move"
+        }
+      },
+      "renju": {
+        "hud": {
+          "status": {
+            "ended": "Game Over",
+            "playerTurn": "Your turn",
+            "aiTurn": "AI turn"
+          }
+        },
+        "overlay": {
+          "title": "Game Over",
+          "restartHint": "Press R to reset",
+          "result": {
+            "win": "You win!",
+            "draw": "Draw",
+            "loss": "AI wins..."
+          }
+        },
+        "popups": {
+          "defense": "Countered",
+          "checkmate": "Checkmate threat",
+          "winning": "Winning move",
+          "pressured": "Pressured move",
+          "chasing": "Chasing move"
+        },
+        "renju": {
+          "foulLabel": {
+            "overline": "Forbidden move: Overline",
+            "doubleFour": "Forbidden move: Double four",
+            "doubleThree": "Forbidden move: Double three"
+          },
+          "genericFoul": "Forbidden move"
+        }
+      },
+      "connect4": {
+        "hud": {
+          "status": {
+            "ended": "Game Over",
+            "playerTurn": "Your turn",
+            "aiTurn": "AI turn"
+          }
+        },
+        "overlay": {
+          "title": "Game Over",
+          "restartHint": "Press R to reset",
+          "result": {
+            "win": "You win!",
+            "draw": "Draw",
+            "loss": "AI wins..."
+          }
+        },
+        "popups": {
+          "defense": "Countered",
+          "checkmate": "Checkmate threat",
+          "winning": "Winning move",
+          "pressured": "Pressured move",
+          "chasing": "Chasing move"
+        }
+      },
+      "tic_tac_toe": {
+        "hud": {
+          "status": {
+            "ended": "Game Over",
+            "playerTurn": "Your turn",
+            "aiTurn": "AI turn"
+          }
+        },
+        "overlay": {
+          "title": "Game Over",
+          "restartHint": "Press R to reset",
+          "result": {
+            "win": "You win!",
+            "draw": "Draw",
+            "loss": "AI wins..."
+          }
+        },
+        "popups": {
+          "defense": "Countered",
+          "checkmate": "Checkmate threat",
+          "winning": "Winning move",
+          "pressured": "Pressured move",
+          "chasing": "Chasing move"
         }
       },
       "riichi_mahjong": {

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -8246,6 +8246,23 @@
     },
 
     "minigame": {
+      "checkers": {
+        "hud": {
+          "turn": {
+            "playerPrompt": "あなたの番 - 駒を選択して移動",
+            "aiThinking": "AI思考中..."
+          },
+          "expHint": "移動: +1EXP / 捕獲: +6EXP×駒 / 王冠昇格: +12EXP"
+        },
+        "overlay": {
+          "defaultTitle": "ゲーム終了",
+          "restartHint": "Rキーでリスタート",
+          "result": {
+            "win": "勝利！",
+            "loss": "敗北..."
+          }
+        }
+      },
       "othello": {
         "hud": {
           "status": {
@@ -8265,6 +8282,139 @@
         },
         "popup": {
           "movePreview": "{flips}枚 / 予想+{xp}EXP"
+        }
+      },
+      "connect6": {
+        "hud": {
+          "status": {
+            "ended": "ゲーム終了",
+            "playerTurn": "あなたの番",
+            "aiTurn": "AIの番"
+          }
+        },
+        "overlay": {
+          "title": "ゲーム終了",
+          "restartHint": "Rキーでリセットできます",
+          "result": {
+            "win": "あなたの勝ち！",
+            "draw": "引き分け",
+            "loss": "AIの勝ち…"
+          }
+        },
+        "popups": {
+          "defense": "防手",
+          "checkmate": "詰み手",
+          "winning": "勝ち手",
+          "pressured": "追われ手",
+          "chasing": "追い手"
+        }
+      },
+      "gomoku": {
+        "hud": {
+          "status": {
+            "ended": "ゲーム終了",
+            "playerTurn": "あなたの番",
+            "aiTurn": "AIの番"
+          }
+        },
+        "overlay": {
+          "title": "ゲーム終了",
+          "restartHint": "Rキーでリセットできます",
+          "result": {
+            "win": "あなたの勝ち！",
+            "draw": "引き分け",
+            "loss": "AIの勝ち…"
+          }
+        },
+        "popups": {
+          "defense": "防手",
+          "checkmate": "詰み手",
+          "winning": "勝ち手",
+          "pressured": "追われ手",
+          "chasing": "追い手"
+        }
+      },
+      "renju": {
+        "hud": {
+          "status": {
+            "ended": "ゲーム終了",
+            "playerTurn": "あなたの番",
+            "aiTurn": "AIの番"
+          }
+        },
+        "overlay": {
+          "title": "ゲーム終了",
+          "restartHint": "Rキーでリセットできます",
+          "result": {
+            "win": "あなたの勝ち！",
+            "draw": "引き分け",
+            "loss": "AIの勝ち…"
+          }
+        },
+        "popups": {
+          "defense": "防手",
+          "checkmate": "詰み手",
+          "winning": "勝ち手",
+          "pressured": "追われ手",
+          "chasing": "追い手"
+        },
+        "renju": {
+          "foulLabel": {
+            "overline": "禁手: 長連",
+            "doubleFour": "禁手: 四々",
+            "doubleThree": "禁手: 三々"
+          },
+          "genericFoul": "禁手"
+        }
+      },
+      "connect4": {
+        "hud": {
+          "status": {
+            "ended": "ゲーム終了",
+            "playerTurn": "あなたの番",
+            "aiTurn": "AIの番"
+          }
+        },
+        "overlay": {
+          "title": "ゲーム終了",
+          "restartHint": "Rキーでリセットできます",
+          "result": {
+            "win": "あなたの勝ち！",
+            "draw": "引き分け",
+            "loss": "AIの勝ち…"
+          }
+        },
+        "popups": {
+          "defense": "防手",
+          "checkmate": "詰み手",
+          "winning": "勝ち手",
+          "pressured": "追われ手",
+          "chasing": "追い手"
+        }
+      },
+      "tic_tac_toe": {
+        "hud": {
+          "status": {
+            "ended": "ゲーム終了",
+            "playerTurn": "あなたの番",
+            "aiTurn": "AIの番"
+          }
+        },
+        "overlay": {
+          "title": "ゲーム終了",
+          "restartHint": "Rキーでリセットできます",
+          "result": {
+            "win": "あなたの勝ち！",
+            "draw": "引き分け",
+            "loss": "AIの勝ち…"
+          }
+        },
+        "popups": {
+          "defense": "防手",
+          "checkmate": "詰み手",
+          "winning": "勝ち手",
+          "pressured": "追われ手",
+          "chasing": "追い手"
         }
       },
       "riichi_mahjong": {


### PR DESCRIPTION
## Summary
- integrate localization helpers into the checkers and stone board mini-games and redraw on locale changes
- replace hard-coded HUD, result, and popup strings with localized lookups while cleaning up localization listeners on stop/destroy
- add Japanese and English locale entries for the new checkers and stone board strings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5e1860b44832b885583a5f809429a