### PR TITLE
Add localization keys for dungeon addon packs

### DIFF
--- a/dungeontypes/FantasicalAndSci-fiAndDremerPack.js
+++ b/dungeontypes/FantasicalAndSci-fiAndDremerPack.js
@@ -2079,6 +2079,7 @@
   window.registerDungeonAddon({
     id: addonId,
     name: 'ファンタジカルと近未来をテーマにした夢の世界パック',
+    nameKey: "dungeon.packs.fantasical_sci_fi_dream_pack.name",
     version: '3.0.0',
     blocks,
     generators

--- a/dungeontypes/abstract_spectrum_pack.js
+++ b/dungeontypes/abstract_spectrum_pack.js
@@ -1526,6 +1526,7 @@
   window.registerDungeonAddon({
     id: ADDON_ID,
     name: ADDON_NAME,
+    nameKey: "dungeon.packs.abstract_spectrum_pack.name",
     version: VERSION,
     blocks,
     generators

--- a/dungeontypes/arabian_legends_pack.js
+++ b/dungeontypes/arabian_legends_pack.js
@@ -1309,12 +1309,14 @@
   const addon = {
     id: ADDON_ID,
     name: ADDON_NAME,
+    nameKey: "dungeon.packs.arabian_legends_pack.name",
     version: VERSION,
     api: '1.0.0',
     description: [
       '砂海に眠る伝承と幻影をテーマに、オアシス、城砦、市場、宙庭、星図聖堂など16種類のダンジョン生成アルゴリズムと',
       '50種以上のアラビア語ブロックを鮮やかな色彩表現で追加する大型パック。'
     ].join(''),
+    descriptionKey: "dungeon.packs.arabian_legends_pack.description",
     generators: createGenerators(),
     blocks: createBlocks()
   };

--- a/dungeontypes/biome_convergence_megapack.js
+++ b/dungeontypes/biome_convergence_megapack.js
@@ -711,5 +711,12 @@
     });
   });
 
-  window.registerDungeonAddon({ id: ADDON_ID, name: ADDON_NAME, version: VERSION, blocks, generators });
+  window.registerDungeonAddon({
+    id: ADDON_ID,
+    name: ADDON_NAME,
+    nameKey: "dungeon.packs.biome_convergence_megapack.name",
+    version: VERSION,
+    blocks,
+    generators
+  });
 })();

--- a/dungeontypes/celestial_dynasty.js
+++ b/dungeontypes/celestial_dynasty.js
@@ -2530,6 +2530,7 @@
   window.registerDungeonAddon({
     id: ADDON_ID,
     name: ADDON_NAME,
+    nameKey: "dungeon.packs.celestial_dynasty_pack.name",
     version: VERSION,
     blocks,
     generators

--- a/dungeontypes/nature_expansion.js
+++ b/dungeontypes/nature_expansion.js
@@ -1481,6 +1481,7 @@
   window.registerDungeonAddon({
     id: ADDON_ID,
     name: ADDON_NAME,
+    nameKey: "dungeon.packs.nature_expansion_pack.name",
     version: VERSION,
     blocks,
     generators

--- a/dungeontypes/neo_research_arcology.js
+++ b/dungeontypes/neo_research_arcology.js
@@ -807,9 +807,11 @@
   const addon = {
     id: ADDON_ID,
     name: ADDON_NAME,
+    nameKey: "dungeon.packs.neo_research_arcology_pack.name",
     version: VERSION,
     api: '1.0.0',
     description: '未来研究都市アーコロジーを舞台に、多層リングや螺旋実験路、バイオドーム、冷却金庫、ホロシティなど7つの生成タイプと36ブロック、4次元帯を追加する大規模拡張。',
+    descriptionKey: "dungeon.packs.neo_research_arcology_pack.description",
     blocks: createBlocks(),
     generators: createGenerators()
   };

--- a/dungeontypes/noise_interference_pack.js
+++ b/dungeontypes/noise_interference_pack.js
@@ -303,5 +303,12 @@
     blocks.blocks3.push(blockRelic);
   });
 
-  window.registerDungeonAddon({ id: ADDON_ID, name: ADDON_NAME, version: VERSION, blocks, generators });
+  window.registerDungeonAddon({
+    id: ADDON_ID,
+    name: ADDON_NAME,
+    nameKey: "dungeon.packs.noise_interference_pack.name",
+    version: VERSION,
+    blocks,
+    generators
+  });
 })();

--- a/dungeontypes/sf_expansion.js
+++ b/dungeontypes/sf_expansion.js
@@ -3019,9 +3019,11 @@
   const addon = {
     id: ADDON_ID,
     name: ADDON_NAME,
+    nameKey: "dungeon.packs.sf_expansion_pack.name",
     version: VERSION,
     api: '1.0.0',
     description: '宇宙船・サイバー空間・未来都市・軌道施設・量子/時間研究・異星生態・メガコロニーを網羅し、50タイプと5次元拡張を収録した大規模SFダンジョン生成パック。',
+    descriptionKey: "dungeon.packs.sf_expansion_pack.description",
     blocks: createBlocks(),
     structures: createStructures(),
     generators: createGenerators()

--- a/dungeontypes/skyrim_nordic_legends.js
+++ b/dungeontypes/skyrim_nordic_legends.js
@@ -1505,5 +1505,12 @@
     ]
   };
 
-  window.registerDungeonAddon({ id: ADDON_ID, name: ADDON_NAME, version: VERSION, blocks, generators });
+  window.registerDungeonAddon({
+    id: ADDON_ID,
+    name: ADDON_NAME,
+    nameKey: "dungeon.packs.skyrim_nordic_legends_pack.name",
+    version: VERSION,
+    blocks,
+    generators
+  });
 })();

--- a/dungeontypes/visceral_crimescene_pack.js
+++ b/dungeontypes/visceral_crimescene_pack.js
@@ -855,6 +855,7 @@
   window.registerDungeonAddon({
     id: PACK_ID,
     name: PACK_NAME,
+    nameKey: "dungeon.packs.visceral_crimescene_pack.name",
     version: PACK_VERSION,
     generators,
     blocks: {

--- a/dungeontypes/western_frontier.js
+++ b/dungeontypes/western_frontier.js
@@ -1565,6 +1565,7 @@
   window.registerDungeonAddon({
     id: ADDON_ID,
     name: ADDON_NAME,
+    nameKey: "dungeon.packs.western_frontier_pack.name",
     version: VERSION,
     blocks,
     generators,

--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -741,12 +741,21 @@
           "name": "Abyssal Whorl Pack"
         },
 
+        "abstract_spectrum_pack": {
+          "name": "Abstract Spectrum Generation Pack"
+        },
+
         "amber_marsh_pack": {
           "name": "Amber Marsh Pack"
         },
 
         "ancient_enigma_pack": {
           "name": "Ancient Enigma Excavation Pack"
+        },
+
+        "arabian_legends_pack": {
+          "name": "Arabian Legends Pack",
+          "description": "A large Arabian-inspired expansion with 16 generation algorithms covering oases, fortresses, markets, sky gardens, astral sanctums, and more alongside 50+ themed blocks."
         },
 
         "axis_gallery_pack": {
@@ -757,6 +766,10 @@
           "name": "Bamboo Hollows Pack"
         },
 
+        "biome_convergence_megapack": {
+          "name": "Biome Convergence Mega Pack"
+        },
+
         "shore_pack": {
           "name": "Sunlit Shore Pack"
         },
@@ -764,6 +777,10 @@
         "bomb_pack": {
           "name": "Bomb Hazard Pack",
           "description": "爆弾ギミックに特化した生成タイプを追加するMOD。地雷原・兵舎・迷宮の3種類を収録。"
+        },
+
+        "celestial_dynasty_pack": {
+          "name": "Celestial Dynasty Pack"
         },
 
         "churning_karst_pack": {
@@ -810,6 +827,10 @@
           "name": "Emberglass Caverns Pack"
         },
 
+        "fantasical_sci_fi_dream_pack": {
+          "name": "Fantasical & Sci-Fi Dream Pack"
+        },
+
         "forest_pack": {
           "name": "Verdant Forest Pack"
         },
@@ -850,8 +871,21 @@
           "name": "Medieval Stronghold Pack"
         },
 
+        "nature_expansion_pack": {
+          "name": "Nature Biome Expansion Pack"
+        },
+
         "natural_roadways_pack": {
           "name": "Natural Roadways Pack"
+        },
+
+        "neo_research_arcology_pack": {
+          "name": "Neo Research Arcology Expansion",
+          "description": "A large expansion set in a futuristic research arcology, adding seven generation types—multi-layer rings, spiral experiment routes, biodomes, coolant vaults, holo cities—and 36 blocks across four dimensional bands."
+        },
+
+        "noise_interference_pack": {
+          "name": "Interference Noise Expansion Pack"
         },
 
         "oneway_labyrinth_pack": {
@@ -898,6 +932,15 @@
           "name": "Serpentine River Pack"
         },
 
+        "sf_expansion_pack": {
+          "name": "SF Expansion Pack",
+          "description": "A massive sci-fi generation pack spanning starships, cyberspace, future cities, orbital facilities, quantum/time research, alien biomes, and mega colonies with 50 dungeon types and five dimensional expansions."
+        },
+
+        "skyrim_nordic_legends_pack": {
+          "name": "Skyrim Nordic Legends Pack"
+        },
+
         "skyward_pack": {
           "name": "Skyward Bastions Pack"
         },
@@ -912,6 +955,14 @@
 
         "traditional_japan_expansion_pack": {
           "name": "Traditional Japan Expansion Pack"
+        },
+
+        "visceral_crimescene_pack": {
+          "name": "Visceral Crime Scene Pack"
+        },
+
+        "western_frontier_pack": {
+          "name": "Western Frontier Mega Pack"
         },
 
         "prison_pack": {

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -741,12 +741,21 @@
           "name": "Abyssal Whorl Pack"
         },
 
+        "abstract_spectrum_pack": {
+          "name": "抽象スペクトラム生成パック"
+        },
+
         "amber_marsh_pack": {
           "name": "Amber Marsh Pack"
         },
 
         "ancient_enigma_pack": {
           "name": "Ancient Enigma Excavation Pack"
+        },
+
+        "arabian_legends_pack": {
+          "name": "Arabian Legends Pack",
+          "description": "砂海に眠る伝承と幻影をテーマに、オアシス、城砦、市場、宙庭、星図聖堂など16種類のダンジョン生成アルゴリズムと50種以上のアラビア語ブロックを鮮やかな色彩表現で追加する大型パック。"
         },
 
         "axis_gallery_pack": {
@@ -757,6 +766,10 @@
           "name": "Bamboo Hollows Pack"
         },
 
+        "biome_convergence_megapack": {
+          "name": "Biome Convergence Mega Pack"
+        },
+
         "shore_pack": {
           "name": "Sunlit Shore Pack"
         },
@@ -764,6 +777,10 @@
         "bomb_pack": {
           "name": "Bomb Hazard Pack",
           "description": "爆弾ギミックに特化した生成タイプを追加するMOD。地雷原・兵舎・迷宮の3種類を収録。"
+        },
+
+        "celestial_dynasty_pack": {
+          "name": "華夏王朝拡張パック"
         },
 
         "churning_karst_pack": {
@@ -810,6 +827,10 @@
           "name": "Emberglass Caverns Pack"
         },
 
+        "fantasical_sci_fi_dream_pack": {
+          "name": "ファンタジカルと近未来をテーマにした夢の世界パック"
+        },
+
         "forest_pack": {
           "name": "Verdant Forest Pack"
         },
@@ -850,8 +871,21 @@
           "name": "Medieval Stronghold Pack"
         },
 
+        "nature_expansion_pack": {
+          "name": "Nature Biome Expansion Pack"
+        },
+
         "natural_roadways_pack": {
           "name": "Natural Roadways Pack"
+        },
+
+        "neo_research_arcology_pack": {
+          "name": "ネオ・リサーチアーコロジー拡張",
+          "description": "未来研究都市アーコロジーを舞台に、多層リングや螺旋実験路、バイオドーム、冷却金庫、ホロシティなど7つの生成タイプと36ブロック、4次元帯を追加する大規模拡張。"
+        },
+
+        "noise_interference_pack": {
+          "name": "Interference Noise Expansion Pack"
         },
 
         "oneway_labyrinth_pack": {
@@ -898,6 +932,15 @@
           "name": "Serpentine River Pack"
         },
 
+        "sf_expansion_pack": {
+          "name": "SF Expansion Pack",
+          "description": "宇宙船・サイバー空間・未来都市・軌道施設・量子/時間研究・異星生態・メガコロニーを網羅し、50タイプと5次元拡張を収録した大規模SFダンジョン生成パック。"
+        },
+
+        "skyrim_nordic_legends_pack": {
+          "name": "Skyrim Nordic Legends Pack"
+        },
+
         "skyward_pack": {
           "name": "Skyward Bastions Pack"
         },
@@ -912,6 +955,14 @@
 
         "traditional_japan_expansion_pack": {
           "name": "Traditional Japan Expansion Pack"
+        },
+
+        "visceral_crimescene_pack": {
+          "name": "Visceral Crime Scene Pack"
+        },
+
+        "western_frontier_pack": {
+          "name": "Western Frontier Mega Pack"
         },
 
         "prison_pack": {


### PR DESCRIPTION
## Summary
- add nameKey/descriptionKey metadata to each affected dungeon addon registration
- define matching localization entries for the new dungeon pack keys in both English and Japanese locale files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5e1b626f8832bb954099aabf23d57