### PR TITLE
Fix Math Lab localization key prefix

### DIFF
--- a/games/math_lab.js
+++ b/games/math_lab.js
@@ -37,7 +37,7 @@
   }
 
   function gameText(subKey, fallback, params){
-    const key = subKey ? `games.mathLab.${subKey}` : null;
+    const key = subKey ? `games.math_lab.${subKey}` : null;
     return translateText(key, fallback, params);
   }
 


### PR DESCRIPTION
## Summary
- fix the Math Lab mini-game localization prefix so that translations resolve correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7ae77078c832bb6b2f2e6dbd3f63c