### PR TITLE
Add localized HUD strings for breakout keyboard mini-game

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -10845,6 +10845,14 @@
     },
 
     "minigame": {
+      "breakout_k": {
+        "hud": {
+          "lives": "Lives: {count}",
+          "destroyed": "Destroyed: {count}",
+          "difficulty": "Difficulty: {difficulty}",
+          "controls": "Move with ← / → or A / D"
+        }
+      },
       "login_bonus": {
         "title": "Login Bonus Calendar",
         "subtitle": "Log in daily to claim rewards. Your progress is saved automatically.",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -10845,6 +10845,14 @@
     },
 
     "minigame": {
+      "breakout_k": {
+        "hud": {
+          "lives": "ライフ: {count}",
+          "destroyed": "破壊: {count}",
+          "difficulty": "難易度: {difficulty}",
+          "controls": "← / → または A / D でバー操作"
+        }
+      },
       "login_bonus": {
         "title": "ログインボーナスカレンダー",
         "subtitle": "毎日ログインして特典を獲得しましょう。獲得情報は自動保存されます。",


### PR DESCRIPTION
## Summary
- hook the breakout keyboard mini-game into the MiniExp localization helper so HUD labels translate and redraw on locale change
- add English and Japanese HUD strings for lives, bricks destroyed, difficulty, and control instructions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7a9f0814c832b9deec6b3d14bbd4f