### PR TITLE
Fix timer fallback for Onigokko countdown

### DIFF
--- a/games/onigokko.js
+++ b/games/onigokko.js
@@ -21,8 +21,8 @@
       if (typeof fallback === 'function') return fallback(params);
       return fallback ?? '';
     };
-    const defaultTimerFallback = (params) => {
-      const seconds = Number(params?.seconds ?? 0);
+    const defaultTimerFallback = () => {
+      const seconds = Number(timerState?.params?.seconds ?? 0);
       return `残り ${seconds.toFixed(1)}s`;
     };
     const timerState = {


### PR DESCRIPTION
## Summary
- add localization plumbing to the Onigokko mini game so text uses translation keys
- replace hard-coded status strings and timer label formatting with localized fallbacks
- hook locale change handling and clean up the listener during teardown
- ensure the timer fallback reads the live countdown seconds when translations are missing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e733ed54a8832bbe10b927ebed865f