### PR TITLE
Add localization support for Clock Hub UI

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -11813,6 +11813,233 @@
         "cleared": "Input cleared."
       }
     },
+    "games": {
+      "clockHub": {
+        "errors": {
+          "noContainer": "Clock Hub requires a container"
+        },
+        "header": {
+          "title": "Clock Utility Hub",
+          "subtitle": "Switch between digital, analog, and detailed time views",
+          "exp": "EXP Earned: {xp}"
+        },
+        "tabs": {
+          "digital": "Digital Clock",
+          "analog": "Analog Clock",
+          "detail": "Details"
+        },
+        "detailTabs": {
+          "overview": "Overview",
+          "progress": "Progress",
+          "remain": "Time Remaining",
+          "stats": "Information",
+          "calendar": "Calendar"
+        },
+        "digital": {
+          "format": {
+            "24h": "24-hour format",
+            "12h": "12-hour format"
+          },
+          "period": {
+            "am": "AM",
+            "pm": "PM"
+          },
+          "dateLine": "{weekday}, {month}/{day}/{year}",
+          "timeLine12": "{period} {hour}:{minute}:{second}",
+          "timeLine24": "{hour}:{minute}:{second}"
+        },
+        "analog": {
+          "type": {
+            "12h": "Standard analog clock",
+            "24h": "24-hour analog clock"
+          }
+        },
+        "weekdays": {
+          "0": "Sun",
+          "1": "Mon",
+          "2": "Tue",
+          "3": "Wed",
+          "4": "Thu",
+          "5": "Fri",
+          "6": "Sat"
+        },
+        "dates": {
+          "full": "{weekday}, {month}/{day}/{year}"
+        },
+        "era": {
+          "reiwa": "Reiwa",
+          "heisei": "Heisei",
+          "showa": "Showa",
+          "taisho": "Taisho",
+          "meiji": "Meiji",
+          "format": "{era} Year {year}",
+          "unknown": "Unknown"
+        },
+        "eto": {
+          "stems": {
+            "0": "Kinoe",
+            "1": "Kinoto",
+            "2": "Hinoe",
+            "3": "Hinoto",
+            "4": "Tsuchinoe",
+            "5": "Tsuchinoto",
+            "6": "Kanoe",
+            "7": "Kanoto",
+            "8": "Mizunoe",
+            "9": "Mizunoto"
+          },
+          "branches": {
+            "0": "Rat",
+            "1": "Ox",
+            "2": "Tiger",
+            "3": "Rabbit",
+            "4": "Dragon",
+            "5": "Snake",
+            "6": "Horse",
+            "7": "Goat",
+            "8": "Monkey",
+            "9": "Rooster",
+            "10": "Dog",
+            "11": "Boar"
+          },
+          "format": "{stem}-{branch}"
+        },
+        "season": {
+          "winter": "Winter",
+          "spring": "Spring",
+          "summer": "Summer",
+          "autumn": "Autumn",
+          "unknown": "Unknown"
+        },
+        "solarTerms": {
+          "risshun": "Beginning of Spring",
+          "usui": "Rain Water",
+          "keichitsu": "Awakening of Insects",
+          "shunbun": "Spring Equinox",
+          "seimei": "Clear and Bright",
+          "kokuu": "Grain Rain",
+          "rikka": "Beginning of Summer",
+          "shoman": "Grain Full",
+          "boshu": "Grain in Ear",
+          "geshi": "Summer Solstice",
+          "shosho": "Lesser Heat",
+          "taisho": "Greater Heat",
+          "risshu": "Beginning of Autumn",
+          "shoshoLimitHeat": "Limit of Heat",
+          "hakuro": "White Dew",
+          "shubun": "Autumn Equinox",
+          "kanro": "Cold Dew",
+          "soko": "Frost Descent",
+          "rittou": "Beginning of Winter",
+          "shosetsu": "Lesser Snow",
+          "taisetsu": "Greater Snow",
+          "touji": "Winter Solstice",
+          "shokan": "Lesser Cold",
+          "dahan": "Greater Cold",
+          "nextDate": "{month}/{day}/{year}",
+          "description": "Prev {previous} → Next {next} ({nextDate}, {duration})"
+        },
+        "duration": {
+          "prefix": {
+            "future": "in ",
+            "past": "ago "
+          },
+          "unit": {
+            "year": "{value} yr",
+            "day": "{value} d",
+            "hour": "{value} h",
+            "minute": "{value} min",
+            "second": "{value} s"
+          },
+          "joiner": " "
+        },
+        "progress": {
+          "labels": {
+            "millennium": "Millennium",
+            "century": "Century",
+            "decade": "Decade",
+            "year": "Year",
+            "month": "Month",
+            "day": "Day",
+            "hour": "Hour",
+            "minute": "Minute",
+            "second": "Second"
+          },
+          "percent": "{value}%"
+        },
+        "remaining": {
+          "labels": {
+            "nextSecond": "Next second",
+            "nextMinute": "Next minute",
+            "nextHour": "Next hour",
+            "nextDay": "Next day",
+            "nextMonth": "Next month",
+            "nextYear": "Next year"
+          },
+          "delta": " (±{millis} ms)",
+          "value": "{duration}{delta}"
+        },
+        "stats": {
+          "labels": {
+            "unix": "UNIX time",
+            "ticks": "Elapsed milliseconds",
+            "iso": "ISO 8601",
+            "yearday": "Day of year",
+            "daySeconds": "Seconds today",
+            "timezone": "Time zone"
+          },
+          "yeardayValue": "Day {value}",
+          "daySecondsValue": "{value} s",
+          "timezoneFallback": "Local"
+        },
+        "calendar": {
+          "settings": {
+            "title": "Custom holiday/workday settings",
+            "holidayTitle": "Add as holiday",
+            "workdayTitle": "Add as workday",
+            "add": "Add",
+            "empty": "None",
+            "remove": "Remove"
+          },
+          "info": {
+            "summary": "Date: {date}",
+            "era": "Japanese era: {era} | Zodiac: {eto}",
+            "season": "Season: {season} | Quarter {quarter}",
+            "progress": "Day {dayOfYear} | ISO week {isoWeek} | Week {weekOfMonth} of month",
+            "status": "Status: {status}"
+          },
+          "status": {
+            "rest": "Rest day",
+            "workday": "Expected workday",
+            "holiday": "Marked holiday",
+            "workdayOverride": "Marked workday",
+            "separator": " / "
+          },
+          "controls": {
+            "prev": "← Prev",
+            "next": "Next →",
+            "today": "Today"
+          },
+          "monthLabel": "{year}-{month}",
+          "today": "Today: {date}"
+        },
+        "common": {
+          "yes": "Yes",
+          "no": "No"
+        },
+        "overview": {
+          "gregorian": "Gregorian: {month}/{day}/{year} ({weekday})",
+          "era": "Japanese era: {era}",
+          "eto": "Zodiac: {eto} | Imperial year: {imperial}",
+          "season": "Season: {season} | Solar term: {solarTerm}",
+          "leapYear": "Leap year: {value}"
+        },
+        "xp": {
+          "note": "Sec:+{second} / Min:+{minute} / Hr:+{hour} / Day:+{day} / Month:+{month} / Year:+{year} / Century:+{century} / Millennium:+{millennium}"
+        }
+      }
+    },
+
     "statusModal": {
       "title": "Player Status",
       "sections": {

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -11813,6 +11813,233 @@
         "cleared": "入力をクリアしました。"
       }
     },
+    "games": {
+      "clockHub": {
+        "errors": {
+          "noContainer": "Clock Hubにはコンテナが必要です"
+        },
+        "header": {
+          "title": "時計ユーティリティハブ",
+          "subtitle": "デジタル／アナログ／詳細情報を切り替え",
+          "exp": "獲得EXP: {xp}"
+        },
+        "tabs": {
+          "digital": "デジタル時計",
+          "analog": "アナログ時計",
+          "detail": "詳細"
+        },
+        "detailTabs": {
+          "overview": "概要",
+          "progress": "進捗率",
+          "remain": "残り時間",
+          "stats": "情報一覧",
+          "calendar": "カレンダー"
+        },
+        "digital": {
+          "format": {
+            "24h": "24時間制",
+            "12h": "12時間制"
+          },
+          "period": {
+            "am": "午前",
+            "pm": "午後"
+          },
+          "dateLine": "{year}年{month}月{day}日（{weekday}）",
+          "timeLine12": "{period}{hour}時{minute}分{second}秒",
+          "timeLine24": "{hour}時{minute}分{second}秒"
+        },
+        "analog": {
+          "type": {
+            "12h": "通常アナログ時計",
+            "24h": "24時間制アナログ時計"
+          }
+        },
+        "weekdays": {
+          "0": "日",
+          "1": "月",
+          "2": "火",
+          "3": "水",
+          "4": "木",
+          "5": "金",
+          "6": "土"
+        },
+        "dates": {
+          "full": "{year}年{month}月{day}日（{weekday}）"
+        },
+        "era": {
+          "reiwa": "令和",
+          "heisei": "平成",
+          "showa": "昭和",
+          "taisho": "大正",
+          "meiji": "明治",
+          "format": "{era}{year}年",
+          "unknown": "不明"
+        },
+        "eto": {
+          "stems": {
+            "0": "甲",
+            "1": "乙",
+            "2": "丙",
+            "3": "丁",
+            "4": "戊",
+            "5": "己",
+            "6": "庚",
+            "7": "辛",
+            "8": "壬",
+            "9": "癸"
+          },
+          "branches": {
+            "0": "子",
+            "1": "丑",
+            "2": "寅",
+            "3": "卯",
+            "4": "辰",
+            "5": "巳",
+            "6": "午",
+            "7": "未",
+            "8": "申",
+            "9": "酉",
+            "10": "戌",
+            "11": "亥"
+          },
+          "format": "{stem}{branch}"
+        },
+        "season": {
+          "winter": "冬",
+          "spring": "春",
+          "summer": "夏",
+          "autumn": "秋",
+          "unknown": "不明"
+        },
+        "solarTerms": {
+          "risshun": "立春",
+          "usui": "雨水",
+          "keichitsu": "啓蟄",
+          "shunbun": "春分",
+          "seimei": "清明",
+          "kokuu": "穀雨",
+          "rikka": "立夏",
+          "shoman": "小満",
+          "boshu": "芒種",
+          "geshi": "夏至",
+          "shosho": "小暑",
+          "taisho": "大暑",
+          "risshu": "立秋",
+          "shoshoLimitHeat": "処暑",
+          "hakuro": "白露",
+          "shubun": "秋分",
+          "kanro": "寒露",
+          "soko": "霜降",
+          "rittou": "立冬",
+          "shosetsu": "小雪",
+          "taisetsu": "大雪",
+          "touji": "冬至",
+          "shokan": "小寒",
+          "dahan": "大寒",
+          "nextDate": "{year}年{month}月{day}日",
+          "description": "{previous} → 次は{next}（{nextDate}、{duration}）"
+        },
+        "duration": {
+          "prefix": {
+            "future": "あと",
+            "past": "前"
+          },
+          "unit": {
+            "year": "{value}年",
+            "day": "{value}日",
+            "hour": "{value}時間",
+            "minute": "{value}分",
+            "second": "{value}秒"
+          },
+          "joiner": ""
+        },
+        "progress": {
+          "labels": {
+            "millennium": "千年紀",
+            "century": "世紀",
+            "decade": "年代",
+            "year": "年",
+            "month": "月",
+            "day": "日",
+            "hour": "時",
+            "minute": "分",
+            "second": "秒"
+          },
+          "percent": "{value}%"
+        },
+        "remaining": {
+          "labels": {
+            "nextSecond": "次の秒",
+            "nextMinute": "次の分",
+            "nextHour": "次の時",
+            "nextDay": "次の日",
+            "nextMonth": "次の月",
+            "nextYear": "次の年"
+          },
+          "delta": "（±{millis}ms）",
+          "value": "{duration}{delta}"
+        },
+        "stats": {
+          "labels": {
+            "unix": "UNIX時間",
+            "ticks": "経過ミリ秒",
+            "iso": "ISO 8601",
+            "yearday": "年内通算日",
+            "daySeconds": "今日の経過秒",
+            "timezone": "タイムゾーン"
+          },
+          "yeardayValue": "第{value}日目",
+          "daySecondsValue": "{value}秒",
+          "timezoneFallback": "ローカル"
+        },
+        "calendar": {
+          "settings": {
+            "title": "休暇／出勤日のカスタム設定",
+            "holidayTitle": "祝日・休暇として登録",
+            "workdayTitle": "出勤日として登録",
+            "add": "追加",
+            "empty": "登録なし",
+            "remove": "削除"
+          },
+          "info": {
+            "summary": "日付: {date}",
+            "era": "和暦: {era}｜干支: {eto}",
+            "season": "季節: {season}｜四半期: 第{quarter}四半期",
+            "progress": "年内通算日: 第{dayOfYear}日｜ISO週番号: 第{isoWeek}週｜月内第{weekOfMonth}週",
+            "status": "区分: {status}"
+          },
+          "status": {
+            "rest": "休み",
+            "workday": "出勤日想定",
+            "holiday": "祝日登録あり",
+            "workdayOverride": "出勤登録あり",
+            "separator": " / "
+          },
+          "controls": {
+            "prev": "← 前月",
+            "next": "翌月 →",
+            "today": "今日"
+          },
+          "monthLabel": "{year}年{month}月",
+          "today": "本日: {date}"
+        },
+        "common": {
+          "yes": "はい",
+          "no": "いいえ"
+        },
+        "overview": {
+          "gregorian": "西暦: {year}年 {month}月{day}日（{weekday}）",
+          "era": "和暦: {era}",
+          "eto": "干支: {eto}｜皇紀: {imperial}",
+          "season": "季節: {season}｜二十四節気: {solarTerm}",
+          "leapYear": "うるう年: {value}"
+        },
+        "xp": {
+          "note": "秒:+{second} / 分:+{minute} / 時:+{hour} / 日:+{day} / 月:+{month} / 年:+{year} / 世紀:+{century} / 千年紀:+{millennium}"
+        }
+      }
+    },
+
     "statusModal": {
       "title": "プレイヤーステータス",
       "sections": {


### PR DESCRIPTION
## Summary
- integrate an i18n helper into `games/clock_hub.js` and replace hardcoded strings with translated lookups
- restructure clock hub data definitions and dynamic formatting to support localized text for tabs, calendar data, and timers
- add English and Japanese locale entries covering the new Clock Hub keys

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e65b68dafc832b87ff25d04fede739