### PR TITLE
Add translation for sandbox domain placeholder

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -10604,6 +10604,13 @@
           "hint": "Export or import all game and tool data in one bundle."
         }
       },
+      "sandbox": {
+        "controls": {
+          "domain": {
+            "noneAvailable": "No domain crystals available"
+          }
+        }
+      },
       "modMaker": {
         "panelAriaLabel": "Dungeon Type Mod Maker",
         "header": {

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -10604,6 +10604,13 @@
           "hint": "ゲームとツールの全データをまとめてエクスポート／インポートします。"
         }
       },
+      "sandbox": {
+        "controls": {
+          "domain": {
+            "noneAvailable": "配置可能なクリスタルなし"
+          }
+        }
+      },
       "modMaker": {
         "panelAriaLabel": "ダンジョンタイプMod作成ツール",
         "header": {

--- a/main.js
+++ b/main.js
@@ -4069,7 +4069,10 @@ function updateSandboxToolControls() {
         if (!list.length) {
             const option = document.createElement('option');
             option.value = '';
-            option.textContent = '配置可能なクリスタルなし';
+            option.textContent = translateOrFallback(
+                'tools.sandbox.controls.domain.noneAvailable',
+                '配置可能なクリスタルなし'
+            );
             sandboxToolDomainSelect.appendChild(option);
         } else {
             const fragment = document.createDocumentFragment();
@@ -18849,6 +18852,11 @@ document.addEventListener('app:rerender', () => {
         }
     } catch (err) {
         console.warn('[app] Failed to refresh BlockDim UI on rerender', err);
+    }
+    try {
+        updateSandboxToolControls();
+    } catch (err) {
+        console.warn('[app] Failed to refresh sandbox tool controls on rerender', err);
     }
 });
 


### PR DESCRIPTION
## Summary
- add a localized translation key for the sandbox domain crystal placeholder in Japanese and English dictionaries
- set the sandbox domain selection placeholder via translateOrFallback and refresh it when rerendering after locale changes

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e6395bf3c4832bbaa3fd381cc3c80b