### PR TITLE
Fix BlockDim preview selection localization

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -12816,6 +12816,11 @@
           "nested": "NESTED x{value}"
         }
       },
+      "blockDim": {
+        "preview": {
+          "selection": "NESTED {nested} / Dimension {dimension}: {block1} · {block2} · {block3}"
+        }
+      },
       "playerStats": {
         "labels": {
           "level": "Level",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -12820,6 +12820,11 @@
           "nested": "NESTED x{value}"
         }
       },
+      "blockDim": {
+        "preview": {
+          "selection": "NESTED {nested} ／ 次元 {dimension}：{block1}・{block2}・{block3}"
+        }
+      },
       "playerStats": {
         "labels": {
           "level": "レベル",

--- a/main.js
+++ b/main.js
@@ -8921,7 +8921,12 @@ function renderBdimPreview(spec) {
         const b1 = resolveBlockNameByKey(blockDimTables.blocks1, b1Key) || b1Key;
         const b2 = resolveBlockNameByKey(blockDimTables.blocks2, b2Key) || b2Key;
         const b3 = resolveBlockNameByKey(blockDimTables.blocks3, b3Key) || b3Key;
-        bdimCardSelection.textContent = `NESTED ${nested} ／ 次元 ${dimensionName || String(dimKey).toUpperCase()}：${b1}・${b2}・${b3}`;
+        const dimensionLabel = dimensionName || String(dimKey).toUpperCase();
+        bdimCardSelection.textContent = translateOrFallback(
+            'game.blockDim.preview.selection',
+            () => `NESTED ${nested} ／ 次元 ${dimensionLabel}：${b1}・${b2}・${b3}`,
+            { nested, dimension: dimensionLabel, block1: b1, block2: b2, block3: b3 }
+        );
     }
     bdimCardLevel.textContent = String(spec.level);
     bdimCardType.textContent = formatSpecType(spec);


### PR DESCRIPTION
## Summary
- update the BlockDim preview card to read its selection label from i18n instead of a hardcoded string
- add localized strings for the new BlockDim preview label in English and Japanese

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7a82930bc832b965a90e72c6f0ba1