### PR TITLE
Fix localization in ultimate tic tac toe minigame

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -12843,6 +12843,22 @@
           "gameOver": "GAME OVER",
           "restartHint": "Press Space / R to Restart",
           "distanceLabel": "DIST {distance}"
+        },
+        "ultimateTtt": {
+          "status": {
+            "player": "Your turn",
+            "ai": "AI's turn",
+            "ended": "Game Over"
+          },
+          "activeBoard": "Target board: ({x}, {y})",
+          "overlay": {
+            "restartHint": "Press R to restart"
+          },
+          "result": {
+            "playerWin": "You win!",
+            "aiWin": "AI wins...",
+            "draw": "Draw"
+          }
         }
       },
       "runResult": {

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -12847,6 +12847,22 @@
           "gameOver": "GAME OVER",
           "restartHint": "スペース / R でリスタート",
           "distanceLabel": "距離 {distance}"
+        },
+        "ultimateTtt": {
+          "status": {
+            "player": "あなたの番",
+            "ai": "AIの番",
+            "ended": "ゲーム終了"
+          },
+          "activeBoard": "指定盤: ({x}, {y})",
+          "overlay": {
+            "restartHint": "Rキーで再開できます"
+          },
+          "result": {
+            "playerWin": "あなたの勝ち！",
+            "aiWin": "AIの勝ち…",
+            "draw": "引き分け"
+          }
         }
       },
       "runResult": {


### PR DESCRIPTION
## Summary
- integrate localization helpers into the Ultimate Tic-Tac-Toe minigame and refresh UI text on locale changes
- replace hard-coded status/result strings with translation lookups
- add English and Japanese locale entries for Ultimate Tic-Tac-Toe UI messages

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7ab52b8d4832bb9f86e2984eb5504