### PR TITLE
Fix indentation for logicCircuit locale entries

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -733,6 +733,168 @@
           }
         },
 
+        "logicCircuit": {
+          "categories": {
+            "input": "Input",
+            "gate": "Gate",
+            "wiring": "Wiring",
+            "composite": "Composite",
+            "sequential": "Sequential",
+            "measurement": "Measurement",
+            "output": "Output",
+            "other": "Other"
+          },
+          "common": {
+            "high": "HIGH",
+            "low": "LOW",
+            "on": "ON",
+            "off": "OFF",
+            "set": "SET",
+            "reset": "RESET",
+            "metastable": "Metastable",
+            "metastableIndicator": "S=R=1 (Invalid)",
+            "metastableMessage": "S and R are both 1. Output is unstable.",
+            "warning": "Warning",
+            "toggleState": "Toggle state",
+            "previousClock": "Previous clock",
+            "periodMs": "Period (ms)",
+            "outLabel": "OUT: {value}",
+            "muxStatus": "OUT:{out} (SEL={sel})"
+          },
+          "ui": {
+            "title": "Logic Circuit Simulator",
+            "subtitle": "Arrange inputs and gates to verify combinational logic in real time",
+            "clearCanvas": "Reset canvas",
+            "clearTool": "Clear tool (Esc)",
+            "step": "⏭ Step",
+            "stepLabel": "Step (ms)",
+            "pause": "⏸ Pause",
+            "resume": "▶ Resume",
+            "sessionXp": "Session EXP: {value}",
+            "elapsedTime": "Elapsed time: {value}ms"
+          },
+          "hints": {
+            "board": "Select a tool and click an empty spot on the canvas to place it. Click output ports then input ports to draw wires. Press Delete to remove the selected component.",
+            "wires": "Click a wire path to remove it. Alt+click an input port to detach its incoming wire.",
+            "footer": "Tip: Toggle inputs to inspect results instantly. Pause or step the simulation to analyze sequential behavior."
+          },
+          "inspector": {
+            "title": "Component Inspector",
+            "empty": "Select a component to see its details and an auto-generated truth table for up to 3 inputs.",
+            "truthTitle": "Truth table",
+            "connectionCount": "{count} lines",
+            "delayValue": "{value} ns",
+            "fields": {
+              "id": "ID",
+              "type": "Type",
+              "inputs": "Input ports",
+              "outputs": "Output ports",
+              "lastInputs": "Last inputs",
+              "lastOutputs": "Last outputs",
+              "inputConnections": "Input connections",
+              "outputConnections": "Output connections",
+              "delay": "Propagation delay (approx.)",
+              "description": "Description"
+            }
+          },
+          "truthTable": {
+            "out": "OUT"
+          },
+          "ports": {
+            "output": "Output #{index}",
+            "input": "Input #{index}"
+          },
+          "components": {
+            "toggle": {
+              "label": "Toggle input",
+              "description": "Basic input that toggles ON/OFF when clicked",
+              "buttonOn": "Turn ON",
+              "buttonOff": "Turn OFF"
+            },
+            "clock": {
+              "label": "Clock",
+              "description": "Clock input oscillating at a fixed interval"
+            },
+            "constHigh": {
+              "label": "Constant 1",
+              "description": "Constant source that always outputs HIGH"
+            },
+            "constLow": {
+              "label": "Constant 0",
+              "description": "Constant source that always outputs LOW"
+            },
+            "buffer": {
+              "label": "Buffer",
+              "description": "Buffer that outputs the input as-is"
+            },
+            "not": {
+              "label": "NOT",
+              "description": "NOT gate that inverts the input"
+            },
+            "and": {
+              "label": "AND",
+              "description": "Outputs HIGH when all inputs are HIGH"
+            },
+            "nand": {
+              "label": "NAND",
+              "description": "Inverted AND gate"
+            },
+            "or": {
+              "label": "OR",
+              "description": "Outputs HIGH when any input is HIGH"
+            },
+            "nor": {
+              "label": "NOR",
+              "description": "Inverted OR gate"
+            },
+            "xor": {
+              "label": "XOR",
+              "description": "Outputs HIGH when the number of HIGH inputs is odd"
+            },
+            "xnor": {
+              "label": "XNOR",
+              "description": "Inverted XOR gate"
+            },
+            "splitter": {
+              "label": "Splitter",
+              "description": "Duplicate one input to multiple outputs"
+            },
+            "mux2": {
+              "label": "2:1 MUX",
+              "description": "Two-input multiplexer controlled by a select signal"
+            },
+            "decoder2": {
+              "label": "2-4 Decoder",
+              "description": "Decoder producing one-hot outputs from a 2-bit input"
+            },
+            "dff": {
+              "label": "D Flip-Flop",
+              "description": "Edge-triggered flip-flop that latches D on the rising clock (with async reset)",
+              "indicator": "Q={q} / Q̅={qbar}",
+              "status": "Q={value}",
+              "inspectLatch": "Latch state"
+            },
+            "srLatch": {
+              "label": "SR Latch",
+              "description": "Basic NOR SR latch. S sets, R resets.",
+              "qStatus": "Q={value}"
+            },
+            "tff": {
+              "label": "T Flip-Flop",
+              "description": "Toggles output on each rising clock edge when T input is HIGH. Includes reset input.",
+              "status": "Q={value}"
+            },
+            "probe": {
+              "label": "Probe",
+              "description": "Measurement node that monitors the input value"
+            },
+            "led": {
+              "label": "LED",
+              "description": "Lights when the input is HIGH"
+            }
+          }
+        },
+
         "difficulty": {
           "label": "Difficulty",
           "easy": "EASY",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -733,6 +733,168 @@
           }
         },
 
+        "logicCircuit": {
+          "categories": {
+            "input": "入力",
+            "gate": "ゲート",
+            "wiring": "配線",
+            "composite": "複合",
+            "sequential": "シーケンシャル",
+            "measurement": "計測",
+            "output": "出力",
+            "other": "その他"
+          },
+          "common": {
+            "high": "HIGH",
+            "low": "LOW",
+            "on": "ON",
+            "off": "OFF",
+            "set": "SET",
+            "reset": "RESET",
+            "metastable": "不定状態",
+            "metastableIndicator": "S=R=1 (不定)",
+            "metastableMessage": "SとRが同時に1です。安定しません。",
+            "warning": "注意",
+            "toggleState": "トグル状態",
+            "previousClock": "前回クロック",
+            "periodMs": "周期 (ms)",
+            "outLabel": "OUT: {value}",
+            "muxStatus": "OUT:{out} (SEL={sel})"
+          },
+          "ui": {
+            "title": "論理回路シミュレータ",
+            "subtitle": "入力ノードとゲートを並べ、リアルタイム評価で組み合わせ論理を検証",
+            "clearCanvas": "キャンバス初期化",
+            "clearTool": "ツール解除 (Esc)",
+            "step": "⏭ ステップ",
+            "stepLabel": "ステップ(ms)",
+            "pause": "⏸ 停止",
+            "resume": "▶ 再開",
+            "sessionXp": "セッションEXP: {value}",
+            "elapsedTime": "経過時間: {value}ms"
+          },
+          "hints": {
+            "board": "ツールを選択し、キャンバスの空いている場所をクリックして配置します。出力ポート→入力ポートの順でクリックすると配線できます。Deleteキーで選択中の部品を削除。",
+            "wires": "配線はパスをクリックで削除。Alt+入力クリックでその入力への配線を解除。",
+            "footer": "ヒント: 入力をトグルして即座に出力を確認。シミュレーション制御で一時停止やステップ実行を行いながらシーケンシャル動作を解析できます。"
+          },
+          "inspector": {
+            "title": "部品インスペクタ",
+            "empty": "部品を選択すると詳細と真理値表を表示します。最大入力3本のゲートで真理値表を自動生成します。",
+            "truthTitle": "真理値表",
+            "connectionCount": "{count} 本",
+            "delayValue": "{value} ns",
+            "fields": {
+              "id": "ID",
+              "type": "タイプ",
+              "inputs": "入力ポート",
+              "outputs": "出力ポート",
+              "lastInputs": "最新入力",
+              "lastOutputs": "最新出力",
+              "inputConnections": "入力接続",
+              "outputConnections": "出力接続",
+              "delay": "伝播遅延(目安)",
+              "description": "説明"
+            }
+          },
+          "truthTable": {
+            "out": "OUT"
+          },
+          "ports": {
+            "output": "出力 #{index}",
+            "input": "入力 #{index}"
+          },
+          "components": {
+            "toggle": {
+              "label": "トグル入力",
+              "description": "クリックでON/OFFを切り替える基本入力",
+              "buttonOn": "ONにする",
+              "buttonOff": "OFFにする"
+            },
+            "clock": {
+              "label": "クロック",
+              "description": "一定周期で振動するクロック入力"
+            },
+            "constHigh": {
+              "label": "定数1",
+              "description": "常にHIGHを出力する定数ソース"
+            },
+            "constLow": {
+              "label": "定数0",
+              "description": "常にLOWを出力する定数ソース"
+            },
+            "buffer": {
+              "label": "バッファ",
+              "description": "入力をそのまま出力するバッファ"
+            },
+            "not": {
+              "label": "NOT",
+              "description": "入力を反転するNOTゲート"
+            },
+            "and": {
+              "label": "AND",
+              "description": "全ての入力がHIGHでHIGH"
+            },
+            "nand": {
+              "label": "NAND",
+              "description": "ANDの反転"
+            },
+            "or": {
+              "label": "OR",
+              "description": "いずれかの入力がHIGHでHIGH"
+            },
+            "nor": {
+              "label": "NOR",
+              "description": "ORの反転"
+            },
+            "xor": {
+              "label": "XOR",
+              "description": "入力のHIGH数が奇数でHIGH"
+            },
+            "xnor": {
+              "label": "XNOR",
+              "description": "XORの反転"
+            },
+            "splitter": {
+              "label": "スプリッタ",
+              "description": "1入力を複数の出力へ複製する"
+            },
+            "mux2": {
+              "label": "2:1 MUX",
+              "description": "選択信号で入力を切り替える2入力1出力の多重化器"
+            },
+            "decoder2": {
+              "label": "2-4デコーダ",
+              "description": "2ビット入力からワンホットの4出力を生成するデコーダ"
+            },
+            "dff": {
+              "label": "Dフリップフロップ",
+              "description": "立ち上がりクロックでD入力をラッチしQ/Q̅を出力する同期フリップフロップ (非同期リセット付)",
+              "indicator": "Q={q} / Q̅={qbar}",
+              "status": "Q={value}",
+              "inspectLatch": "ラッチ状態"
+            },
+            "srLatch": {
+              "label": "SRラッチ",
+              "description": "NOR構成の基本SRラッチ。Sでセット、Rでリセット。",
+              "qStatus": "Q={value}"
+            },
+            "tff": {
+              "label": "Tフリップフロップ",
+              "description": "立ち上がりクロック毎にT入力がHIGHなら出力を反転。リセット入力付き。",
+              "status": "Q={value}"
+            },
+            "probe": {
+              "label": "プローブ",
+              "description": "入力値を監視する計測ノード"
+            },
+            "led": {
+              "label": "LED",
+              "description": "入力がHIGHのとき点灯"
+            }
+          }
+        },
+
         "difficulty": {
           "label": "難易度",
           "easy": "EASY",


### PR DESCRIPTION
## Summary
- align the `logicCircuit` locale entries in both the English and Japanese bundles with the surrounding indentation
- ensure the section sits correctly between the `games` entries and the following metadata

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e65df02af0832b8ffeda3780c6f503