### PR TITLE
Fix timer minigame localization

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -10976,6 +10976,58 @@
           "sunday": "Sunday Bonus"
         }
       },
+      "timer": {
+        "title": "Timer",
+        "subtitle": "Manage focus and breaks with a simple countdown and stopwatch.",
+        "xpBadge": {
+          "current": "Session EXP {amount}"
+        },
+        "modes": {
+          "countdown": "Countdown",
+          "stopwatch": "Stopwatch"
+        },
+        "inputs": {
+          "hours": "Hours",
+          "minutes": "Minutes",
+          "seconds": "Seconds"
+        },
+        "quickButtons": {
+          "plus1m": "+1 min",
+          "plus5m": "+5 min",
+          "plus10m": "+10 min",
+          "minus1m": "-1 min",
+          "pomodoro": "25-min Pomodoro"
+        },
+        "buttons": {
+          "start": "Start",
+          "pause": "Pause",
+          "resume": "Resume",
+          "reset": "Reset"
+        },
+        "status": {
+          "readyGeneric": "Ready",
+          "readyCountdown": "Countdown ready",
+          "readyStopwatch": "Stopwatch ready",
+          "countdownRunning": "Counting...",
+          "countdownResumed": "Resumed",
+          "paused": "Paused",
+          "completed": "Done! Great job",
+          "stopwatchRunning": "Running...",
+          "stopwatchMinute": "{minutes} min elapsed",
+          "stopwatchMinuteWithXp": "{minutes} min elapsed!"
+        },
+        "history": {
+          "title": "Recent log",
+          "labels": {
+            "complete": "Complete",
+            "start": "Start",
+            "stopwatchMinute": "Elapsed",
+            "default": "Progress"
+          },
+          "expGain": "{label}: +{xp} EXP",
+          "completeNoXp": "Timer finished!"
+        }
+      },
       "exceler": {
         "header": {
           "title": "Exceler Spreadsheet",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -10976,6 +10976,58 @@
           "sunday": "サンデーボーナス"
         }
       },
+      "timer": {
+        "title": "タイマー",
+        "subtitle": "集中や休憩の時間管理に。シンプルなカウントダウンとストップウォッチ。",
+        "xpBadge": {
+          "current": "今回獲得 {amount} EXP"
+        },
+        "modes": {
+          "countdown": "カウントダウン",
+          "stopwatch": "ストップウォッチ"
+        },
+        "inputs": {
+          "hours": "時間",
+          "minutes": "分",
+          "seconds": "秒"
+        },
+        "quickButtons": {
+          "plus1m": "+1分",
+          "plus5m": "+5分",
+          "plus10m": "+10分",
+          "minus1m": "-1分",
+          "pomodoro": "25分ポモドーロ"
+        },
+        "buttons": {
+          "start": "開始",
+          "pause": "一時停止",
+          "resume": "再開",
+          "reset": "リセット"
+        },
+        "status": {
+          "readyGeneric": "準備完了",
+          "readyCountdown": "カウントダウンの準備完了",
+          "readyStopwatch": "ストップウォッチの準備完了",
+          "countdownRunning": "カウント中…",
+          "countdownResumed": "再開しました",
+          "paused": "一時停止中",
+          "completed": "完了！お疲れさまでした",
+          "stopwatchRunning": "計測中…",
+          "stopwatchMinute": "{minutes}分経過",
+          "stopwatchMinuteWithXp": "{minutes}分経過！"
+        },
+        "history": {
+          "title": "最近のログ",
+          "labels": {
+            "complete": "完了",
+            "start": "開始",
+            "stopwatchMinute": "経過",
+            "default": "達成"
+          },
+          "expGain": "{label}: +{xp} EXP",
+          "completeNoXp": "タイマー完了！"
+        }
+      },
       "exceler": {
         "header": {
           "title": "表計算エクセラー",


### PR DESCRIPTION
## Summary
- add a reusable translation helper to the timer minigame and update all UI strings to use localized text
- add timer-specific strings to the Japanese and English locale bundles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7ae4e12a4832bb384a6b4b7d78aa7