### PR TITLE
Fix import error localization handler

### DIFF
--- a/games/memory_app.js
+++ b/games/memory_app.js
@@ -571,8 +571,8 @@
       if (!file) return;
       const reader = new FileReader();
       reader.onload = () => {
-        const text = typeof reader.result === 'string' ? reader.result : '';
-        const parsed = safeParse(text);
+        const fileText = typeof reader.result === 'string' ? reader.result : '';
+        const parsed = safeParse(fileText);
         if (!parsed) {
           alert(text('.import.error.invalidJson', 'JSON を読み取れませんでした。'));
           return;


### PR DESCRIPTION
## Summary
- rename the FileReader result variable to avoid shadowing the localization helper
- ensure invalid import errors once again call the translation helper instead of throwing

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e733fcc078832bbea44380525876a7