### PR TITLE
Ensure achievements statistics tab reflects locale changes

### DIFF
--- a/js/achievements.js
+++ b/js/achievements.js
@@ -2219,6 +2219,9 @@
 
     if (typeof global.document?.addEventListener === 'function') {
         global.document.addEventListener('visibilitychange', resetPlaytimeClock, { passive: true });
+        global.document.addEventListener('i18n:locale-changed', () => {
+            if (ui.initialized) renderAll();
+        }, { passive: true });
     }
     if (typeof global.addEventListener === 'function') {
         global.addEventListener('focus', resetPlaytimeClock, { passive: true });


### PR DESCRIPTION
## Summary
- re-render the achievements and statistics UI when the locale changes so the statistics tab updates translated text

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e6530a74dc832ba5d54588c6cf3e61