### PR TITLE
Fix janken minigame start state reset

### DIFF
--- a/games/janken.js
+++ b/games/janken.js
@@ -461,14 +461,21 @@
 
     updateStats();
 
-    function start(){}
-    function stop(){
+    function resetInteractionState(){
       clearTimers();
       if (isResolving){
         isResolving = false;
-        setButtonsDisabled(false);
-        clearHighlights();
       }
+      setButtonsDisabled(false);
+      clearHighlights();
+    }
+
+    function start(){
+      resetInteractionState();
+      setStatus('status.prompt', '手を選ぶと掛け声が始まるよ');
+    }
+    function stop(){
+      resetInteractionState();
       setStatus('status.paused', '一時停止中');
     }
     function destroy(){


### PR DESCRIPTION
## Summary
- reset timers, button states, and highlights before starting or stopping the janken minigame
- restore the default prompt when the minigame is started so it no longer remains paused after resuming

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e7b56c0838832b8a85840caeb723cd