### PR TITLE
Localize golden chest interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -1337,14 +1337,14 @@
 
     <div id="rare-chest-modal" class="modal modal--rare-chest" style="display:none;" aria-hidden="true">
         <div class="modal-content rare-chest-modal__content">
-            <h3>黄金の宝箱</h3>
-            <p id="rare-chest-status" class="rare-chest-status">タイミングバーを中央で止めよう！（Space/Enter）</p>
+            <h3 data-i18n="game.goldenChest.modal.title">黄金の宝箱</h3>
+            <p id="rare-chest-status" class="rare-chest-status" data-i18n="game.goldenChest.modal.status">タイミングバーを中央で止めよう！（Space/Enter）</p>
             <div class="rare-chest-bar">
                 <div class="rare-chest-bar__target"></div>
                 <div id="rare-chest-pointer" class="rare-chest-bar__pointer"></div>
             </div>
-            <button id="rare-chest-stop" class="rare-chest-stop-btn">ストップ</button>
-            <p class="rare-chest-hint">Space / Enter キーでも止められます。</p>
+            <button id="rare-chest-stop" class="rare-chest-stop-btn" data-i18n="game.goldenChest.modal.stop">ストップ</button>
+            <p class="rare-chest-hint" data-i18n="game.goldenChest.modal.hint">Space / Enter キーでも止められます。</p>
         </div>
     </div>
 

--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -11679,6 +11679,12 @@
           }
         },
         "goldenChest": {
+          "modal": {
+            "title": "Golden Chest",
+            "status": "Stop the timing bar in the center! (Space/Enter)",
+            "stop": "Stop",
+            "hint": "You can also press Space or Enter."
+          },
           "elixir": "Found a special SP Elixir in the golden chest! SP greatly restored.",
           "openedSafely": "Opened the golden chest safely!",
           "prompt": "A golden chest! Time your press with the bar.",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -11679,6 +11679,12 @@
           }
         },
         "goldenChest": {
+          "modal": {
+            "title": "黄金の宝箱",
+            "status": "タイミングバーを中央で止めよう！（Space/Enter）",
+            "stop": "ストップ",
+            "hint": "Space / Enter キーでも止められます。"
+          },
           "elixir": "黄金の宝箱から特製SPエリクサーを手に入れた！SPが大幅に回復する。",
           "openedSafely": "黄金の宝箱を安全に開けた！",
           "prompt": "黄金の宝箱だ！タイミングバーを狙おう。",

--- a/main.js
+++ b/main.js
@@ -15636,7 +15636,11 @@ function startRareChestMinigame(chest) {
     rareChestState.direction = Math.random() < 0.5 ? -1 : 1;
     rareChestState.pendingEnemyTurn = true;
     updateRareChestPointerVisual();
-    setRareChestStatus('タイミングバーを中央で止めよう！（Space/Enter）');
+    const statusText = translateOrFallback(
+        'game.goldenChest.modal.status',
+        'タイミングバーを中央で止めよう！（Space/Enter）'
+    );
+    setRareChestStatus(statusText);
     openModal(rareChestModal);
     stopRareChestAnimation();
     rareChestState.rafId = requestAnimationFrame(rareChestAnimationStep);


### PR DESCRIPTION
## Summary
- add i18n bindings to the golden chest modal so its title, status text, hint, and stop button translate per locale
- provide locale strings in Japanese and English for the modal and use translateOrFallback when starting the mini-game

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6469ae070832b885ac1174474c50c