### PR TITLE
Use localization keys for status effect display

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -11602,6 +11602,8 @@
         "type": "Type"
       },
       "effects": {
+        "none": "No status ailments.",
+        "remaining": "{label} {turns} turns remaining",
         "entry": "{label} {turns} turns remaining"
       },
       "skillCharms": {

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -11602,6 +11602,8 @@
         "type": "タイプ"
       },
       "effects": {
+        "none": "状態異常なし",
+        "remaining": "{label} 残り{turns}ターン",
         "entry": "{label} 残り{turns}ターン"
       },
       "skillCharms": {

--- a/main.js
+++ b/main.js
@@ -14821,12 +14821,20 @@ function updateUI() {
 
     if (statStatusEffects) {
         if (!combinedStatusList.length) {
-            statStatusEffects.textContent = '状態異常なし';
+            statStatusEffects.textContent = translateOrFallback(
+                'statusModal.effects.none',
+                '状態異常なし'
+            );
         } else {
             statStatusEffects.innerHTML = combinedStatusList.map(status => {
                 const classes = ['status-badge'];
                 if (status.badgeClass) classes.push(status.badgeClass);
-                return `<span class="${classes.join(' ')}">${status.label} 残り${status.remaining}</span>`;
+                const remainingText = translateOrFallback(
+                    'statusModal.effects.remaining',
+                    () => `${status.label} 残り${status.remaining}`,
+                    { label: status.label, turns: status.remaining }
+                );
+                return `<span class="${classes.join(' ')}">${remainingText}</span>`;
             }).join('');
         }
     }


### PR DESCRIPTION
## Summary
- replace the hard-coded status effect display strings with i18n lookups in the status modal
- add localized English and Japanese strings for status-effect badges and the empty state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6233f718c832baf40f33ec41ba64d