### PR TITLE
feat: localize falling shooter overlay

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -10401,6 +10401,12 @@
           "movePreview": "{flips} flips / approx +{xp} EXP"
         }
       },
+      "falling_shooter": {
+        "overlay": {
+          "title": "Game Over",
+          "restartHint": "Press R to restart"
+        }
+      },
       "connect6": {
         "hud": {
           "status": {

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -10401,6 +10401,12 @@
           "movePreview": "{flips}枚 / 予想+{xp}EXP"
         }
       },
+      "falling_shooter": {
+        "overlay": {
+          "title": "ゲームオーバー",
+          "restartHint": "Rで再開/再起動"
+        }
+      },
       "connect6": {
         "hud": {
           "status": {


### PR DESCRIPTION
## Summary
- integrate the mini-game localization helper into Falling Shooter so the overlay text reacts to locale changes
- provide Japanese and English strings for the game over overlay and restart hint

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e65cd60b20832baeb7e9faf742eeeb