### PR TITLE
Localize dynamic event log messages

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -11457,10 +11457,19 @@
           "maxIncreased": "SP cap increased to {value}!",
           "gained": "Gained {amount} SP.",
           "spent": "Spent {amount} SP.",
+          "offered": "Offered a healing item and gained {amount} SP.",
           "offerLocked": "You can offer items once the SP system is unlocked.",
           "notUnlockedForItem": "You can't use that until SP is unlocked.",
           "noCapacity": "Your SP cap is 0, so it has no effect.",
-          "alreadyFull": "SP is already full."
+          "alreadyFull": "SP is already full.",
+          "elixirUsed": "Used an SP Elixir! Restored {amount} SP.",
+          "fullyRestored": "SP fully restored (+{amount})."
+        },
+        "exp": {
+          "bossBonusSuffix": " (Boss Bonus!)",
+          "enemyGain": "Earned {amount} EXP!{bonus}",
+          "spent": "Spent {amount} EXP. ({context})",
+          "gained": "Earned {amount} EXP! ({context})"
         },
         "status": {
           "paralyzed": "You're paralyzed and can't move...",
@@ -11485,7 +11494,8 @@
           "started": "Sandbox mode started. EXP will not be awarded."
         },
         "console": {
-          "executed": "Creator Console executed the code."
+          "executed": "Creator Console executed the code.",
+          "error": "Creator Console Error: {message}"
         },
         "unlocks": {
           "nestedLegend": "Cleared NESTED 99999999 and attained Anos-class divinity!",
@@ -11500,18 +11510,38 @@
         },
         "charms": {
           "unknown": "An unknown charm can't be used.",
-          "notOwned": "You don't own that charm."
+          "notOwned": "You don't own that charm.",
+          "activated": "Activated the {label} charm! Effect lasts {turns} turns."
         },
         "satiety": {
           "enabled": "Satiety system enabled!",
           "disabled": "Satiety system disabled.",
           "cannotEat": "You can only eat while the satiety system is active.",
-          "alreadyFull": "Satiety is already at maximum."
+          "alreadyFull": "Satiety is already at maximum.",
+          "damage": "Took {amount} damage from hunger!"
+        },
+        "chest": {
+          "prefix": {
+            "normal": "Opened the chest! ",
+            "rare": "Opened the golden chest! "
+          },
+          "reward": {
+            "potion30": "{prefix}Obtained an HP 30% potion!",
+            "hpBoost": "{prefix}Obtained a Max HP Boost item!",
+            "atkBoost": "{prefix}Obtained an Attack Boost item!",
+            "defBoost": "{prefix}Obtained a Defense Boost item!"
+          }
         },
         "goldenChest": {
           "elixir": "Found a special SP Elixir in the golden chest! SP greatly restored.",
           "openedSafely": "Opened the golden chest safely!",
-          "prompt": "A golden chest! Time your press with the bar."
+          "prompt": "A golden chest! Time your press with the bar.",
+          "major": {
+            "hp": "Found a Max HP +{amount} elixir in the golden chest!",
+            "atk": "Found an ATK +{amount} tactical orb in the golden chest!",
+            "def": "Found a DEF +{amount} guardian shield card in the golden chest!"
+          },
+          "skillCharm": "Found a skill charm \"{effectName}\" in the golden chest! ({turns} turns)"
         },
         "combat": {
           "noEnemyInDirection": "No enemy in that direction!",
@@ -11527,7 +11557,9 @@
           "teleportResistedByLevel": "Level gap let you withstand the warp!",
           "instantDeathResisted": "Level gap nullified the instant-death attack!",
           "instantDeathHit": "The enemy's instant-death attack landed…!",
-          "knockbackResistedByLevel": "Level gap let you resist the knockback!"
+          "knockbackResistedByLevel": "Level gap let you resist the knockback!",
+          "playerDamage": "You dealt {amount} damage to the enemy!",
+          "knockbackCollision": "Slammed into the wall and took {amount} damage!"
         },
         "orb": {
           "statusAttackNegated": "Orb's blessing nullified the status attack!",
@@ -11548,6 +11580,7 @@
           "throwNoTarget": "Found no target to throw at.",
           "throwIneffective": "The enemy's level is too high; the throw had no effect...",
           "throwNoEffect": "You threw a healing item, but nothing happened.",
+          "throwDamage": "Threw a healing item and dealt {damage} damage to the enemy!",
           "autoSatietyRecovered": "Auto item triggered! Satiety recovered by {amount}.",
           "potionSatietyRecovered": "Ate a potion! Satiety recovered by {amount}.",
           "autoReversedDamage": "Auto item misfired! Took {amount} damage!",
@@ -11556,9 +11589,13 @@
           "potionHpRecovered": "Used a potion! Recovered {amount} HP.",
           "autoNoEffect": "Auto item triggered but nothing happened.",
           "potionNoEffect": "Used a potion but nothing happened.",
+          "cleansedStatus": "Used a healing item and cured {status}.",
           "hpBoostUsed": "Used a Max HP Boost! Max HP increased by 5!",
           "attackBoostUsed": "Used an Attack Boost! Attack increased by 1!",
           "defenseBoostUsed": "Used a Defense Boost! Defense increased by 1!",
+          "hpBoostMajorUsed": "Used a Grand Max HP Boost! Max HP increased by {amount}!",
+          "attackBoostMajorUsed": "Used a Grand Attack Boost! Attack increased by {amount}!",
+          "defenseBoostMajorUsed": "Used a Grand Defense Boost! Defense increased by {amount}!",
           "notOwned": "You don't have that item.",
           "noSpElixir": "You don't have an SP Elixir."
         },
@@ -11569,7 +11606,8 @@
           "selectionIncomplete": "Block selection is incomplete."
         },
         "progress": {
-          "dungeonCleared": "Dungeon cleared!"
+          "dungeonCleared": "Dungeon cleared!",
+          "nextFloor": "Advanced to the next floor! ({floor}F)"
         }
       }
     },

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -11457,10 +11457,19 @@
           "maxIncreased": "SP上限が{value}に上昇した！",
           "gained": "SPを{amount}獲得した。",
           "spent": "SPを{amount}消費した。",
+          "offered": "回復アイテムを捧げ、SPを{amount}獲得した。",
           "offerLocked": "SPシステムが解放されてから捧げられる。",
           "notUnlockedForItem": "SPが解放されていないため使用できない。",
           "noCapacity": "SP上限が0のため効果がない。",
-          "alreadyFull": "SPはすでに最大だ。"
+          "alreadyFull": "SPはすでに最大だ。",
+          "elixirUsed": "SPエリクサーを使用！SPが{amount}回復した。",
+          "fullyRestored": "SPが全快した。（+{amount}）"
+        },
+        "exp": {
+          "bossBonusSuffix": " (ボスボーナス!)",
+          "enemyGain": "経験値を {amount} 獲得！{bonus}",
+          "spent": "経験値を {amount} 消費。（{context}）",
+          "gained": "経験値を {amount} 獲得！（{context}）"
         },
         "status": {
           "paralyzed": "体が痺れて動けない…",
@@ -11485,7 +11494,8 @@
           "started": "サンドボックスを開始しました。経験値は獲得できません。"
         },
         "console": {
-          "executed": "創造神コンソールがコードを実行しました。"
+          "executed": "創造神コンソールがコードを実行しました。",
+          "error": "創造神コンソール エラー: {message}"
         },
         "unlocks": {
           "nestedLegend": "NESTED 99999999 のダンジョンを攻略し、アノス級の神格を得た！",
@@ -11500,18 +11510,38 @@
         },
         "charms": {
           "unknown": "未知の護符は使用できない。",
-          "notOwned": "その護符は所持していない。"
+          "notOwned": "その護符は所持していない。",
+          "activated": "{label}の護符が発動！効果は{turns}ターン持続する。"
         },
         "satiety": {
           "enabled": "満腹度システムが発動した！",
           "disabled": "満腹度システムが解除された。",
           "cannotEat": "満腹度システムが有効な時だけ食べられる。",
-          "alreadyFull": "満腹度は既に最大値です。"
+          "alreadyFull": "満腹度は既に最大値です。",
+          "damage": "空腹で {amount} のダメージを受けた！"
+        },
+        "chest": {
+          "prefix": {
+            "normal": "宝箱を開けた！",
+            "rare": "黄金の宝箱を開けた！"
+          },
+          "reward": {
+            "potion30": "{prefix}HP30%回復ポーションを手に入れた！",
+            "hpBoost": "{prefix}最大HP強化アイテムを手に入れた！",
+            "atkBoost": "{prefix}攻撃力強化アイテムを手に入れた！",
+            "defBoost": "{prefix}防御力強化アイテムを手に入れた！"
+          }
         },
         "goldenChest": {
           "elixir": "黄金の宝箱から特製SPエリクサーを手に入れた！SPが大幅に回復する。",
           "openedSafely": "黄金の宝箱を安全に開けた！",
-          "prompt": "黄金の宝箱だ！タイミングバーを狙おう。"
+          "prompt": "黄金の宝箱だ！タイミングバーを狙おう。",
+          "major": {
+            "hp": "黄金の宝箱から最大HP+{amount}の秘薬を手に入れた！",
+            "atk": "黄金の宝箱から攻撃力+{amount}の戦術オーブを手に入れた！",
+            "def": "黄金の宝箱から防御力+{amount}の護りの盾札を手に入れた！"
+          },
+          "skillCharm": "黄金の宝箱からスキル効果「{effectName}」の護符を手に入れた！（{turns}ターン）"
         },
         "combat": {
           "noEnemyInDirection": "その方向には敵がいない！",
@@ -11527,7 +11557,9 @@
           "teleportResistedByLevel": "レベル差で転移攻撃を耐えた！",
           "instantDeathResisted": "レベル差で即死攻撃を無効化した！",
           "instantDeathHit": "敵の即死攻撃が命中した…！",
-          "knockbackResistedByLevel": "レベル差で吹き飛ばしを踏ん張った！"
+          "knockbackResistedByLevel": "レベル差で吹き飛ばしを踏ん張った！",
+          "playerDamage": "プレイヤーは敵に {amount} のダメージを与えた！",
+          "knockbackCollision": "壁に激突して{amount}のダメージ！"
         },
         "orb": {
           "statusAttackNegated": "オーブの加護で状態異常攻撃を無効化した！",
@@ -11548,6 +11580,7 @@
           "throwNoTarget": "投げつける相手が見つからなかった。",
           "throwIneffective": "敵のレベルが高すぎて投げつけても効果がなかった…",
           "throwNoEffect": "回復アイテムを投げつけたが効果がなかった。",
+          "throwDamage": "回復アイテムを投げつけ、敵に{damage}のダメージを与えた！",
           "autoSatietyRecovered": "オートアイテムが発動！満腹度が{amount}回復",
           "potionSatietyRecovered": "ポーションを食べた！満腹度が{amount}回復",
           "autoReversedDamage": "オートアイテムが暴発し、{amount}のダメージを受けた！",
@@ -11556,9 +11589,13 @@
           "potionHpRecovered": "ポーションを使用！HPが{amount}回復",
           "autoNoEffect": "オートアイテムが発動したが体調に変化はなかった。",
           "potionNoEffect": "ポーションを使用したが体調に変化はなかった。",
+          "cleansedStatus": "回復アイテムを消費し、{status}の状態異常を治した。",
           "hpBoostUsed": "最大HP強化アイテムを使用！最大HPが5増加！",
           "attackBoostUsed": "攻撃力強化アイテムを使用！攻撃力が1増加！",
           "defenseBoostUsed": "防御力強化アイテムを使用！防御力が1増加！",
+          "hpBoostMajorUsed": "最大HP特大強化アイテムを使用！最大HPが{amount}増加！",
+          "attackBoostMajorUsed": "攻撃力特大強化アイテムを使用！攻撃力が{amount}増加！",
+          "defenseBoostMajorUsed": "防御力特大強化アイテムを使用！防御力が{amount}増加！",
           "notOwned": "そのアイテムは所持していない。",
           "noSpElixir": "SPエリクサーを所持していない。"
         },
@@ -11569,7 +11606,8 @@
           "selectionIncomplete": "ブロック選択が不完全です"
         },
         "progress": {
-          "dungeonCleared": "ダンジョンを攻略した！"
+          "dungeonCleared": "ダンジョンを攻略した！",
+          "nextFloor": "次の階層に進んだ！（{floor}F）"
         }
       }
     },


### PR DESCRIPTION
## Summary
- replace hard-coded event log template literals in `main.js` with translation-aware calls
- add matching English and Japanese locale entries for new chest, combat, SP/EXP, and charm messages

## Testing
- `node - <<'NODE'\nglobalThis.window = globalThis;\nrequire('./js/i18n/locales/en.json.js');\nconst en = globalThis.__i18nLocales.en;\nconsole.log('EN chest potion:', en.game.events.chest.reward.potion30);\nconsole.log('EN exp enemyGain:', en.game.events.exp.enemyGain);\nrequire('./js/i18n/locales/ja.json.js');\nconst ja = globalThis.__i18nLocales.ja;\nconsole.log('JA chest potion:', ja.game.events.chest.reward.potion30);\nconsole.log('JA exp enemyGain:', ja.game.events.exp.enemyGain);\nNODE`

------
https://chatgpt.com/codex/tasks/task_e_68e62bd1a76c832bbe31b6e2162ca3b1