### PR TITLE
Add localization for dungeon tower defense mini-game

### DIFF
--- a/games/dungeon_tower_defense.js
+++ b/games/dungeon_tower_defense.js
@@ -226,22 +226,17 @@
     function updateHud(){
       const nextWaveNumber = state.runningWave ? state.wave : state.wave + 1;
       const currentWave = Math.min(nextWaveNumber, config.maxWaves);
+      const hasMax = config.maxWaves > 0;
       const waveParams = {
         current: currentWave,
         currentFormatted: formatInteger(currentWave),
-        max: config.maxWaves > 0 ? config.maxWaves : null,
-        maxFormatted: config.maxWaves > 0 ? formatInteger(config.maxWaves) : null
+        max: hasMax ? config.maxWaves : null,
+        maxFormatted: hasMax ? formatInteger(config.maxWaves) : null
       };
-      waveLabel.textContent = text(
-        'hud.wave',
-        () => {
-          if (config.maxWaves > 0){
-            return `Wave ${waveParams.currentFormatted}/${waveParams.maxFormatted}`;
-          }
-          return `Wave ${waveParams.currentFormatted}`;
-        },
-        waveParams
-      );
+      const waveSuffix = hasMax ? `/${waveParams.maxFormatted}` : '';
+      waveParams.suffix = waveSuffix;
+      const waveFallback = `Wave ${waveParams.currentFormatted}${waveSuffix}`;
+      waveLabel.textContent = text('hud.wave', waveFallback, waveParams);
       const coinsFormatted = formatInteger(state.coins);
       coinsLabel.textContent = text('hud.coins', () => `資金 ${coinsFormatted} G`, { value: state.coins, formatted: coinsFormatted });
       const baseHpFormatted = formatInteger(state.baseHp);

--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -11782,6 +11782,39 @@
           "chasing": "Chasing move"
         }
       },
+      "dungeon_td": {
+        "controls": {
+          "startWave": "Start Wave"
+        },
+        "hud": {
+          "hint": "Click a floor tile to place a turret (Shift+Click to upgrade). Enemies that reach the core reduce its durability.",
+          "wave": "Wave {currentFormatted}{suffix}",
+          "coins": "Funds {formatted} G",
+          "baseHp": "Core HP {valueFormatted}/{maxFormatted}",
+          "exp": "EXP Earned {formatted}"
+        },
+        "status": {
+          "tileUnavailable": "You can't place a turret on that tile.",
+          "insufficientFunds": "Not enough funds.",
+          "towerPlaced": "Turret placed.",
+          "upgradeInsufficientFunds": "Not enough funds to upgrade ({costFormatted} G).",
+          "towerUpgraded": "Upgraded turret to Lv{levelFormatted}.",
+          "noPath": "Unable to compute a valid path.",
+          "waveStarted": "Wave {waveFormatted} has begun!",
+          "allWavesCleared": "All waves defended! Bonus {bonusCoinsFormatted} G / EXP +{bonusXpFormatted}",
+          "waveCleared": "Defended Wave {waveFormatted}! Funds +{bonusCoinsFormatted} / EXP +{bonusXpFormatted}",
+          "coreDestroyed": "The core was destroyed… Wave failed.",
+          "fullClearBonus": "Perfect defense! Bonus EXP +{bonusFormatted}",
+          "coreBreached": "Enemies breached the core…",
+          "coreDamaged": "An enemy reached the core! Durability decreased.",
+          "apiUnavailable": "Dungeon API unavailable.",
+          "generatingStage": "Generating stage…",
+          "pathFailedRetry": "Failed to secure a path. Please reload.",
+          "ready": "Place turrets and press Start Wave.",
+          "stageGenerationFailed": "Stage generation failed.",
+          "upgradeHint": "Shift+Click to upgrade a turret."
+        }
+      },
       "imperial_realm": {
         "ui": {
           "logTitle": "Operations Log",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -11786,6 +11786,39 @@
           "chasing": "追い手"
         }
       },
+      "dungeon_td": {
+        "controls": {
+          "startWave": "ウェーブ開始"
+        },
+        "hud": {
+          "hint": "床タイルをクリックで砲塔を設置 (Shift+クリックで砲塔強化)。敵がコアに到達すると耐久が減ります。",
+          "wave": "Wave {currentFormatted}{suffix}",
+          "coins": "資金 {formatted} G",
+          "baseHp": "コア耐久 {valueFormatted}/{maxFormatted}",
+          "exp": "獲得EXP {formatted}"
+        },
+        "status": {
+          "tileUnavailable": "そのタイルには砲塔を設置できません",
+          "insufficientFunds": "資金が不足しています",
+          "towerPlaced": "砲塔を設置しました",
+          "upgradeInsufficientFunds": "強化に必要な資金が不足しています ({costFormatted} G)",
+          "towerUpgraded": "砲塔をLv{levelFormatted}に強化しました",
+          "noPath": "経路を構成できませんでした",
+          "waveStarted": "Wave {waveFormatted} が始まりました！",
+          "allWavesCleared": "全ウェーブ防衛成功！ボーナス {bonusCoinsFormatted}G / EXP +{bonusXpFormatted}",
+          "waveCleared": "Wave {waveFormatted} を防衛！ 資金+{bonusCoinsFormatted} / EXP +{bonusXpFormatted}",
+          "coreDestroyed": "コアが破壊されました…ウェーブ失敗",
+          "fullClearBonus": "完全防衛達成！追加ボーナスEXP +{bonusFormatted}",
+          "coreBreached": "敵がコアに侵入しました…",
+          "coreDamaged": "敵がコアに到達！耐久が減少",
+          "apiUnavailable": "ダンジョンAPIを利用できません",
+          "generatingStage": "ステージ生成中…",
+          "pathFailedRetry": "経路の確保に失敗しました。再読み込みしてください。",
+          "ready": "砲塔を配置してウェーブ開始を押してください",
+          "stageGenerationFailed": "ステージ生成に失敗しました",
+          "upgradeHint": "Shift+クリックで砲塔を強化できます"
+        }
+      },
       "imperial_realm": {
         "ui": {
           "logTitle": "作戦ログ",


### PR DESCRIPTION
## Summary
- expose a reusable suffix for the wave HUD label so it can be localized cleanly
- add English and Japanese localization strings for Dungeon Tower Defense controls, HUD, and status messages

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68e7aa7213f0832ba4424ce3663ac529