### PR TITLE
Add localization strings for Match-3 mini-game

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -537,7 +537,20 @@
           },
           "match3": {
             "name": "Match 3",
-            "description": "Swap gems to make chains, with longer matches and combos boosting EXP."
+            "description": "Swap gems to make chains, with longer matches and combos boosting EXP.",
+            "hud": {
+              "title": "Match-3",
+              "cleared": "Cleared",
+              "status": "{title} | {difficulty} | {clearedLabel}: {tiles}"
+            },
+            "difficulty": {
+              "easy": "Easy",
+              "normal": "Normal",
+              "hard": "Hard"
+            },
+            "popup": {
+              "chain": "Chain {chain}!"
+            }
           },
           "minesweeper": {
             "name": "Minesweeper",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -537,7 +537,20 @@
           },
           "match3": {
             "name": "マッチ3",
-            "description": "3:+1 / 4:+3 / 5:+10、連鎖×1.5"
+            "description": "3:+1 / 4:+3 / 5:+10、連鎖×1.5",
+            "hud": {
+              "title": "マッチ3",
+              "cleared": "消去数",
+              "status": "{title} | {difficulty} | {clearedLabel}: {tiles}"
+            },
+            "difficulty": {
+              "easy": "かんたん",
+              "normal": "ふつう",
+              "hard": "むずかしい"
+            },
+            "popup": {
+              "chain": "{chain}連鎖！"
+            }
           },
           "minesweeper": {
             "name": "マインスイーパー",


### PR DESCRIPTION
## Summary
- add localized HUD labels, difficulty names, and chain popup text for the Match-3 mini-game
- provide translations in both Japanese and English locale bundles

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68e7aae4ce58832b9f040705d1a3556a