### PR TITLE
Localize status labels and level-up log

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -12827,6 +12827,13 @@
           "sp": "SP"
         }
       },
+      "statuses": {
+        "poison": "Poison",
+        "paralysis": "Paralysis",
+        "abilityUp": "Power Up",
+        "abilityDown": "Stat Down",
+        "levelDown": "Level Down"
+      },
       "autoItem": {
         "status": "Auto Items ON: Healing Items x {count}"
       },
@@ -13048,6 +13055,9 @@
             "abilityDown": "Your stats dropped... Max HP/ATK/DEF down ({turns} turns)",
             "levelDown": "Your level temporarily decreased! ({turns} turns)"
           }
+        },
+        "levelUp": {
+          "log": "Level Up!\nLevel: {level} (+{levelDelta})\nMax HP: {maxHp} (+{maxHpDelta})\nATK: {attack} (+{attackDelta})\nDEF: {defense} (+{defenseDelta})"
         },
         "sandbox": {
           "noExp": "Sandbox mode does not award EXP.",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -12831,6 +12831,13 @@
           "sp": "SP"
         }
       },
+      "statuses": {
+        "poison": "毒",
+        "paralysis": "麻痺",
+        "abilityUp": "能力強化",
+        "abilityDown": "能力低下",
+        "levelDown": "レベル低下"
+      },
       "autoItem": {
         "status": "オートアイテムON：回復アイテム x {count}"
       },
@@ -13052,6 +13059,9 @@
             "abilityDown": "能力が低下した…最大HP/攻撃/防御が下がる ({turns}ターン)",
             "levelDown": "レベルが一時的に低下した！ ({turns}ターン)"
           }
+        },
+        "levelUp": {
+          "log": "レベルアップ！\nレベル：{level} (+{levelDelta})\n最大HP：{maxHp}(+{maxHpDelta})\n攻撃力：{attack}(+{attackDelta})\n防御力：{defense}(+{defenseDelta})"
         },
         "sandbox": {
           "noExp": "サンドボックスでは経験値は獲得できません。",

--- a/main.js
+++ b/main.js
@@ -1992,11 +1992,45 @@ const SKILL_AREA_OFFSETS = [
 ];
 
 const PLAYER_STATUS_EFFECTS = {
-    poison: { id: 'poison', label: '毒', defaultDuration: 4, damageRatio: 0.1, badgeClass: 'status-badge--poison' },
-    paralysis: { id: 'paralysis', label: '麻痺', defaultDuration: 5, badgeClass: 'status-badge--paralysis' },
-    abilityUp: { id: 'abilityUp', label: '能力強化', defaultDuration: 5, statMultiplier: 1.2, badgeClass: 'status-badge--ability' },
-    abilityDown: { id: 'abilityDown', label: '能力低下', defaultDuration: 5, statMultiplier: 0.8, badgeClass: 'status-badge--ability' },
-    levelDown: { id: 'levelDown', label: 'レベル低下', defaultDuration: 5, levelReduction: 3, badgeClass: 'status-badge--level' }
+    poison: {
+        id: 'poison',
+        labelKey: 'game.statuses.poison',
+        label: '毒',
+        defaultDuration: 4,
+        damageRatio: 0.1,
+        badgeClass: 'status-badge--poison'
+    },
+    paralysis: {
+        id: 'paralysis',
+        labelKey: 'game.statuses.paralysis',
+        label: '麻痺',
+        defaultDuration: 5,
+        badgeClass: 'status-badge--paralysis'
+    },
+    abilityUp: {
+        id: 'abilityUp',
+        labelKey: 'game.statuses.abilityUp',
+        label: '能力強化',
+        defaultDuration: 5,
+        statMultiplier: 1.2,
+        badgeClass: 'status-badge--ability'
+    },
+    abilityDown: {
+        id: 'abilityDown',
+        labelKey: 'game.statuses.abilityDown',
+        label: '能力低下',
+        defaultDuration: 5,
+        statMultiplier: 0.8,
+        badgeClass: 'status-badge--ability'
+    },
+    levelDown: {
+        id: 'levelDown',
+        labelKey: 'game.statuses.levelDown',
+        label: 'レベル低下',
+        defaultDuration: 5,
+        levelReduction: 3,
+        badgeClass: 'status-badge--level'
+    }
 };
 
 const NEGATIVE_STATUS_EFFECT_IDS = Object.freeze(['poison', 'paralysis', 'abilityDown', 'levelDown']);
@@ -6820,7 +6854,9 @@ function getPlayerStatus(effectId) {
 }
 
 function getStatusLabel(effectId) {
-    return PLAYER_STATUS_EFFECTS[effectId]?.label || effectId;
+    const def = PLAYER_STATUS_EFFECTS[effectId];
+    if (!def) return effectId;
+    return resolveLocalizedText(def.labelKey, def.label || effectId);
 }
 
 function isPlayerStatusActive(effectId) {
@@ -7316,9 +7352,10 @@ function getPlayerStatusDisplayList() {
         const remaining = getStatusRemaining(key);
         if (remaining > 0) {
             const def = PLAYER_STATUS_EFFECTS[key];
+            const label = getStatusLabel(key);
             list.push({
                 id: key,
-                label: def.label,
+                label,
                 remaining,
                 badgeClass: def.badgeClass || null
             });
@@ -18448,8 +18485,28 @@ function grantExp(amount, opts = { source: 'misc', reason: '', popup: true }) {
         refreshGeneratorHazardSuppression();
         try { showLevelUpPopup(); } catch {}
         try {
-            const levelUpMsg = `レベルアップ！レベル：${player.level} (+${player.level - beforeLevel})|最大HP：${player.maxHp}(+${player.maxHp - beforeMaxHp})|攻撃力：${player.attack}(+${player.attack - beforeAttack})|防御力：${player.defense}(+${player.defense - beforeDefense})`;
-            addMessage(levelUpMsg);
+            const levelDisplay = formatNumberLocalized(player.level);
+            const levelDeltaDisplay = formatNumberLocalized(player.level - beforeLevel);
+            const maxHpDisplay = formatNumberLocalized(player.maxHp);
+            const maxHpDeltaDisplay = formatNumberLocalized(player.maxHp - beforeMaxHp);
+            const attackDisplay = formatNumberLocalized(player.attack);
+            const attackDeltaDisplay = formatNumberLocalized(player.attack - beforeAttack);
+            const defenseDisplay = formatNumberLocalized(player.defense);
+            const defenseDeltaDisplay = formatNumberLocalized(player.defense - beforeDefense);
+            addMessage({
+                key: 'game.events.levelUp.log',
+                fallback: () => `レベルアップ！\nレベル：${levelDisplay} (+${levelDeltaDisplay})\n最大HP：${maxHpDisplay}(+${maxHpDeltaDisplay})\n攻撃力：${attackDisplay}(+${attackDeltaDisplay})\n防御力：${defenseDisplay}(+${defenseDeltaDisplay})`,
+                params: {
+                    level: levelDisplay,
+                    levelDelta: levelDeltaDisplay,
+                    maxHp: maxHpDisplay,
+                    maxHpDelta: maxHpDeltaDisplay,
+                    attack: attackDisplay,
+                    attackDelta: attackDeltaDisplay,
+                    defense: defenseDisplay,
+                    defenseDelta: defenseDeltaDisplay
+                }
+            });
         } catch {}
         if (expBar) {
             expBar.style.transition = 'width 0.25s';


### PR DESCRIPTION
## Summary
- add translation entries for status effect names and level-up log messaging
- use localized status labels in the UI and log level-up details with localized formatting

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e7a7dba970832ba33fb376ec7f60ef