### PR TITLE
Wrap bright game texts in dark cards

### DIFF
--- a/games/go.js
+++ b/games/go.js
@@ -22,12 +22,26 @@
     container.style.gap = '8px';
     container.style.padding = '8px';
 
+    const infoCard = document.createElement('div');
+    infoCard.style.display = 'flex';
+    infoCard.style.justifyContent = 'center';
+    infoCard.style.alignItems = 'center';
+    infoCard.style.padding = '10px 18px';
+    infoCard.style.borderRadius = '12px';
+    infoCard.style.background = 'rgba(15,23,42,0.9)';
+    infoCard.style.border = '1px solid rgba(148,163,184,0.4)';
+    infoCard.style.width = '100%';
+    infoCard.style.maxWidth = '420px';
+    infoCard.style.boxShadow = '0 10px 24px rgba(15,23,42,0.35)';
+
     const info = document.createElement('div');
     info.style.color = '#f8fafc';
     info.style.fontSize = '16px';
     info.style.textAlign = 'center';
     info.textContent = '囲碁 9×9 — あなたが先手 (黒)';
-    container.appendChild(info);
+    infoCard.appendChild(info);
+
+    container.appendChild(infoCard);
 
     const canvas = document.createElement('canvas');
     canvas.width = 480;

--- a/games/nine_mens_morris.js
+++ b/games/nine_mens_morris.js
@@ -360,11 +360,32 @@
     boardWrap.style.alignItems = 'center';
     boardWrap.style.gap = '8px';
 
+    const headerCard = document.createElement('div');
+    headerCard.style.display = 'flex';
+    headerCard.style.flexDirection = 'column';
+    headerCard.style.alignItems = 'center';
+    headerCard.style.gap = '6px';
+    headerCard.style.padding = '12px 18px';
+    headerCard.style.borderRadius = '14px';
+    headerCard.style.background = 'rgba(15,23,42,0.9)';
+    headerCard.style.border = '1px solid rgba(148,163,184,0.4)';
+    headerCard.style.boxShadow = '0 12px 28px rgba(15,23,42,0.35)';
+    headerCard.style.width = '100%';
+    headerCard.style.maxWidth = '520px';
+
     const title = document.createElement('div');
     title.textContent = 'ナイン・メンズ・モリス — あなたが先手';
     title.style.fontSize = '18px';
     title.style.fontWeight = '600';
-    boardWrap.appendChild(title);
+    headerCard.appendChild(title);
+
+    const status = document.createElement('div');
+    status.style.fontSize = '16px';
+    status.style.minHeight = '24px';
+    status.style.textAlign = 'center';
+    headerCard.appendChild(status);
+
+    boardWrap.appendChild(headerCard);
 
     const canvas = document.createElement('canvas');
     canvas.width = 520;
@@ -377,11 +398,6 @@
     boardWrap.appendChild(canvas);
 
     const ctx = canvas.getContext('2d');
-
-    const status = document.createElement('div');
-    status.style.fontSize = '16px';
-    status.style.minHeight = '24px';
-    boardWrap.appendChild(status);
 
     const panel = document.createElement('div');
     panel.style.background = 'rgba(15,23,42,0.55)';

--- a/games/pinball.js
+++ b/games/pinball.js
@@ -10,6 +10,18 @@
     wrapper.style.color = '#e2e8f0';
     wrapper.style.fontFamily = "'Segoe UI', sans-serif";
 
+    const infoCard = document.createElement('div');
+    infoCard.style.display = 'flex';
+    infoCard.style.flexDirection = 'column';
+    infoCard.style.alignItems = 'center';
+    infoCard.style.gap = '12px';
+    infoCard.style.padding = '14px 18px';
+    infoCard.style.borderRadius = '16px';
+    infoCard.style.background = 'rgba(15,23,42,0.9)';
+    infoCard.style.border = '1px solid rgba(148,163,184,0.4)';
+    infoCard.style.boxShadow = '0 16px 32px rgba(15,23,42,0.35)';
+    infoCard.style.width = 'min(100%, 620px)';
+
     const info = document.createElement('div');
     info.style.display = 'flex';
     info.style.flexWrap = 'wrap';
@@ -21,14 +33,16 @@
       <span>プランジャー: スペースキー長押しでショット</span>
       <span>Rキー: リセット</span>
     `;
-    wrapper.appendChild(info);
+    infoCard.appendChild(info);
 
     const status = document.createElement('div');
     status.style.display = 'flex';
     status.style.gap = '18px';
     status.style.fontSize = '15px';
     status.style.fontWeight = '600';
-    wrapper.appendChild(status);
+    status.style.flexWrap = 'wrap';
+    status.style.justifyContent = 'center';
+    infoCard.appendChild(status);
 
     const missionInfo = document.createElement('div');
     missionInfo.style.fontSize = '13px';
@@ -37,16 +51,16 @@
     missionInfo.style.minHeight = '56px';
     missionInfo.style.padding = '4px 12px';
     missionInfo.style.borderRadius = '10px';
-    missionInfo.style.background = 'rgba(15, 23, 42, 0.45)';
+    missionInfo.style.background = 'rgba(15, 23, 42, 0.65)';
     missionInfo.style.border = '1px solid rgba(148, 163, 184, 0.35)';
-    wrapper.appendChild(missionInfo);
+    infoCard.appendChild(missionInfo);
 
     const skillInfo = document.createElement('div');
     skillInfo.style.fontSize = '12px';
     skillInfo.style.opacity = '0.85';
     skillInfo.style.textAlign = 'center';
     skillInfo.style.minHeight = '22px';
-    wrapper.appendChild(skillInfo);
+    infoCard.appendChild(skillInfo);
 
     const announcer = document.createElement('div');
     announcer.style.minHeight = '28px';
@@ -55,7 +69,9 @@
     announcer.style.color = '#facc15';
     announcer.style.transition = 'opacity 0.3s ease';
     announcer.style.opacity = '0';
-    wrapper.appendChild(announcer);
+    infoCard.appendChild(announcer);
+
+    wrapper.appendChild(infoCard);
 
     const canvas = document.createElement('canvas');
     const W = 600, H = 820;

--- a/games/taiko_drum.js
+++ b/games/taiko_drum.js
@@ -101,26 +101,41 @@
     container.style.flexDirection = 'column';
     container.style.gap = '12px';
 
+    const baseFont = "'Segoe UI', 'Yu Gothic UI', sans-serif";
+
+    const headerCard = document.createElement('div');
+    headerCard.style.display = 'flex';
+    headerCard.style.flexDirection = 'column';
+    headerCard.style.alignItems = 'center';
+    headerCard.style.gap = '8px';
+    headerCard.style.padding = '12px 18px';
+    headerCard.style.borderRadius = '16px';
+    headerCard.style.background = 'rgba(15,23,42,0.9)';
+    headerCard.style.border = '1px solid rgba(148,163,184,0.4)';
+    headerCard.style.boxShadow = '0 14px 28px rgba(15,23,42,0.35)';
+
     const title = document.createElement('h2');
     title.textContent = `太鼓リズム（${difficulty}）`;
     title.style.margin = '0';
     title.style.fontSize = '20px';
     title.style.textAlign = 'center';
     title.style.color = '#f8fafc';
-    title.style.fontFamily = "'Segoe UI', 'Yu Gothic UI', sans-serif";
-    container.appendChild(title);
-
-    const hud = createResultHud();
-    container.appendChild(hud);
-    let resultNode = null;
+    title.style.fontFamily = baseFont;
+    headerCard.appendChild(title);
 
     const tips = document.createElement('div');
     tips.textContent = 'F/J/Space = ドン（赤）、D/K = カッ（青）。大音符は両方同時！タップもOK。';
     tips.style.fontSize = '12px';
-    tips.style.color = 'rgba(226,232,240,0.8)';
+    tips.style.color = 'rgba(226,232,240,0.85)';
     tips.style.textAlign = 'center';
-    tips.style.fontFamily = hud.style.fontFamily;
-    container.appendChild(tips);
+    tips.style.fontFamily = baseFont;
+    headerCard.appendChild(tips);
+
+    container.appendChild(headerCard);
+
+    const hud = createResultHud();
+    container.appendChild(hud);
+    let resultNode = null;
 
     const canvas = document.createElement('canvas');
     canvas.width = CANVAS_WIDTH;


### PR DESCRIPTION
## Summary
- wrap the Go minigame's introductory text in a dark card for contrast
- add dark header panels for Nine Men's Morris and Taiko Drum to hold status/help copy
- consolidate Pinball's instructions and HUD text into a shared dark info card

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e63805ee40832bbbf796c9f5f6962d