### PR TITLE
Fix Sudoku mini-game localization

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -11344,6 +11344,40 @@
           "defenseTimeout": "Defense timeout: reacted too late."
         }
       },
+      "sudoku": {
+        "title": "Number Place (Sudoku)",
+        "description": "Fill each row, column, and 3×3 box with digits 1-9 without repeats. Click cells or use the keyboard (digits/arrows/Backspace).",
+        "info": {
+          "difficultyLabel": "Difficulty",
+          "progressLabel": "Progress",
+          "progressValue": "{filledFormatted}/{totalFormatted}",
+          "mistakesLabel": "Mistakes",
+          "mistakesValue": "{formatted}",
+          "timeLabel": "Time"
+        },
+        "difficulty": {
+          "easy": "Easy",
+          "normal": "Normal",
+          "hard": "Hard"
+        },
+        "time": {
+          "display": "{minutesFormatted}:{secondsFormatted}"
+        },
+        "keypad": {
+          "clear": "Clear"
+        },
+        "actions": {
+          "reset": "Reset",
+          "newBoard": "New Puzzle"
+        },
+        "status": {
+          "invalid": "That digit can't go there.",
+          "selectCell": "Select a cell first.",
+          "reset": "Board reset.",
+          "newBoard": "Generated a new puzzle.",
+          "cleared": "Solved! Time {time} / Mistakes {mistakes}."
+        }
+      },
       "taiko_drum": {
         "title": "Taiko Rhythm ({difficulty})",
         "tips": "F/J/Space = Don (red), D/K = Ka (blue). Hit both at once for big notes! Touch input works too.",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -11344,6 +11344,40 @@
           "defenseTimeout": "防御時間切れ：反応が遅れた"
         }
       },
+      "sudoku": {
+        "title": "ナンプレ (数独)",
+        "description": "1〜9の数字を使い、各行・列・3×3ブロックに同じ数字が入らないよう埋めてください。クリックまたはキーボード（数字/矢印/Backspace）で操作できます。",
+        "info": {
+          "difficultyLabel": "難易度",
+          "progressLabel": "進行",
+          "progressValue": "{filledFormatted}/{totalFormatted}",
+          "mistakesLabel": "ミス",
+          "mistakesValue": "{formatted}",
+          "timeLabel": "タイム"
+        },
+        "difficulty": {
+          "easy": "EASY",
+          "normal": "NORMAL",
+          "hard": "HARD"
+        },
+        "time": {
+          "display": "{minutesFormatted}:{secondsFormatted}"
+        },
+        "keypad": {
+          "clear": "消す"
+        },
+        "actions": {
+          "reset": "リセット",
+          "newBoard": "新しい盤面"
+        },
+        "status": {
+          "invalid": "その数字は入れられません。",
+          "selectCell": "マスを選択してください。",
+          "reset": "リセットしました。",
+          "newBoard": "新しい盤面を生成しました。",
+          "cleared": "クリア！タイム {time} / ミス {mistakes}。"
+        }
+      },
       "taiko_drum": {
         "title": "太鼓リズム（{difficulty}）",
         "tips": "F/J/Space = ドン（赤）、D/K = カッ（青）。大音符は両方同時！タップもOK。",


### PR DESCRIPTION
## Summary
- hook the Sudoku mini-game into the shared localization helpers and refresh UI strings on locale change
- replace hardcoded Japanese labels with translation-aware helpers and number formatting
- add English and Japanese locale entries for Sudoku-specific text, status messages, and controls

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7ab265bfc832b8e9d96e47402fadb