### PR TITLE
Fix localization prefix for 2048 mini game

### DIFF
--- a/games/2048.js
+++ b/games/2048.js
@@ -3,7 +3,7 @@
   function create(root, awardXp, opts){
     const shortcuts = opts?.shortcuts;
     const localization = opts?.localization || (typeof window !== 'undefined' && typeof window.createMiniGameLocalization === 'function'
-      ? window.createMiniGameLocalization({ id: 'game2048' })
+      ? window.createMiniGameLocalization({ id: 'game2048', textKeyPrefix: 'miniexp.games.game2048' })
       : null);
     const text = (key, fallback, params) => {
       if (localization && typeof localization.t === 'function') {


### PR DESCRIPTION
## Summary
- ensure the 2048 mini game requests localization strings using the `miniexp.games.game2048` prefix so setup UI text can translate correctly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e7ac550688832b964d3f52ff8ea632