### PR TITLE
Add translations for god console labels and statuses

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -11552,6 +11552,32 @@
         }
       }
     },
+    "godConsole": {
+      "mode": {
+        "current": "Current: {mode}",
+        "sandbox": "Sandbox Mode",
+        "normal": "Exploration Mode",
+        "toggle": {
+          "toSandbox": "Enter Sandbox Mode",
+          "toNormal": "Return to Exploration Mode"
+        }
+      },
+      "status": {
+        "prompt": "Enter code and unleash your creative power.",
+        "notAwakened": "The Creator's power has not awakened yet.",
+        "enterCode": "Please enter code.",
+        "running": "Running code…",
+        "executedWithReturn": "Code executed (return value: {value})",
+        "executed": "Code executed.",
+        "error": "Error: {message}",
+        "requiresGodPower": "Creator power is required.",
+        "toggleRestricted": "Can only switch while exploring a dungeon.",
+        "sandboxEnabled": "Sandbox mode enabled.",
+        "sandboxDisabled": "Returned to exploration mode.",
+        "sampleInserted": "Sample code inserted.",
+        "cleared": "Input cleared."
+      }
+    },
     "statusModal": {
       "title": "Player Status",
       "sections": {

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -11552,6 +11552,32 @@
         }
       }
     },
+    "godConsole": {
+      "mode": {
+        "current": "現在: {mode}",
+        "sandbox": "サンドボックスモード",
+        "normal": "探索モード",
+        "toggle": {
+          "toSandbox": "サンドボックスモードに入る",
+          "toNormal": "探索モードに戻る"
+        }
+      },
+      "status": {
+        "prompt": "コードを入力し、創造の力を解き放ちましょう。",
+        "notAwakened": "創造神の力がまだ覚醒していません。",
+        "enterCode": "コードを入力してください。",
+        "running": "コードを実行中…",
+        "executedWithReturn": "コードを実行しました（返値: {value}）",
+        "executed": "コードを実行しました。",
+        "error": "エラー: {message}",
+        "requiresGodPower": "創造神の力が必要です。",
+        "toggleRestricted": "ダンジョン探索中のみ切り替えできます。",
+        "sandboxEnabled": "サンドボックスモードを有効化しました。",
+        "sandboxDisabled": "探索モードに戻りました。",
+        "sampleInserted": "サンプルコードを挿入しました。",
+        "cleared": "入力をクリアしました。"
+      }
+    },
     "statusModal": {
       "title": "プレイヤーステータス",
       "sections": {


### PR DESCRIPTION
## Summary
- add a dedicated godConsole namespace in the English and Japanese locale files for mode labels and status messages
- update the god console mode label and toggle to use the translated strings
- localize status updates emitted by the god console when running code or changing modes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e63829d9cc832b8ab37798e90f1bff