### PR TITLE
Add localization strings for music player mini-game

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -11164,6 +11164,74 @@
           "digital_strings": "Digital Strings"
         }
       },
+      "music_player": {
+        "title": "Music Player",
+        "subtitle": "Play local tracks with visualizers and EQ.",
+        "actions": {
+          "import": "Import Tracks"
+        },
+        "settings": {
+          "shuffle": "Shuffle Play",
+          "loopMode": "Loop Mode",
+          "clearLibrary": "Clear Library"
+        },
+        "controls": {
+          "volume": "Volume",
+          "playbackRate": "Playback Speed"
+        },
+        "playlist": {
+          "title": "Playlist",
+          "search": "Search...",
+          "count": "Tracks {count}"
+        },
+        "status": {
+          "playlist": "Tracks: {count} / {max} | Total time: {duration}",
+          "session": "Session EXP: {exp}"
+        },
+        "eq": {
+          "title": "Equalizer",
+          "presets": {
+            "flat": "Flat",
+            "rock": "Rock",
+            "vocal": "Vocal",
+            "bassBoost": "Bass Boost",
+            "custom": "Custom"
+          }
+        },
+        "loop": {
+          "none": "No Loop",
+          "one": "Repeat One",
+          "all": "Repeat All"
+        },
+        "visualizer": {
+          "oscilloscope": "Oscilloscope",
+          "frequency": "Frequency Spectrum"
+        },
+        "toast": {
+          "audioInitFailed": "Failed to initialize the audio context.",
+          "fileTooLarge": "{name} exceeds the size limit ({maxBytes} bytes).",
+          "libraryCleared": "Library cleared.",
+          "libraryLoadFailed": "Failed to load the library.",
+          "loadFailed": "Failed to load the track.",
+          "noTracks": "No tracks to play.",
+          "playFailed": "Couldn't start playback.",
+          "playlistFull": "Playlist limit reached ({max} tracks).",
+          "removed": "Removed {name}.",
+          "saveFailed": "Couldn't save {name}.",
+          "trackMissing": "Track not found."
+        },
+        "dialog": {
+          "renamePrompt": "Enter track name",
+          "clearConfirm": "Delete all tracks?"
+        },
+        "track": {
+          "untitled": "Untitled"
+        },
+        "header": {
+          "measuring": "Measuring length",
+          "playing": "Playing • {duration}"
+        }
+      },
       "counter_pad": {
         "title": "Counter Pad",
         "subtitle": "Track multiple counters quickly. Adjustments are saved automatically.",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -11164,6 +11164,74 @@
           "digital_strings": "デジタルストリングス"
         }
       },
+      "music_player": {
+        "title": "ミュージックプレイヤー",
+        "subtitle": "ローカル音源を再生するユーティリティ",
+        "actions": {
+          "import": "音源を追加"
+        },
+        "settings": {
+          "shuffle": "シャッフル再生",
+          "loopMode": "ループモード",
+          "clearLibrary": "ライブラリを全削除"
+        },
+        "controls": {
+          "volume": "音量",
+          "playbackRate": "再生速度"
+        },
+        "playlist": {
+          "title": "プレイリスト",
+          "search": "検索...",
+          "count": "{count} 曲"
+        },
+        "status": {
+          "playlist": "曲数: {count} / {max} | 合計時間: {duration}",
+          "session": "セッションEXP: {exp}"
+        },
+        "eq": {
+          "title": "イコライザー",
+          "presets": {
+            "flat": "フラット",
+            "rock": "ロック",
+            "vocal": "ボーカル",
+            "bassBoost": "低音強調",
+            "custom": "カスタム"
+          }
+        },
+        "loop": {
+          "none": "ループなし",
+          "one": "1曲リピート",
+          "all": "全曲リピート"
+        },
+        "visualizer": {
+          "oscilloscope": "オシロスコープ",
+          "frequency": "周波数スペクトラム"
+        },
+        "toast": {
+          "audioInitFailed": "オーディオコンテキストを初期化できませんでした",
+          "fileTooLarge": "{name} はサイズ上限 ({maxBytes} バイト) を超えています",
+          "libraryCleared": "ライブラリをクリアしました",
+          "libraryLoadFailed": "ライブラリの読み込みに失敗しました",
+          "loadFailed": "音源の読み込みに失敗しました",
+          "noTracks": "再生するトラックがありません",
+          "playFailed": "再生を開始できませんでした",
+          "playlistFull": "プレイリストの上限に達しました（最大 {max} 曲）",
+          "removed": "{name} を削除しました",
+          "saveFailed": "{name} を保存できませんでした",
+          "trackMissing": "トラックが見つかりません"
+        },
+        "dialog": {
+          "renamePrompt": "トラック名を入力",
+          "clearConfirm": "すべての音源を削除しますか？"
+        },
+        "track": {
+          "untitled": "名称未設定"
+        },
+        "header": {
+          "measuring": "長さ計測中",
+          "playing": "再生中 • {duration}"
+        }
+      },
       "counter_pad": {
         "title": "カウンターパッド",
         "subtitle": "複数のカウントを素早く管理。増減操作は自動保存されます。",


### PR DESCRIPTION
## Summary
- add English localization entries for the music player mini-game UI, status, and toast strings
- add matching Japanese entries so the mini-game can resolve all localization keys

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7af19af58832b8037dc1eb7464060