### PR TITLE
Add localization strings for Minesweeper mini-game

### DIFF
--- a/games/minesweeper.js
+++ b/games/minesweeper.js
@@ -10,7 +10,7 @@
       if (localization && typeof localization.t === 'function'){
         return localization.t(key, fallback, params);
       }
-      if (typeof fallback === 'function') return fallback();
+      if (typeof fallback === 'function') return fallback(params || {});
       return fallback ?? '';
     };
     const formatNumber = (value, options) => {
@@ -139,6 +139,7 @@
       const timeWithUnit = `${elapsedValue}${uiTextState.secondsUnit}`;
       info.textContent = text('.hud.info', () => `難易度:${difficultyLabel} 地雷:${minesValue} 残り旗:${flagsValue} 時間:${timeWithUnit} 開放:${openedValue}`, {
         difficulty: difficultyLabel,
+        difficultyLabel,
         mines: minesValue,
         flags: flagsValue,
         elapsed: elapsedValue,

--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -11383,6 +11383,22 @@
         "goodRateLabel": "Good Rate"
       }
     },
+      "minesweeper": {
+        "controls": {
+          "restart": "Restart ({key})"
+        },
+        "hud": {
+          "info": "{difficultyLabel}: {difficulty} | Mines: {mines} | Flags left: {flags} | Time: {timeWithUnit} | Revealed: {opened}",
+          "timeUnit": {
+            "seconds": "s"
+          }
+        },
+        "difficulty": {
+          "easy": "Easy",
+          "normal": "Normal",
+          "hard": "Hard"
+        }
+      },
       "piano_tiles": {
         "tips": "Tap lanes or press D/F/J/K keys, and hold for long notes.",
         "hud": {

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -11383,6 +11383,22 @@
         "goodRateLabel": "良率"
       }
     },
+      "minesweeper": {
+        "controls": {
+          "restart": "再開/再起動 ({key})"
+        },
+        "hud": {
+          "info": "難易度:{difficulty} 地雷:{mines} 残り旗:{flags} 時間:{timeWithUnit} 開放:{opened}",
+          "timeUnit": {
+            "seconds": "秒"
+          }
+        },
+        "difficulty": {
+          "easy": "かんたん",
+          "normal": "ふつう",
+          "hard": "むずかしい"
+        }
+      },
       "piano_tiles": {
         "tips": "タップ or D/F/J/Kキーでレーンを叩き、長いノーツは離さずにホールド。",
         "hud": {


### PR DESCRIPTION
## Summary
- allow Minesweeper fallback text helpers to receive parameters and expose the difficulty label for translations
- add English translation entries for Minesweeper HUD info, time units, controls, and difficulty labels
- add Japanese localization entries mirroring the Minesweeper HUD, control, and difficulty strings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7ab0c86c0832b89cf4c9b637ccbf0