### PR TITLE
Localize Aim mini-game HUD

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -589,7 +589,16 @@
           },
           "aim": {
             "name": "Aim Trainer",
-            "description": "Hit targets for 1–3 EXP and keep streaks alive for bonuses."
+            "description": "Hit targets for 1–3 EXP and keep streaks alive for bonuses.",
+            "hud": {
+              "time": "TIME: {time}",
+              "hitsAccuracy": "HITS: {hits}  ACC: {accuracy}%",
+              "combo": "COMBO x{combo}"
+            },
+            "overlay": {
+              "timeUp": "Time Up",
+              "restartHint": "Press R to restart"
+            }
           },
           "dodge_race": {
             "name": "Dodge Race",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -589,7 +589,16 @@
           },
           "aim": {
             "name": "的あて（エイム）",
-            "description": "命中で1〜3EXP／連続命中ボーナス"
+            "description": "命中で1〜3EXP／連続命中ボーナス",
+            "hud": {
+              "time": "残り時間: {time}",
+              "hitsAccuracy": "命中: {hits}  精度: {accuracy}%",
+              "combo": "コンボ x{combo}"
+            },
+            "overlay": {
+              "timeUp": "タイムアップ",
+              "restartHint": "Rで再開/再起動"
+            }
           },
           "dodge_race": {
             "name": "回避レース",


### PR DESCRIPTION
## Summary
- add localization helpers to the Aim mini-game so HUD text reacts to locale changes
- translate HUD and end-screen strings for Aim into Japanese and English locale files

## Testing
- not run (no automated tests provided)


------
https://chatgpt.com/codex/tasks/task_e_68e6597a2f40832bbf0983529d8a6cb9