### PR TITLE
Add localization support to chess mini-game

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -381,7 +381,36 @@
           },
           "chess": {
             "name": "Chess",
-            "description": "Outmaneuver the king with tactical captures and checks to gain EXP."
+            "description": "Outmaneuver the king with tactical captures and checks to gain EXP.",
+            "title": "Chess",
+            "difficultyTag": "Difficulty: {value}",
+            "difficultyValue": {
+              "easy": "Easy",
+              "normal": "Normal",
+              "hard": "Hard"
+            },
+            "status": {
+              "stopped": "Stopped",
+              "turnLabel": "Turn:",
+              "yourTurn": "Your move",
+              "aiThinking": "AI is thinking…",
+              "scoreLabel": "Score:"
+            },
+            "messages": {
+              "checkmateWin": "Checkmate! You win.",
+              "checkmateLoss": "Checkmated…",
+              "stalemate": "Stalemate. The game is a draw.",
+              "draw": "The game was recorded as a draw.",
+              "playerCheck": "Check!",
+              "playerInCheck": "You are in check!",
+              "selectMove": "Select a destination square."
+            },
+            "prompts": {
+              "promotion": "Choose a promotion piece (Q/R/B/N)"
+            },
+            "controls": {
+              "restart": "Restart"
+            }
           },
           "xiangqi": {
             "name": "Xiangqi",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -381,7 +381,36 @@
           },
           "chess": {
             "name": "チェス",
-            "description": "駒の組み合わせで王を詰ませる本格チェス。駒取りとチェックでEXPを獲得"
+            "description": "駒の組み合わせで王を詰ませる本格チェス。駒取りとチェックでEXPを獲得",
+            "title": "チェス",
+            "difficultyTag": "難易度: {value}",
+            "difficultyValue": {
+              "easy": "EASY",
+              "normal": "NORMAL",
+              "hard": "HARD"
+            },
+            "status": {
+              "stopped": "停止中",
+              "turnLabel": "手番:",
+              "yourTurn": "あなたの番です",
+              "aiThinking": "AIの思考中…",
+              "scoreLabel": "スコア:"
+            },
+            "messages": {
+              "checkmateWin": "チェックメイト！勝利しました。",
+              "checkmateLoss": "チェックメイトを受けました…",
+              "stalemate": "ステイルメイト。引き分けです。",
+              "draw": "引き分け扱いになりました。",
+              "playerCheck": "チェック！",
+              "playerInCheck": "チェックされています！",
+              "selectMove": "移動するマスを選択してください"
+            },
+            "prompts": {
+              "promotion": "昇格する駒を選んでください (Q/R/B/N)"
+            },
+            "controls": {
+              "restart": "リスタート"
+            }
           },
           "xiangqi": {
             "name": "シャンチー",


### PR DESCRIPTION
## Summary
- integrate i18n translation helpers into the chess mini-game UI and messaging
- add localized strings for chess controls, statuses, and prompts in Japanese and English

## Testing
- node -e "require('./js/i18n/locales/en.json.js')"
- node -e "require('./js/i18n/locales/ja.json.js')"

------
https://chatgpt.com/codex/tasks/task_e_68e65b2f2514832b9a06eca1f601d90f