### PR TITLE
Add localization to forced scroll jump minigame

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -10380,6 +10380,28 @@
           }
         }
       },
+      "forced_scroll_jump": {
+        "hud": {
+          "score": "Score: {score}",
+          "coinStreak": "CX streak: {streak}",
+          "lives": "Lives: {lives}"
+        },
+        "overlay": {
+          "title": "Game Over",
+          "rank": "Rank: {rank}",
+          "summary": "Score {score} / Bonus XP +{bonus}",
+          "restart": "Press Space or click to restart"
+        },
+        "rank": {
+          "extreme": "Extreme",
+          "superb": "Superb",
+          "great": "Great",
+          "notable": "Notable",
+          "fair": "Fair",
+          "steady": "Steady",
+          "modest": "Modest"
+        }
+      },
       "othello": {
         "hud": {
           "status": {

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -10380,6 +10380,28 @@
           }
         }
       },
+      "forced_scroll_jump": {
+        "hud": {
+          "score": "スコア: {score}",
+          "coinStreak": "CX連続: {streak}",
+          "lives": "ライフ: {lives}"
+        },
+        "overlay": {
+          "title": "ゲームオーバー",
+          "rank": "ランク: {rank}",
+          "summary": "スコア {score} / ボーナスXP +{bonus}",
+          "restart": "スペースかクリックでリスタート"
+        },
+        "rank": {
+          "extreme": "極めて",
+          "superb": "非常に",
+          "great": "すごい",
+          "notable": "かなり",
+          "fair": "わりと",
+          "steady": "そこそこ",
+          "modest": "まあまあ"
+        }
+      },
       "othello": {
         "hud": {
           "status": {


### PR DESCRIPTION
## Summary
- integrate localization hooks and formatted HUD/result strings into the forced scroll jump minigame
- expose rank identifiers so rank labels and XP events use localized text
- add English and Japanese locale entries for the new forced scroll jump strings

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68e65d379c10832bbda75100fc9b74bb