### PR TITLE
Fix go minigame localization namespaces

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -409,36 +409,7 @@
           },
           "go": {
             "name": "Go",
-            "description": "Surround territory, capture stones, and score EXP for smart invasions and victories.",
-            "info": {
-              "intro": "Go 9×9 — You play first (Black)"
-            },
-            "hud": {
-              "turn": {
-                "player": "Your turn (Black)",
-                "ai": "AI turn (White)"
-              },
-              "status": "{turn} | Black captures: {blackCaptures} | White captures: {whiteCaptures} (komi +{komi})",
-              "passNotice": "{actor} passed ({count} in a row)",
-              "aiThinking": "AI is thinking…"
-            },
-            "buttons": {
-              "pass": "Pass",
-              "resign": "Resign"
-            },
-            "messages": {
-              "koViolation": "That move violates the ko rule."
-            },
-            "actors": {
-              "player": "You",
-              "ai": "AI"
-            },
-            "result": {
-              "win": "You win!",
-              "loss": "AI wins…",
-              "draw": "Jigo (Draw)",
-              "summary": "{result} | Black {blackScore} - White {whiteScore}"
-            }
+            "description": "Surround territory, capture stones, and score EXP for smart invasions and victories."
           },
           "backgammon": {
             "name": "Backgammon",
@@ -10511,6 +10482,37 @@
             "doubleThree": "Forbidden move: Double three"
           },
           "genericFoul": "Forbidden move"
+        }
+      },
+      "go": {
+        "info": {
+          "intro": "Go 9×9 — You play first (Black)"
+        },
+        "hud": {
+          "turn": {
+            "player": "Your turn (Black)",
+            "ai": "AI turn (White)"
+          },
+          "status": "{turn} | Black captures: {blackCaptures} | White captures: {whiteCaptures} (komi +{komi})",
+          "passNotice": "{actor} passed ({count} in a row)",
+          "aiThinking": "AI is thinking…"
+        },
+        "buttons": {
+          "pass": "Pass",
+          "resign": "Resign"
+        },
+        "messages": {
+          "koViolation": "That move violates the ko rule."
+        },
+        "actors": {
+          "player": "You",
+          "ai": "AI"
+        },
+        "result": {
+          "win": "You win!",
+          "loss": "AI wins…",
+          "draw": "Jigo (Draw)",
+          "summary": "{result} | Black {blackScore} - White {whiteScore}"
         }
       },
       "connect4": {

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -409,36 +409,7 @@
           },
           "go": {
             "name": "囲碁",
-            "description": "配置+1/捕獲ボーナス/勝利EXP",
-            "info": {
-              "intro": "囲碁 9×9 — あなたが先手 (黒)"
-            },
-            "hud": {
-              "turn": {
-                "player": "あなたの番 (黒)",
-                "ai": "AIの番 (白)"
-              },
-              "status": "{turn} ｜ 黒 捕獲:{blackCaptures} ｜ 白 捕獲:{whiteCaptures} (コミ+{komi})",
-              "passNotice": "{actor}がパスしました (連続{count})",
-              "aiThinking": "AIが思考中…"
-            },
-            "buttons": {
-              "pass": "パス",
-              "resign": "投了"
-            },
-            "messages": {
-              "koViolation": "その手はコウで禁じられています"
-            },
-            "actors": {
-              "player": "あなた",
-              "ai": "AI"
-            },
-            "result": {
-              "win": "あなたの勝ち！",
-              "loss": "AIの勝ち…",
-              "draw": "持碁 (引き分け)",
-              "summary": "{result} ｜ 黒 {blackScore} - 白 {whiteScore}"
-            }
+            "description": "配置+1/捕獲ボーナス/勝利EXP"
           },
           "backgammon": {
             "name": "バックギャモン",
@@ -10511,6 +10482,37 @@
             "doubleThree": "禁手: 三々"
           },
           "genericFoul": "禁手"
+        }
+      },
+      "go": {
+        "info": {
+          "intro": "囲碁 9×9 — あなたが先手 (黒)"
+        },
+        "hud": {
+          "turn": {
+            "player": "あなたの番 (黒)",
+            "ai": "AIの番 (白)"
+          },
+          "status": "{turn} ｜ 黒 捕獲:{blackCaptures} ｜ 白 捕獲:{whiteCaptures} (コミ+{komi})",
+          "passNotice": "{actor}がパスしました (連続{count})",
+          "aiThinking": "AIが思考中…"
+        },
+        "buttons": {
+          "pass": "パス",
+          "resign": "投了"
+        },
+        "messages": {
+          "koViolation": "その手はコウで禁じられています"
+        },
+        "actors": {
+          "player": "あなた",
+          "ai": "AI"
+        },
+        "result": {
+          "win": "あなたの勝ち！",
+          "loss": "AIの勝ち…",
+          "draw": "持碁 (引き分け)",
+          "summary": "{result} ｜ 黒 {blackScore} - 白 {whiteScore}"
         }
       },
       "connect4": {


### PR DESCRIPTION
## Summary
- move go mini-game translations under the `minigame.go` namespace
- keep game selection entries limited to name/description so the helper resolves localized HUD strings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e73407f4f4832b89c100889abc1cff