### PR TITLE
Fix taiko note travel positioning

### DIFF
--- a/games/taiko_drum.js
+++ b/games/taiko_drum.js
@@ -580,8 +580,8 @@
           continue;
         }
         if (timeUntil > NOTE_TRAVEL_TIME) continue;
-        const ratio = 1 - (timeUntil + NOTE_TRAVEL_TIME) / NOTE_TRAVEL_TIME;
-        const x = HIT_CIRCLE_X + (spawnX - HIT_CIRCLE_X) * (1 - ratio);
+        const travelProgress = Math.min(Math.max(1 - timeUntil / NOTE_TRAVEL_TIME, 0), 1);
+        const x = spawnX - (spawnX - HIT_CIRCLE_X) * travelProgress;
         const y = CANVAS_HEIGHT / 2;
         const color = note.type === 'don' ? DON_COLOR : KA_COLOR;
         const radius = note.big ? 42 : 28;


### PR DESCRIPTION
## Summary
- correct the taiko rhythm note travel calculation so notes align with the hit circle timing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7b0fd45e0832b8346b4124cff2254