### PR TITLE
Localize piano tiles mini game

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -10357,10 +10357,27 @@
         "result": {
           "title": "Result",
           "judgementTemplate": "{goodLabel}: {good} / {okLabel}: {ok} / {passLabel}: {pass} / {missLabel}: {miss}",
-          "summaryTemplate": "{maxLabel} {maxCombo} | {totalExpLabel} {score} ({bonusLabel} {clearBonus}) | {goodRateLabel} {rate}%",
-          "totalExpLabel": "Total EXP",
-          "clearBonusLabel": "Clear Bonus",
-          "goodRateLabel": "Good Rate"
+        "summaryTemplate": "{maxLabel} {maxCombo} | {totalExpLabel} {score} ({bonusLabel} {clearBonus}) | {goodRateLabel} {rate}%",
+        "totalExpLabel": "Total EXP",
+        "clearBonusLabel": "Clear Bonus",
+        "goodRateLabel": "Good Rate"
+      }
+    },
+      "piano_tiles": {
+        "tips": "Tap lanes or press D/F/J/K keys, and hold for long notes.",
+        "hud": {
+          "template": "{difficultyLabel}: {difficulty} | {hitsLabel}: {hits} | {missesLabel}: {misses} | {comboLabel}: {combo} ({maxLabel} {maxCombo}) | {accuracyLabel}: {accuracy}%",
+          "difficultyLabel": "Difficulty",
+          "hitsLabel": "Hits",
+          "missesLabel": "Misses",
+          "comboLabel": "Combo",
+          "maxLabel": "Max",
+          "accuracyLabel": "Accuracy"
+        },
+        "difficulty": {
+          "easy": "Easy",
+          "normal": "Normal",
+          "hard": "Hard"
         }
       },
       "checkers": {

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -10354,13 +10354,30 @@
           "accuracyLabel": "精度",
           "expLabel": "EXP"
         },
-        "result": {
-          "title": "結果",
-          "judgementTemplate": "{goodLabel}: {good} / {okLabel}: {ok} / {passLabel}: {pass} / {missLabel}: {miss}",
-          "summaryTemplate": "{maxLabel} {maxCombo} | {totalExpLabel} {score} ({bonusLabel} {clearBonus}) | {goodRateLabel} {rate}%",
-          "totalExpLabel": "総EXP",
-          "clearBonusLabel": "クリアボーナス",
-          "goodRateLabel": "良率"
+      "result": {
+        "title": "結果",
+        "judgementTemplate": "{goodLabel}: {good} / {okLabel}: {ok} / {passLabel}: {pass} / {missLabel}: {miss}",
+        "summaryTemplate": "{maxLabel} {maxCombo} | {totalExpLabel} {score} ({bonusLabel} {clearBonus}) | {goodRateLabel} {rate}%",
+        "totalExpLabel": "総EXP",
+        "clearBonusLabel": "クリアボーナス",
+        "goodRateLabel": "良率"
+      }
+    },
+      "piano_tiles": {
+        "tips": "タップ or D/F/J/Kキーでレーンを叩き、長いノーツは離さずにホールド。",
+        "hud": {
+          "template": "{difficultyLabel}: {difficulty} | {hitsLabel}: {hits} | {missesLabel}: {misses} | {comboLabel}: {combo} ({maxLabel} {maxCombo}) | {accuracyLabel}: {accuracy}%",
+          "difficultyLabel": "難易度",
+          "hitsLabel": "成功",
+          "missesLabel": "ミス",
+          "comboLabel": "コンボ",
+          "maxLabel": "最大",
+          "accuracyLabel": "精度"
+        },
+        "difficulty": {
+          "easy": "EASY",
+          "normal": "NORMAL",
+          "hard": "HARD"
         }
       },
       "checkers": {


### PR DESCRIPTION
## Summary
- integrate the mini game localization helper into Piano Tiles and refresh HUD/tips strings through translations
- add Japanese and English locale entries for the Piano Tiles instructions and HUD labels
- register the Piano Tiles localization key for the mini game definition

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e65f39c4ec832bb4f04b74f1923403