### PR TITLE
Fix janken stats initialization order

### DIFF
--- a/games/janken.js
+++ b/games/janken.js
@@ -249,9 +249,6 @@
       renderHistory();
     }
 
-    applyStaticTexts();
-    attachLocaleListener();
-
     const timers = new Set();
     const BEATS = [1,2,0];
     const BEATEN_BY = [2,0,1];
@@ -265,6 +262,9 @@
     let roundCount = 0;
     let isResolving = false;
     let lastPlayerChoice = null;
+
+    applyStaticTexts();
+    attachLocaleListener();
 
     function setGameTimeout(fn, delay){
       const id = setTimeout(() => {


### PR DESCRIPTION
## Summary
- ensure janken stats variables are initialized before the first locale refresh

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7334c59d0832b82ebef61e1a276b0