### PR TITLE
Add i18n support to ToDo list mini-game

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -13549,6 +13549,53 @@
       }
     },
     "games": {
+      "todoList": {
+        "defaults": {
+          "untitled": "Untitled"
+        },
+        "header": {
+          "title": "To-Do List",
+          "today": "Today · {date}",
+          "stats": "Pending: {pending} / Completed: {completed}"
+        },
+        "form": {
+          "titleCreate": "Add New To-Do",
+          "titleEdit": "Edit To-Do",
+          "name": "Name",
+          "namePlaceholder": "e.g., Send daily report",
+          "xp": "EXP Reward",
+          "color": "Color",
+          "memo": "Notes",
+          "memoPlaceholder": "Add notes or checkpoints",
+          "submitCreate": "Add",
+          "submitUpdate": "Update",
+          "cancel": "Cancel"
+        },
+        "sections": {
+          "pending": "Pending Tasks",
+          "completed": "Completed Tasks",
+          "emptyPending": "No pending to-dos.",
+          "emptyCompleted": "No completed to-dos yet."
+        },
+        "task": {
+          "xpChip": "{xp} EXP",
+          "memoEmpty": "No notes",
+          "createdAt": "Created: {date}",
+          "completedAt": "Completed: {date}",
+          "statusCompleted": "Success",
+          "statusFailed": "Failed",
+          "actions": {
+            "complete": "Complete",
+            "fail": "Fail",
+            "edit": "Edit",
+            "delete": "Delete"
+          }
+        },
+        "dialogs": {
+          "confirmDelete": "Delete this to-do?",
+          "requireName": "Enter a name."
+        }
+      },
       "notepad": {
         "defaultFileName": "Untitled.txt",
         "confirm": {

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -13553,6 +13553,53 @@
       }
     },
     "games": {
+      "todoList": {
+        "defaults": {
+          "untitled": "名称未設定"
+        },
+        "header": {
+          "title": "ToDoリスト",
+          "today": "{date}",
+          "stats": "未完了: {pending}件 / 完了: {completed}件"
+        },
+        "form": {
+          "titleCreate": "新規ToDoを登録",
+          "titleEdit": "ToDoを編集",
+          "name": "名前",
+          "namePlaceholder": "例: 日次レポートを送信",
+          "xp": "獲得EXP",
+          "color": "カラー",
+          "memo": "メモ",
+          "memoPlaceholder": "補足情報やチェックポイントなどを入力",
+          "submitCreate": "追加",
+          "submitUpdate": "更新",
+          "cancel": "キャンセル"
+        },
+        "sections": {
+          "pending": "未完了タスク",
+          "completed": "完了済みタスク",
+          "emptyPending": "未完了のToDoはありません。",
+          "emptyCompleted": "完了したToDoはまだありません。"
+        },
+        "task": {
+          "xpChip": "{xp} EXP",
+          "memoEmpty": "メモなし",
+          "createdAt": "登録: {date}",
+          "completedAt": "完了: {date}",
+          "statusCompleted": "成功",
+          "statusFailed": "失敗",
+          "actions": {
+            "complete": "完了",
+            "fail": "失敗",
+            "edit": "編集",
+            "delete": "削除"
+          }
+        },
+        "dialogs": {
+          "confirmDelete": "このToDoを削除しますか？",
+          "requireName": "名前を入力してください。"
+        }
+      },
       "notepad": {
         "defaultFileName": "タイトルなし.txt",
         "confirm": {


### PR DESCRIPTION
## Summary
- wire the ToDo list mini-game UI to the global I18n helper and refresh labels when the locale changes
- add English and Japanese translation entries for all ToDo list strings, including headers, forms, empty states, and actions

## Testing
- Not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e7ac9730c4832b95386f61ff7735ed