### PR TITLE
Fix Triomino Columns localization support

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -13900,6 +13900,115 @@
           "draw": "<strong>Draw</strong> +{exp}EXP",
           "defeat": "<strong>Defeat</strong> +{exp}EXP"
         }
+      },
+      "triominoColumns": {
+        "menu": {
+          "title": "Triomino Columns",
+          "subtitle": "Choose a mode",
+          "options": {
+            "endless": {
+              "label": "ENDLESS - Play until game over",
+              "description": "Core single-player mode"
+            },
+            "vsCpu": {
+              "label": "VS.RIVAL - CPU Battle",
+              "description": "Face off against GEARS characters"
+            },
+            "vs2p": {
+              "label": "VS.2P - Two-Player Battle",
+              "description": "Local battle (WASD + JK controls)"
+            }
+          }
+        },
+        "cpuSelect": {
+          "title": "VS.RIVAL - Select Opponent",
+          "subtitle": "Choose the rival you want to challenge",
+          "detail": "Speed Lv.{speedLevel} / Aggression {aggression}%",
+          "hint": "※ Hugleman Lady unlocks by consecutive victories. ??? unlocks by clearing without continues within 15 minutes.",
+          "back": "← Back to Mode Select",
+          "lockReasons": {
+            "lady": "Requirement: Break through the Hugleman squad in one streak",
+            "hidden": "Requirement: Clear without continues within 15 minutes",
+            "default": "Requirement: Defeat the previous rival"
+          },
+          "rivals": {
+            "0": { "name": "Karakurin" },
+            "1": { "name": "Hugleman Jr." },
+            "2": { "name": "Karakuri Ninja" },
+            "3": { "name": "Hugleman Mk-II" },
+            "4": { "name": "Hugleman Mk-III" },
+            "5": { "name": "Shadow Hugle" },
+            "6": { "name": "Hugleman Lady" },
+            "7": { "name": "???" }
+          }
+        },
+        "marks": {
+          "sun": "Sun",
+          "leaf": "Leaf",
+          "aqua": "Droplet",
+          "berry": "Berry",
+          "rose": "Rose",
+          "amber": "Amber"
+        },
+        "blocks": {
+          "multi": "Multi"
+        },
+        "messages": {
+          "garbageAttack": "Sent garbage to {target}!",
+          "lineSpark": "Line Spark!",
+          "vs2pStart": "VS 2P Start!",
+          "vsCpuStart": "VS RIVAL: {name}",
+          "combo": "{target}: {combo}-chain!"
+        },
+        "floating": {
+          "clear": "{count} CLEAR",
+          "combo": "{combo} Chain!",
+          "spark": "SPARK!"
+        },
+        "boards": {
+          "player": "Player",
+          "p1": "P1",
+          "p2": "P2"
+        },
+        "results": {
+          "gameOver": "Game Over",
+          "victoryTitle": "{name} Wins!",
+          "drawTitle": "Draw",
+          "endlessStats": "Lines {lines} / Combos {combos} / Sparks {spark}",
+          "buttons": {
+            "retryEndless": "Play Endless Again",
+            "backToMenu": "Back to Mode Select"
+          },
+          "vsCpu": {
+            "victoryMessage": "Victory! Time {duration}s / Total {total}s",
+            "defeatMessage": "Defeat… Time {duration}s",
+            "nextRival": "Next Rival ({name})",
+            "retrySame": "Rematch Same Rival",
+            "backToSelect": "Back to Rival Select"
+          },
+          "vs2p": {
+            "retry": "Rematch",
+            "hint": "You can battle again with the same keyboard setup."
+          }
+        },
+        "panel": {
+          "next": "NEXT",
+          "hold": "HOLD",
+          "stats": "STATS",
+          "lines": "Lines: {value}",
+          "combo": "Combo: {value}",
+          "spark": "Spark: {value}",
+          "attack": "Attack: {value}"
+        },
+        "miniStats": {
+          "lines": "Lines {value}",
+          "comboSpark": "Combo {combo} / Spark {spark}"
+        },
+        "modeLabels": {
+          "endless": "ENDLESS Mode",
+          "vsCpu": "VS.RIVAL Mode",
+          "vs2p": "VS.2P Mode"
+        }
       }
     },
     "games": {

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -13904,6 +13904,115 @@
           "draw": "<strong>引き分け</strong> +{exp}EXP",
           "defeat": "<strong>敗北</strong> +{exp}EXP"
         }
+      },
+      "triominoColumns": {
+        "menu": {
+          "title": "トリオミノコラムス",
+          "subtitle": "モードを選んでください",
+          "options": {
+            "endless": {
+              "label": "ENDLESS - ゲームオーバーまで",
+              "description": "基本のひとり用モード"
+            },
+            "vsCpu": {
+              "label": "VS.RIVAL - CPU戦",
+              "description": "GEARSキャラクター達と対戦"
+            },
+            "vs2p": {
+              "label": "VS.2P - ふたりで対戦",
+              "description": "ローカル対戦用（WASD + JK）"
+            }
+          }
+        },
+        "cpuSelect": {
+          "title": "VS.RIVAL - 対戦相手選択",
+          "subtitle": "挑戦したいライバルを選んでください",
+          "detail": "速さLv.{speedLevel} / 攻撃性 {aggression}%",
+          "hint": "※ ハグルマンレディは連勝で解放。？？？はノーコンティニュー＆15分以内で解放。",
+          "back": "← モード選択に戻る",
+          "lockReasons": {
+            "lady": "条件: 連勝でハグルマン軍を突破",
+            "hidden": "条件: ノーコンティニュー15分以内で解放",
+            "default": "条件: 直前のライバルに勝利"
+          },
+          "rivals": {
+            "0": { "name": "カラクリン" },
+            "1": { "name": "ハグルマンJr." },
+            "2": { "name": "からくり忍者" },
+            "3": { "name": "ハグルマン2号" },
+            "4": { "name": "ハグルマン3号" },
+            "5": { "name": "シャドウハグル" },
+            "6": { "name": "ハグルマンレディ" },
+            "7": { "name": "？？？" }
+          }
+        },
+        "marks": {
+          "sun": "太陽",
+          "leaf": "葉っぱ",
+          "aqua": "しずく",
+          "berry": "ベリー",
+          "rose": "ローズ",
+          "amber": "アンバー"
+        },
+        "blocks": {
+          "multi": "マルチ"
+        },
+        "messages": {
+          "garbageAttack": "{target}におじゃま!",
+          "lineSpark": "ラインスパーク!",
+          "vs2pStart": "VS 2P スタート!",
+          "vsCpuStart": "VS RIVAL: {name}",
+          "combo": "{target}: {combo}連鎖!"
+        },
+        "floating": {
+          "clear": "{count} CLEAR",
+          "combo": "{combo}連鎖!",
+          "spark": "SPARK!"
+        },
+        "boards": {
+          "player": "プレイヤー",
+          "p1": "P1",
+          "p2": "P2"
+        },
+        "results": {
+          "gameOver": "Game Over",
+          "victoryTitle": "{name} 勝利!",
+          "drawTitle": "引き分け",
+          "endlessStats": "ライン {lines} / コンボ {combos} / スパーク {spark}",
+          "buttons": {
+            "retryEndless": "もう一度ENDLESS",
+            "backToMenu": "モード選択に戻る"
+          },
+          "vsCpu": {
+            "victoryMessage": "勝利！タイム {duration}秒 / 総経過 {total}秒",
+            "defeatMessage": "敗北… タイム {duration}秒",
+            "nextRival": "次のライバル ({name})",
+            "retrySame": "同じ相手に再挑戦",
+            "backToSelect": "対戦相手選択に戻る"
+          },
+          "vs2p": {
+            "retry": "もう一度対戦",
+            "hint": "キーボード同士で再戦できます。"
+          }
+        },
+        "panel": {
+          "next": "NEXT",
+          "hold": "HOLD",
+          "stats": "STATS",
+          "lines": "ライン: {value}",
+          "combo": "コンボ: {value}",
+          "spark": "スパーク: {value}",
+          "attack": "アタック: {value}"
+        },
+        "miniStats": {
+          "lines": "ライン {value}",
+          "comboSpark": "コンボ {combo} / スパーク {spark}"
+        },
+        "modeLabels": {
+          "endless": "ENDLESS モード",
+          "vsCpu": "VS.RIVAL モード",
+          "vs2p": "VS.2P モード"
+        }
       }
     },
     "games": {


### PR DESCRIPTION
## Summary
- add a localization helper to Triomino Columns and route UI strings through translation lookups
- provide English and Japanese locale entries for the Triomino Columns menu, HUD, and result messages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7ac318100832b89e1fb45b2b49621