### PR TITLE
Improve backgammon localization and UI contrast

### DIFF
--- a/games/backgammon.js
+++ b/games/backgammon.js
@@ -191,13 +191,13 @@
         .bgm-button{background:linear-gradient(135deg,#f59e0b,#facc15);color:#1e293b;border:none;border-radius:999px;padding:8px 18px;font-weight:600;cursor:pointer;transition:transform 0.15s ease, box-shadow 0.15s ease;}
         .bgm-button:disabled{background:#475569;color:#cbd5f5;cursor:not-allowed;box-shadow:none;transform:none;}
         .bgm-button:not(:disabled):hover{transform:translateY(-1px);box-shadow:0 4px 14px rgba(250,204,21,0.35);}
-        .bgm-label{padding:6px 12px;border-radius:999px;background:rgba(148,163,184,0.2);font-size:0.9rem;}
+        .bgm-label{padding:6px 12px;border-radius:14px;background:rgba(226,232,240,0.92);color:#0f172a;font-size:0.9rem;font-weight:600;box-shadow:0 2px 6px rgba(15,23,42,0.18);}
         .bgm-panel{display:flex;flex-direction:column;gap:6px;min-width:160px;}
         .bgm-log{background:rgba(15,23,42,0.75);border-radius:12px;padding:10px;font-size:0.85rem;max-height:140px;overflow-y:auto;line-height:1.5;box-shadow:inset 0 0 0 1px rgba(148,163,184,0.25);}
         .bgm-log p{margin:0 0 4px;}
         .bgm-log p:last-child{margin-bottom:0;}
         .bgm-badges{display:flex;flex-wrap:wrap;gap:8px;font-size:0.8rem;}
-        .bgm-badge{background:rgba(148,163,184,0.25);padding:4px 10px;border-radius:999px;}
+        .bgm-badge{background:rgba(226,232,240,0.9);color:#0f172a;padding:4px 10px;border-radius:12px;font-weight:600;box-shadow:0 1px 4px rgba(15,23,42,0.18);}
       `;
       document.head.appendChild(style);
     }
@@ -395,9 +395,12 @@
 
     function updateUi(){
       const actor = getActorLabel(state.currentPlayer);
-      turnLabel.textContent = translateOrFallback('game.backgammon.ui.turn', () => `手番: ${actor}${state.gameOver ? '（終了）' : ''}`, {
+      const statusSuffix = state.gameOver
+        ? translateOrFallback('game.backgammon.ui.turnFinishedSuffix', '（終了）')
+        : '';
+      turnLabel.textContent = translateOrFallback('game.backgammon.ui.turn', () => `手番: ${actor}${statusSuffix}`, {
         actor,
-        gameOver: state.gameOver
+        status: statusSuffix
       });
       if (state.dice.length === 0){
         diceLabel.textContent = translateOrFallback('game.backgammon.ui.dice.empty', 'ダイス: -');
@@ -416,22 +419,28 @@
       const barTitle = formatBarLabel();
       const playerBarFormatted = formatNumberLocalized(state.playerBar);
       const aiBarFormatted = formatNumberLocalized(state.aiBar);
-      barLabel.textContent = translateOrFallback('game.backgammon.ui.bar', () => `${barTitle}: ${getActorLabel(PLAYER)} ${playerBarFormatted} / ${getActorLabel(AI)} ${aiBarFormatted}`, {
+      const playerLabelText = getActorLabel(PLAYER);
+      const aiLabelText = getActorLabel(AI);
+      barLabel.textContent = translateOrFallback('game.backgammon.ui.bar', () => `${barTitle}: ${playerLabelText} ${playerBarFormatted} / ${aiLabelText} ${aiBarFormatted}`, {
         bar: barTitle,
         player: state.playerBar,
         playerFormatted: playerBarFormatted,
+        playerLabel: playerLabelText,
         ai: state.aiBar,
-        aiFormatted: aiBarFormatted
+        aiFormatted: aiBarFormatted,
+        aiLabel: aiLabelText
       });
       const bearOffTitle = translateOrFallback('game.backgammon.ui.bearOff.title', 'ベアオフ');
       const playerOffFormatted = formatNumberLocalized(state.playerOff);
       const aiOffFormatted = formatNumberLocalized(state.aiOff);
-      offLabel.textContent = translateOrFallback('game.backgammon.ui.bearOff', () => `${bearOffTitle}: ${getActorLabel(PLAYER)} ${playerOffFormatted} / ${getActorLabel(AI)} ${aiOffFormatted}`, {
+      offLabel.textContent = translateOrFallback('game.backgammon.ui.bearOff', () => `${bearOffTitle}: ${playerLabelText} ${playerOffFormatted} / ${aiLabelText} ${aiOffFormatted}`, {
         title: bearOffTitle,
         player: state.playerOff,
         playerFormatted: playerOffFormatted,
+        playerLabel: playerLabelText,
         ai: state.aiOff,
-        aiFormatted: aiOffFormatted
+        aiFormatted: aiOffFormatted,
+        aiLabel: aiLabelText
       });
       updateBadges();
     }

--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -12845,6 +12845,65 @@
           "distanceLabel": "DIST {distance}"
         }
       },
+      "backgammon": {
+        "actor": {
+          "player": "Player",
+          "ai": "AI"
+        },
+        "difficulty": {
+          "easy": "Easy",
+          "normal": "Normal",
+          "hard": "Hard"
+        },
+        "point": "Point {point}",
+        "bar": "Bar",
+        "dice": {
+          "none": "-"
+        },
+        "board": {
+          "playerOff": "{actor} OFF ({countFormatted})",
+          "aiOff": "{actor} OFF ({countFormatted})",
+          "barText": "{label}"
+        },
+        "action": {
+          "roll": "Roll Dice",
+          "rematch": "Rematch"
+        },
+        "badge": {
+          "difficulty": "Difficulty: {difficulty}",
+          "hits": "Hits: {hitsFormatted}",
+          "score": "Score: {scoreFormatted}"
+        },
+        "ui": {
+          "turn": "Turn: {actor}{status}",
+          "turnFinishedSuffix": " (Finished)",
+          "dice": {
+            "empty": "Dice: -",
+            "detail": "Dice: [{diceFormatted}] / Remaining [{remainingFormatted}]"
+          },
+          "bar": "{bar}: {playerLabel} {playerFormatted} / {aiLabel} {aiFormatted}",
+          "bearOff": {
+            "title": "Bear Off",
+            "summary": "{title}: {playerLabel} {playerFormatted} / {aiLabel} {aiFormatted}"
+          }
+        },
+        "log": {
+          "bearOff": "{actor} bears off from {fromLabel} ({dieFormatted})",
+          "barHit": "{actor} enters from {bar} to {toLabel} ({dieFormatted}): Hit!",
+          "barEntry": "{actor} enters from {bar} to {toLabel} ({dieFormatted})",
+          "moveHit": "{actor} moves {fromLabel} → {toLabel} ({dieFormatted}): Hit!",
+          "move": "{actor} moves {fromLabel} → {toLabel} ({dieFormatted})",
+          "win": {
+            "player": "Player wins! {rewardFormatted} EXP earned.",
+            "ai": "AI wins... Try again."
+          },
+          "aiDice": "AI dice: {diceFormatted}",
+          "aiNoMove": "AI cannot move.",
+          "playerDice": "Player dice: {diceFormatted}",
+          "noMoves": "No legal moves available.",
+          "newGame": "New game started. Player goes first."
+        }
+      },
       "runResult": {
         "defaultCause": "Game Over"
       },

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -12849,6 +12849,65 @@
           "distanceLabel": "距離 {distance}"
         }
       },
+      "backgammon": {
+        "actor": {
+          "player": "プレイヤー",
+          "ai": "AI"
+        },
+        "difficulty": {
+          "easy": "イージー",
+          "normal": "ノーマル",
+          "hard": "ハード"
+        },
+        "point": "ポイント{point}",
+        "bar": "バー",
+        "dice": {
+          "none": "-"
+        },
+        "board": {
+          "playerOff": "{actor} OFF（{countFormatted}）",
+          "aiOff": "{actor} OFF（{countFormatted}）",
+          "barText": "{label}"
+        },
+        "action": {
+          "roll": "ダイスを振る",
+          "rematch": "再戦"
+        },
+        "badge": {
+          "difficulty": "難易度: {difficulty}",
+          "hits": "ヒット: {hitsFormatted}",
+          "score": "スコア: {scoreFormatted}"
+        },
+        "ui": {
+          "turn": "手番: {actor}{status}",
+          "turnFinishedSuffix": "（終了）",
+          "dice": {
+            "empty": "ダイス: -",
+            "detail": "ダイス: [{diceFormatted}] / 残り [{remainingFormatted}]"
+          },
+          "bar": "{bar}: {playerLabel} {playerFormatted} / {aiLabel} {aiFormatted}",
+          "bearOff": {
+            "title": "ベアオフ",
+            "summary": "{title}: {playerLabel} {playerFormatted} / {aiLabel} {aiFormatted}"
+          }
+        },
+        "log": {
+          "bearOff": "{actor} が{fromLabel}からベアオフ（{dieFormatted}）",
+          "barHit": "{actor} が{bar}から{toLabel}へエントリー（{dieFormatted}）：ヒット！",
+          "barEntry": "{actor} が{bar}から{toLabel}へエントリー（{dieFormatted}）",
+          "moveHit": "{actor} が{fromLabel} → {toLabel}（{dieFormatted}）：ヒット！",
+          "move": "{actor} が{fromLabel} → {toLabel}（{dieFormatted}）",
+          "win": {
+            "player": "{actor}の勝利！{rewardFormatted} EXP 獲得",
+            "ai": "AIの勝利…再挑戦しよう"
+          },
+          "aiDice": "{actor}のダイス: {diceFormatted}",
+          "aiNoMove": "AIは動けない",
+          "playerDice": "{actor}のダイス: {diceFormatted}",
+          "noMoves": "動かせる手がありません",
+          "newGame": "新しいゲームを開始。プレイヤーの手番です"
+        }
+      },
       "runResult": {
         "defaultCause": "ゲームオーバー"
       },


### PR DESCRIPTION
## Summary
- add dedicated i18n strings for the backgammon mini game UI and logs
- update the mini game UI to use the new strings, including a translated finished suffix
- refresh label and badge styling to improve readability on light cards

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e7a970b9c0832b9a9b3602bfd800a7