### PR TITLE
Fix Notepad menu localization

### DIFF
--- a/games/notepad.js
+++ b/games/notepad.js
@@ -329,7 +329,7 @@
       const menuDefs = [
         { key: 'file', labelKey: 'games.notepad.menu.file', fallback: 'ファイル' },
         { key: 'edit', labelKey: 'games.notepad.menu.edit', fallback: '編集' },
-        { key: 'view', labelKey: 'games.notepad.menu.view', fallback: '表示' }
+        { key: 'view', labelKey: 'games.notepad.menu.view.label', fallback: '表示' }
       ];
       menuDefs.forEach(def => {
         const btn = document.createElement('button');

--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -13558,7 +13558,13 @@
         "menu": {
           "file": "File",
           "edit": "Edit",
-          "view": "View",
+          "view": {
+            "label": "View",
+            "enableWordWrap": "Enable Word Wrap",
+            "disableWordWrap": "Disable Word Wrap",
+            "showStatusBar": "Show Status Bar",
+            "hideStatusBar": "Hide Status Bar"
+          },
           "fileNew": "New",
           "fileOpen": "Open...",
           "fileSave": "Save",
@@ -13575,13 +13581,7 @@
           "editSelectAll": "Select All",
           "viewZoomIn": "Zoom In",
           "viewZoomOut": "Zoom Out",
-          "viewZoomReset": "Reset Zoom",
-          "view": {
-            "enableWordWrap": "Enable Word Wrap",
-            "disableWordWrap": "Disable Word Wrap",
-            "showStatusBar": "Show Status Bar",
-            "hideStatusBar": "Hide Status Bar"
-          }
+          "viewZoomReset": "Reset Zoom"
         },
         "commands": {
           "heading": "Toggle heading level",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -13562,7 +13562,13 @@
         "menu": {
           "file": "ファイル",
           "edit": "編集",
-          "view": "表示",
+          "view": {
+            "label": "表示",
+            "enableWordWrap": "折り返しを有効化",
+            "disableWordWrap": "折り返しを無効化",
+            "showStatusBar": "ステータスバーを表示",
+            "hideStatusBar": "ステータスバーを非表示"
+          },
           "fileNew": "新規",
           "fileOpen": "開く...",
           "fileSave": "上書き保存",
@@ -13579,13 +13585,7 @@
           "editSelectAll": "すべて選択",
           "viewZoomIn": "ズームイン",
           "viewZoomOut": "ズームアウト",
-          "viewZoomReset": "ズームを既定に戻す",
-          "view": {
-            "enableWordWrap": "折り返しを有効化",
-            "disableWordWrap": "折り返しを無効化",
-            "showStatusBar": "ステータスバーを表示",
-            "hideStatusBar": "ステータスバーを非表示"
-          }
+          "viewZoomReset": "ズームを既定に戻す"
         },
         "commands": {
           "heading": "見出しを切り替え",


### PR DESCRIPTION
## Summary
- ensure the Notepad View menu button reads from a locale-specific label key
- adjust the English and Japanese locale files so the View menu label coexists with the existing option strings

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7ace1a200832bb54e669b4495efa0