### PR TITLE
Fix Aim mini-game HUD translations namespace

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -589,16 +589,7 @@
           },
           "aim": {
             "name": "Aim Trainer",
-            "description": "Hit targets for 1–3 EXP and keep streaks alive for bonuses.",
-            "hud": {
-              "time": "TIME: {time}",
-              "hitsAccuracy": "HITS: {hits}  ACC: {accuracy}%",
-              "combo": "COMBO x{combo}"
-            },
-            "overlay": {
-              "timeUp": "Time Up",
-              "restartHint": "Press R to restart"
-            }
+            "description": "Hit targets for 1–3 EXP and keep streaks alive for bonuses."
           },
           "dodge_race": {
             "name": "Dodge Race",
@@ -10333,6 +10324,17 @@
     },
 
     "minigame": {
+      "aim": {
+        "hud": {
+          "time": "TIME: {time}",
+          "hitsAccuracy": "HITS: {hits}  ACC: {accuracy}%",
+          "combo": "COMBO x{combo}"
+        },
+        "overlay": {
+          "timeUp": "Time Up",
+          "restartHint": "Press R to restart"
+        }
+      },
       "taiko_drum": {
         "title": "Taiko Rhythm ({difficulty})",
         "tips": "F/J/Space = Don (red), D/K = Ka (blue). Hit both at once for big notes! Touch input works too.",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -589,16 +589,7 @@
           },
           "aim": {
             "name": "的あて（エイム）",
-            "description": "命中で1〜3EXP／連続命中ボーナス",
-            "hud": {
-              "time": "残り時間: {time}",
-              "hitsAccuracy": "命中: {hits}  精度: {accuracy}%",
-              "combo": "コンボ x{combo}"
-            },
-            "overlay": {
-              "timeUp": "タイムアップ",
-              "restartHint": "Rで再開/再起動"
-            }
+            "description": "命中で1〜3EXP／連続命中ボーナス"
           },
           "dodge_race": {
             "name": "回避レース",
@@ -10333,6 +10324,17 @@
     },
 
     "minigame": {
+      "aim": {
+        "hud": {
+          "time": "残り時間: {time}",
+          "hitsAccuracy": "命中: {hits}  精度: {accuracy}%",
+          "combo": "コンボ x{combo}"
+        },
+        "overlay": {
+          "timeUp": "タイムアップ",
+          "restartHint": "Rで再開/再起動"
+        }
+      },
       "taiko_drum": {
         "title": "太鼓リズム（{difficulty}）",
         "tips": "F/J/Space = ドン（赤）、D/K = カッ（青）。大音符は両方同時！タップもOK。",


### PR DESCRIPTION
## Summary
- move the Aim mini-game HUD and overlay translations under the `minigame.aim` namespace so they load via the localization helper
- retain the Aim listing metadata under `ui.miniexp.games.aim` for both Japanese and English locales

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e73413e7a0832b811cbac688e2b1b2