### PR TITLE
Localize graphics tester UI

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -687,6 +687,96 @@
             "name": "3D Graphics Tester",
             "description": "Run visual demos and ray-tracing style renders to benchmark for EXP."
           },
+          "graphicsTester": {
+            "title": "3D Graphics Tester",
+            "badges": {
+              "webgl2": "WebGL2",
+              "rayMarching": "Ray Marching",
+              "benchmark": "Benchmark"
+            },
+            "errors": {
+              "webgl2Unavailable": "WebGL2 is unavailable",
+              "webglInitFailed": "Failed to initialize the WebGL2 context."
+            },
+            "gpuInfo": {
+              "title": "GPU Info",
+              "unsupported": {
+                "message": "WebGL2 is unsupported or disabled.",
+                "description": "This module requires a WebGL2-capable device or browser. Enable WebGL2 or try a compatible browser."
+              },
+              "unknown": "Unknown",
+              "antialias": {
+                "enabled": "ON",
+                "disabled": "OFF"
+              },
+              "entries": {
+                "vendor": "Vendor: {value}",
+                "renderer": "Renderer: {value}",
+                "version": "WebGL: {value}",
+                "shading": "GLSL: {value}",
+                "maxTextureSize": "Max Texture Size: {value}",
+                "maxCubeMap": "Max Cube Map: {value}",
+                "textureUnits": "Texture Units: {value}",
+                "antialias": "Antialias: {value}"
+              }
+            },
+            "controls": {
+              "demoSelect": {
+                "label": "Demo",
+                "options": {
+                  "objectLab": "Object Lab (Placement Demo)",
+                  "ray": "Ray-Tracing Style Demo",
+                  "gallery": "Tech Gallery"
+                },
+                "note": "Drag to orbit and scroll to zoom. The ray-tracing demo is GPU intensive—close other tabs before benchmarking."
+              },
+              "objectLab": {
+                "title": "Object Placement",
+                "actions": {
+                  "addCube": "Add Cube",
+                  "addSphere": "Add Sphere",
+                  "addCylinder": "Add Cylinder",
+                  "clear": "Clear All",
+                  "autoRotate": "Auto Rotate"
+                },
+                "autoRotateState": {
+                  "on": "ON",
+                  "off": "OFF"
+                },
+                "logs": {
+                  "addCube": "Added a cube.",
+                  "addSphere": "Added a sphere.",
+                  "addCylinder": "Added a cylinder.",
+                  "cleared": "Cleared placements.",
+                  "autoRotate": "Auto rotate: {state}"
+                }
+              },
+              "ray": {
+                "title": "Ray-Tracing Settings",
+                "bounces": "Bounce Count",
+                "exposure": "Exposure"
+              },
+              "gallery": {
+                "title": "Tech Gallery Controls",
+                "description": "Explore ring instancing, dynamic motion blur, and material effects."
+              },
+              "benchmark": {
+                "title": "Benchmark",
+                "start": "Run 6-second benchmark"
+              }
+            },
+            "log": {
+              "demoSwitch": "Switched demo: {label}",
+              "benchmarkStart": "Starting benchmark (high load)",
+              "benchmarkResult": "Average FPS: {fps} / Objects drawn: {count}"
+            },
+            "overlay": {
+              "fps": "FPS: {value}",
+              "objects": "Objects: {count}",
+              "bounces": "Bounces: {count}",
+              "gallery": "Gallery Demo"
+            }
+          },
           "physics_sandbox": {
             "name": "Physics Sandbox",
             "description": "Combine fire, water, vines, lightning, and circuits in a playful physics lab."

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -687,6 +687,96 @@
             "name": "3Dグラフィックテスター",
             "description": "3D技術デモとレイトレーシング風レンダリング・ベンチマーク搭載のトイ系テスター"
           },
+          "graphicsTester": {
+            "title": "3Dグラフィックテスター",
+            "badges": {
+              "webgl2": "WebGL2",
+              "rayMarching": "レイマーチング",
+              "benchmark": "ベンチマーク"
+            },
+            "errors": {
+              "webgl2Unavailable": "WebGL2 が利用できません",
+              "webglInitFailed": "WebGL2 コンテキストの初期化に失敗しました。"
+            },
+            "gpuInfo": {
+              "title": "GPU情報",
+              "unsupported": {
+                "message": "WebGL2非対応または無効化されています",
+                "description": "このモジュールは WebGL2 対応デバイス／ブラウザが必要です。設定で WebGL2 を有効化するか、対応ブラウザで再度お試しください。"
+              },
+              "unknown": "不明",
+              "antialias": {
+                "enabled": "ON",
+                "disabled": "OFF"
+              },
+              "entries": {
+                "vendor": "ベンダー: {value}",
+                "renderer": "レンダラー: {value}",
+                "version": "WebGL: {value}",
+                "shading": "GLSL: {value}",
+                "maxTextureSize": "最大テクスチャサイズ: {value}",
+                "maxCubeMap": "最大キューブマップ: {value}",
+                "textureUnits": "テクスチャユニット: {value}",
+                "antialias": "アンチエイリアス: {value}"
+              }
+            },
+            "controls": {
+              "demoSelect": {
+                "label": "デモ選択",
+                "options": {
+                  "objectLab": "オブジェクトラボ (配置デモ)",
+                  "ray": "レイトレーシング風デモ",
+                  "gallery": "技術ギャラリー"
+                },
+                "note": "マウスドラッグで視点操作、ホイールでズーム。レイトレーシング風デモは GPU 負荷が高いためベンチマーク時は他タブを閉じてください。"
+              },
+              "objectLab": {
+                "title": "オブジェクト配置",
+                "actions": {
+                  "addCube": "キューブ追加",
+                  "addSphere": "スフィア追加",
+                  "addCylinder": "シリンダー追加",
+                  "clear": "全削除",
+                  "autoRotate": "オート回転"
+                },
+                "autoRotateState": {
+                  "on": "ON",
+                  "off": "OFF"
+                },
+                "logs": {
+                  "addCube": "キューブを追加しました",
+                  "addSphere": "スフィアを追加しました",
+                  "addCylinder": "シリンダーを追加しました",
+                  "cleared": "配置をリセットしました",
+                  "autoRotate": "オート回転: {state}"
+                }
+              },
+              "ray": {
+                "title": "レイトレーシング風設定",
+                "bounces": "反射回数",
+                "exposure": "露光"
+              },
+              "gallery": {
+                "title": "技術ギャラリー操作",
+                "description": "リング状インスタンシング・動的モーションブラー・マテリアル演出を観察できます。"
+              },
+              "benchmark": {
+                "title": "ベンチマーク",
+                "start": "6秒間ベンチマーク開始"
+              }
+            },
+            "log": {
+              "demoSwitch": "デモ切り替え: {label}",
+              "benchmarkStart": "ベンチマークを開始します (高負荷)",
+              "benchmarkResult": "平均FPS: {fps} / 描画オブジェクト: {count}"
+            },
+            "overlay": {
+              "fps": "FPS: {value}",
+              "objects": "オブジェクト: {count}",
+              "bounces": "反射回数: {count}",
+              "gallery": "ギャラリーデモ"
+            }
+          },
           "physics_sandbox": {
             "name": "物理遊び",
             "description": "火・水・ツタ・雷・回路を組み合わせるトイ系物理サンドボックス"


### PR DESCRIPTION
## Summary
- add an i18n helper to the graphics tester mini-game and replace hardcoded UI strings with translated variants
- localize GPU information, control panels, benchmark logs, and overlay stats in the graphics tester
- supply Japanese and English locale entries for the new graphics tester strings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e65d7836a4832b9f43b4f5fa652fe0