### PR TITLE
Fix duplicate HP label text in stat displays

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -11870,7 +11870,7 @@
       "stats": {
         "valueWithBase": "{effective} (Base {base})",
         "levelWithBase": "Lv.{effective} (Base {base})",
-        "hp": "HP {current}/{max}{baseSuffix}"
+        "hp": "{current}/{max}{baseSuffix}"
       }
     }
   };

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -11870,7 +11870,7 @@
       "stats": {
         "valueWithBase": "{effective} (基{base})",
         "levelWithBase": "Lv.{effective} (基{base})",
-        "hp": "HP {current}/{max}{baseSuffix}"
+        "hp": "{current}/{max}{baseSuffix}"
       }
     }
   };


### PR DESCRIPTION
## Summary
- remove the redundant "HP" prefix from the stat value translations so the number displays without duplication

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e656a13f1c832bb7943303e527a1dc