### PR TITLE
Localize Acchi Muite Hoi minigame

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -10324,6 +10324,76 @@
     },
 
     "minigame": {
+      "acchimuitehoi": {
+        "instructions": {
+          "rpsTitle": "1. Decide roles with Rock-Paper-Scissors",
+          "rpsHint": "Win to attack, lose to defend.",
+          "directionTitle": "2. Acchi Muite Hoi",
+          "directionHint": "Choose a direction within {seconds} s.",
+          "logTitle": "Battle Log"
+        },
+        "ui": {
+          "stage": {
+            "rps": "Decide offense and defense with rock-paper-scissors",
+            "attack": "Attack phase: quickly choose a direction to point.",
+            "defense": "Defense phase: quickly choose a different direction."
+          }
+        },
+        "hands": {
+          "rock": "Rock",
+          "scissors": "Scissors",
+          "paper": "Paper"
+        },
+        "direction": {
+          "up": "Up",
+          "down": "Down",
+          "left": "Left",
+          "right": "Right"
+        },
+        "role": {
+          "attack": "Attack",
+          "defense": "Defense"
+        },
+        "countdown": {
+          "idle": "Time --.- s left",
+          "remaining": "Time {seconds} s left"
+        },
+        "score": {
+          "primary": "Hits landed: {attackWins} / Dodges: {defenseWins}",
+          "secondary": "Attack streak: {attackStreak} (best {bestAttackStreak}) / Defense streak: {defenseStreak} (best {bestDefenseStreak})",
+          "tertiaryWithRate": "Rounds: {rounds} / Success rate: {successRate}%",
+          "tertiaryEmpty": "Rounds: 0 / Success rate: --%"
+        },
+        "status": {
+          "ready": "Pick a hand to start!",
+          "tie": "Tie with {hand}! Try again.",
+          "playerWin": "You won! Point a direction in time to land a hit.",
+          "cpuWin": "CPU attacks! Choose a different direction in time to dodge.",
+          "attack": {
+            "hit": "Hit! {direction} for {exp} EXP.",
+            "hitBonus": "Hit! {direction} for {exp} EXP (streak {streak}).",
+            "miss": "Missed… CPU looked {cpuDirection}.",
+            "timeout": "Time up… missed your chance."
+          },
+          "defense": {
+            "success": "Dodged! Avoided {cpuDirection}! {exp} EXP.",
+            "successBonus": "Dodged! Avoided {cpuDirection} (streak {streak}).",
+            "fail": "Failed to dodge… also looked {direction}.",
+            "timeout": "Time up… took the hit."
+          },
+          "paused": "Paused"
+        },
+        "log": {
+          "tie": "Tie: keep going.",
+          "rpsResult": "RPS: You={playerHand} / CPU={cpuHand} → {role}",
+          "attackSuccess": "Offense success: CPU looked {cpuDirection} → {exp} EXP",
+          "attackFail": "Offense miss: CPU {cpuDirection} / You {playerDirection}",
+          "defenseSuccess": "Defense success: CPU {cpuDirection} / You {playerDirection} → {exp} EXP",
+          "defenseFail": "Defense failed: hit by matching direction.",
+          "attackTimeout": "Offense timeout: chance slipped away.",
+          "defenseTimeout": "Defense timeout: reacted too late."
+        }
+      },
       "taiko_drum": {
         "title": "Taiko Rhythm ({difficulty})",
         "tips": "F/J/Space = Don (red), D/K = Ka (blue). Hit both at once for big notes! Touch input works too.",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -10324,6 +10324,76 @@
     },
 
     "minigame": {
+      "acchimuitehoi": {
+        "instructions": {
+          "rpsTitle": "1. じゃんけんで攻守決定",
+          "rpsHint": "勝ったら攻め、負けたら防御",
+          "directionTitle": "2. あっち向いてホイ",
+          "directionHint": "制限時間 {seconds} 秒以内に方向を選択",
+          "logTitle": "戦況ログ"
+        },
+        "ui": {
+          "stage": {
+            "rps": "じゃんけんで攻守を決めよう",
+            "attack": "攻撃フェーズ：指す方向を素早く選ぼう",
+            "defense": "防御フェーズ：相手と違う方向を素早く選ぼう"
+          }
+        },
+        "hands": {
+          "rock": "グー",
+          "scissors": "チョキ",
+          "paper": "パー"
+        },
+        "direction": {
+          "up": "上",
+          "down": "下",
+          "left": "左",
+          "right": "右"
+        },
+        "role": {
+          "attack": "攻め",
+          "defense": "守り"
+        },
+        "countdown": {
+          "idle": "残り --.- 秒",
+          "remaining": "残り {seconds} 秒"
+        },
+        "score": {
+          "primary": "攻め成功: {attackWins}／防御成功: {defenseWins}",
+          "secondary": "攻め連続: {attackStreak}（最高 {bestAttackStreak}）／防御連続: {defenseStreak}（最高 {bestDefenseStreak}）",
+          "tertiaryWithRate": "決着数: {rounds}／成功率: {successRate}%",
+          "tertiaryEmpty": "決着数: 0／成功率: --%"
+        },
+        "status": {
+          "ready": "手を選んでミニゲーム開始！",
+          "tie": "あいこで {hand}！もう一度",
+          "playerWin": "あなたの勝ち！制限内に指す方向を選んでヒットを狙おう",
+          "cpuWin": "相手が攻め！制限内に別方向を選んで回避",
+          "attack": {
+            "hit": "ヒット！{direction}で{exp}EXP",
+            "hitBonus": "ヒット！{direction}で{exp}EXP（連続{streak}）",
+            "miss": "外した…CPUは{cpuDirection}を向いた",
+            "timeout": "時間切れ…指しそびれた"
+          },
+          "defense": {
+            "success": "回避成功！{cpuDirection}を避けた！{exp}EXP",
+            "successBonus": "回避成功！{cpuDirection}を避けた（連続{streak}）",
+            "fail": "回避失敗…同じ{direction}を向いた",
+            "timeout": "時間切れ…反応できずヒット"
+          },
+          "paused": "一時停止中"
+        },
+        "log": {
+          "tie": "あいこ続行",
+          "rpsResult": "じゃんけん結果: あなた={playerHand}／相手={cpuHand} → {role}",
+          "attackSuccess": "攻め成功：CPUは{cpuDirection} → {exp}EXP",
+          "attackFail": "攻め失敗：CPU {cpuDirection}／あなた {playerDirection}",
+          "defenseSuccess": "防御成功：相手 {cpuDirection}／あなた {playerDirection} → {exp}EXP",
+          "defenseFail": "防御失敗：同方向でヒット",
+          "attackTimeout": "攻め時間切れ：チャンスを逃した",
+          "defenseTimeout": "防御時間切れ：反応が遅れた"
+        }
+      },
       "taiko_drum": {
         "title": "太鼓リズム（{difficulty}）",
         "tips": "F/J/Space = ドン（赤）、D/K = カッ（青）。大音符は両方同時！タップもOK。",


### PR DESCRIPTION
## Summary
- integrate the MiniExp localization helper into Acchi Muite Hoi so stage, status, score, and log text respond to locale changes
- add Japanese and English translation strings for the game's UI, status messages, countdown, and logs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e659611738832bb82c34cfce71b88b