### PR TITLE
feat: localize JS tester and refresh UI

### DIFF
--- a/games/tester.js
+++ b/games/tester.js
@@ -6,11 +6,11 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    gap: 16px;
-    color: #e2e8f0;
-    background: radial-gradient(circle at 18% 18%, rgba(59,130,246,0.08), rgba(9,12,24,0.96));
+    gap: 18px;
+    color: #0b1120;
+    background: linear-gradient(160deg, #f8fafc 0%, #e2e8f0 45%, #dbeafe 100%);
     font-family: 'Segoe UI', 'Hiragino Sans', 'Noto Sans JP', sans-serif;
-    padding: 22px 26px;
+    padding: 26px 30px;
     box-sizing: border-box;
     overflow: hidden;
   }
@@ -23,33 +23,41 @@
     font-size: 24px;
     font-weight: 600;
     letter-spacing: 0.05em;
+    color: #0f172a;
+    text-shadow: 0 1px 0 rgba(255,255,255,0.6);
   }
   .mini-tester-sub {
     font-size: 13px;
-    color: rgba(226,232,240,0.7);
+    color: #334155;
   }
   .mini-tester-tabs {
     display: flex;
     gap: 10px;
     flex-wrap: wrap;
+    padding: 10px 14px;
+    background: rgba(255,255,255,0.72);
+    border: 1px solid rgba(148,163,184,0.35);
+    border-radius: 16px;
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.7);
   }
   .mini-tester-tab-btn {
-    padding: 8px 14px;
-    background: rgba(30,41,59,0.75);
-    border: 1px solid rgba(148,163,184,0.2);
+    padding: 8px 16px;
+    background: #e2e8f0;
+    border: 1px solid rgba(148,163,184,0.6);
     border-radius: 999px;
-    color: #e2e8f0;
+    color: #0f172a;
     cursor: pointer;
     font-size: 13px;
-    transition: background 0.18s ease, transform 0.18s ease;
+    transition: background 0.18s ease, transform 0.18s ease, box-shadow 0.18s ease;
   }
   .mini-tester-tab-btn:hover {
-    background: rgba(59,130,246,0.2);
+    background: #cbd5f5;
     transform: translateY(-1px);
   }
   .mini-tester-tab-btn.active {
-    background: linear-gradient(135deg, rgba(59,130,246,0.4), rgba(129,140,248,0.55));
-    border-color: rgba(191,219,254,0.6);
+    background: #ffffff;
+    border-color: rgba(100,116,139,0.85);
+    box-shadow: 0 8px 22px rgba(100,116,139,0.18);
   }
   .mini-tester-main {
     flex: 1;
@@ -70,26 +78,28 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    gap: 18px;
+    gap: 20px;
     overflow: hidden;
   }
   .mini-tester-card {
-    background: rgba(15,23,42,0.82);
-    border: 1px solid rgba(148,163,184,0.22);
+    background: rgba(255,255,255,0.92);
+    border: 1px solid rgba(148,163,184,0.4);
     border-radius: 18px;
-    padding: 18px;
-    box-shadow: 0 28px 60px rgba(8,12,24,0.55);
+    padding: 20px;
+    box-shadow: 0 24px 52px rgba(148,163,184,0.25);
   }
   .mini-tester-card h3 {
     margin: 0 0 10px;
     font-size: 18px;
     font-weight: 600;
     letter-spacing: 0.04em;
+    color: #0b1f44;
   }
   .mini-tester-card p {
     margin: 0;
-    color: rgba(226,232,240,0.8);
+    color: #475569;
     font-size: 13px;
+    line-height: 1.6;
   }
   .mini-tester-tests-list {
     display: grid;
@@ -97,9 +107,9 @@
     gap: 14px;
   }
   .mini-tester-test-item {
-    background: rgba(30,41,59,0.6);
+    background: rgba(248,250,252,0.95);
     border-radius: 14px;
-    border: 1px solid rgba(148,163,184,0.25);
+    border: 1px solid rgba(148,163,184,0.45);
     padding: 14px;
     display: flex;
     flex-direction: column;
@@ -107,9 +117,10 @@
   }
   .mini-tester-test-item strong {
     font-size: 15px;
+    color: #0f172a;
   }
   .mini-tester-test-desc {
-    color: rgba(226,232,240,0.7);
+    color: #475569;
     font-size: 12px;
   }
   .mini-tester-test-actions {
@@ -120,28 +131,29 @@
   .mini-tester-button {
     border: none;
     border-radius: 999px;
-    padding: 8px 14px;
+    padding: 8px 16px;
     font-size: 12px;
-    color: #0f172a;
-    background: linear-gradient(135deg, rgba(96,165,250,0.85), rgba(129,140,248,0.9));
+    color: #f8fafc;
+    background: linear-gradient(135deg, #2563eb, #7c3aed);
     cursor: pointer;
     transition: transform 0.15s ease, box-shadow 0.15s ease;
   }
   .mini-tester-button:hover {
     transform: translateY(-1px);
-    box-shadow: 0 10px 18px rgba(37,99,235,0.32);
+    box-shadow: 0 10px 18px rgba(59,130,246,0.28);
   }
   .mini-tester-button.secondary {
-    background: rgba(148,163,184,0.2);
-    color: #e2e8f0;
+    background: #e2e8f0;
+    color: #0f172a;
+    border: 1px solid rgba(148,163,184,0.55);
   }
   .mini-tester-button.danger {
-    background: linear-gradient(135deg, rgba(248,113,113,0.9), rgba(239,68,68,0.85));
-    color: #0b1120;
+    background: linear-gradient(135deg, #ef4444, #f97316);
+    color: #ffffff;
   }
   .mini-tester-test-result {
     font-size: 12px;
-    color: rgba(226,232,240,0.86);
+    color: #1e293b;
   }
   .mini-tester-bench-display {
     display: grid;
@@ -149,65 +161,74 @@
     gap: 16px;
   }
   .mini-tester-bench-box {
-    background: rgba(30,41,59,0.65);
-    border: 1px solid rgba(148,163,184,0.22);
+    background: rgba(248,250,252,0.95);
+    border: 1px solid rgba(148,163,184,0.45);
     border-radius: 16px;
-    padding: 16px;
+    padding: 18px;
   }
   .mini-tester-bench-value {
     font-size: 26px;
     font-weight: 700;
     margin-bottom: 6px;
+    color: #0b1f44;
   }
   .mini-tester-bench-log {
-    background: rgba(15,23,42,0.65);
+    background: rgba(241,245,249,0.95);
     border-radius: 12px;
     padding: 12px;
-    max-height: 180px;
+    max-height: 200px;
     overflow: auto;
     font-size: 12px;
-    line-height: 1.5;
+    line-height: 1.6;
+    border: 1px solid rgba(148,163,184,0.35);
   }
   .mini-tester-bench-log-entry {
-    color: rgba(226,232,240,0.82);
+    color: #1e293b;
   }
   .mini-tester-blocks {
     display: grid;
     grid-template-columns: minmax(320px, 360px) 1fr;
-    gap: 18px;
+    gap: 20px;
     height: 100%;
+    background: linear-gradient(135deg, rgba(248,250,252,0.94), rgba(224,231,255,0.92));
+    border: 1px solid rgba(148,163,184,0.35);
+    border-radius: 22px;
+    padding: 18px;
+    box-shadow: 0 30px 60px rgba(148,163,184,0.28);
   }
-  .mini-tester-blocks-left {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    min-height: 0;
-  }
+  .mini-tester-blocks-left,
   .mini-tester-blocks-right {
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 14px;
     min-height: 0;
+    background: rgba(255,255,255,0.92);
+    border: 1px solid rgba(148,163,184,0.3);
+    border-radius: 16px;
+    padding: 16px;
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.65);
   }
   .mini-tester-block-list {
     flex: 1;
     overflow-y: auto;
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 12px;
+    padding-right: 6px;
   }
   .mini-tester-block-item {
-    background: rgba(30,41,59,0.72);
-    border: 1px solid rgba(148,163,184,0.28);
+    background: linear-gradient(135deg, #ffffff, rgba(241,245,249,0.92));
+    border: 1px solid rgba(148,163,184,0.35);
     border-radius: 14px;
-    padding: 12px;
+    padding: 14px;
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 10px;
     position: relative;
+    box-shadow: 0 12px 28px rgba(148,163,184,0.18);
   }
   .mini-tester-block-item.active {
-    box-shadow: 0 0 0 2px rgba(96,165,250,0.7);
+    box-shadow: 0 0 0 2px rgba(37,99,235,0.45);
   }
   .mini-tester-block-header {
     display: flex;
@@ -217,9 +238,9 @@
   }
   .mini-tester-block-header select,
   .mini-tester-block-header input[type="number"] {
-    background: rgba(15,23,42,0.8);
-    border: 1px solid rgba(148,163,184,0.3);
-    color: #e2e8f0;
+    background: #ffffff;
+    border: 1px solid rgba(148,163,184,0.6);
+    color: #0f172a;
     border-radius: 8px;
     padding: 4px 8px;
     font-size: 12px;
@@ -228,9 +249,9 @@
   .mini-tester-block-body input,
   .mini-tester-block-body select {
     width: 100%;
-    background: rgba(15,23,42,0.78);
-    border: 1px solid rgba(148,163,184,0.25);
-    color: #e2e8f0;
+    background: #f8fafc;
+    border: 1px solid rgba(148,163,184,0.55);
+    color: #0f172a;
     border-radius: 8px;
     padding: 6px 8px;
     font-size: 12px;
@@ -246,55 +267,56 @@
   }
   .mini-tester-story-log {
     flex: 1;
-    background: rgba(15,23,42,0.75);
-    border: 1px solid rgba(148,163,184,0.25);
+    background: rgba(248,250,252,0.95);
+    border: 1px solid rgba(148,163,184,0.45);
     border-radius: 16px;
-    padding: 14px;
+    padding: 16px;
     overflow-y: auto;
     font-size: 13px;
     line-height: 1.6;
   }
   .mini-tester-story-log-entry {
-    margin-bottom: 6px;
+    margin-bottom: 8px;
   }
   .mini-tester-story-log-entry span.label {
     font-weight: 600;
-    color: rgba(125,211,252,0.92);
+    color: #2563eb;
     margin-right: 6px;
   }
   .mini-tester-choice-container {
     display: flex;
     flex-wrap: wrap;
-    gap: 8px;
-    margin-top: 8px;
+    gap: 10px;
+    margin-top: 10px;
   }
   .mini-tester-choice-container button {
-    background: rgba(96,165,250,0.2);
-    border: 1px solid rgba(59,130,246,0.4);
-    color: #bfdbfe;
-    padding: 6px 12px;
+    background: rgba(37,99,235,0.12);
+    border: 1px solid rgba(37,99,235,0.4);
+    color: #1e3a8a;
+    padding: 6px 14px;
     border-radius: 999px;
     cursor: pointer;
+    transition: background 0.18s ease;
   }
   .mini-tester-choice-container button:hover {
-    background: rgba(96,165,250,0.35);
+    background: rgba(37,99,235,0.22);
   }
   .mini-tester-alert-editor textarea {
     width: 100%;
     min-height: 120px;
-    background: rgba(15,23,42,0.82);
-    border: 1px solid rgba(148,163,184,0.25);
-    border-radius: 12px;
-    padding: 10px;
-    color: #e2e8f0;
-    font-size: 12px;
-    line-height: 1.5;
-  }
-  .mini-tester-variables {
-    background: rgba(15,23,42,0.7);
-    border: 1px solid rgba(148,163,184,0.25);
+    background: rgba(248,250,252,0.95);
+    border: 1px solid rgba(148,163,184,0.45);
     border-radius: 12px;
     padding: 12px;
+    color: #0f172a;
+    font-size: 12px;
+    line-height: 1.6;
+  }
+  .mini-tester-variables {
+    background: rgba(248,250,252,0.95);
+    border: 1px solid rgba(148,163,184,0.45);
+    border-radius: 12px;
+    padding: 14px;
     font-size: 12px;
     display: flex;
     flex-direction: column;
@@ -302,51 +324,88 @@
   }
   .mini-tester-alert-status {
     font-size: 12px;
-    color: rgba(248,250,252,0.8);
+    color: #334155;
   }
   .mini-tester-control-block {
-    background: rgba(30,41,59,0.55);
-    border: 1px solid rgba(148,163,184,0.25);
+    background: #ffffff;
+    border: 1px solid rgba(148,163,184,0.45);
     border-radius: 12px;
-    padding: 10px;
+    padding: 12px;
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 10px;
+    box-shadow: 0 18px 32px rgba(148,163,184,0.18);
   }
   .mini-tester-control-message {
     font-weight: 600;
-    color: rgba(226,232,240,0.9);
+    color: #0f172a;
   }
   .mini-tester-control-actions {
     display: flex;
     flex-wrap: wrap;
-    gap: 8px;
+    gap: 10px;
   }
   .mini-tester-control-actions button {
-    background: rgba(96,165,250,0.2);
-    border: 1px solid rgba(59,130,246,0.35);
-    color: #dbeafe;
-    padding: 6px 14px;
+    background: rgba(37,99,235,0.14);
+    border: 1px solid rgba(37,99,235,0.4);
+    color: #1e3a8a;
+    padding: 6px 16px;
     border-radius: 999px;
     cursor: pointer;
   }
   .mini-tester-control-actions button:hover {
-    background: rgba(96,165,250,0.32);
+    background: rgba(37,99,235,0.22);
   }
   .mini-tester-control-input {
-    background: rgba(15,23,42,0.82);
-    border: 1px solid rgba(148,163,184,0.25);
+    background: #f8fafc;
+    border: 1px solid rgba(148,163,184,0.55);
     border-radius: 8px;
     padding: 6px 10px;
-    color: #e2e8f0;
+    color: #0f172a;
     width: 100%;
     box-sizing: border-box;
   }
   .mini-tester-control-error {
-    color: #fca5a5;
+    color: #b91c1c;
     font-size: 12px;
   }
   `;
+
+  const I18N = typeof window !== 'undefined' ? window.I18n : null;
+  const I18N_PREFIX = 'selection.miniexp.games.tester';
+
+  function computeFallbackText(fallback) {
+    if (typeof fallback === 'function') {
+      try {
+        const result = fallback();
+        return typeof result === 'string' ? result : (result ?? '');
+      } catch (error) {
+        console.warn('[tester] Failed to evaluate fallback text:', error);
+        return '';
+      }
+    }
+    return fallback ?? '';
+  }
+
+  function translateKey(fullKey, fallback, params) {
+    if (fullKey && I18N && typeof I18N.t === 'function') {
+      try {
+        const translated = I18N.t(fullKey, params);
+        if (typeof translated === 'string' && translated !== fullKey) {
+          return translated;
+        }
+      } catch (error) {
+        console.warn('[tester] Failed to translate key:', fullKey, error);
+      }
+    }
+    return computeFallbackText(fallback);
+  }
+
+  function t(path, fallback, params) {
+    if (!path) return computeFallbackText(fallback);
+    const fullKey = `${I18N_PREFIX}.${path}`;
+    return translateKey(fullKey, fallback, params);
+  }
 
   function ensureStyles(){
     if (!document.getElementById(STYLE_ID)) {
@@ -371,21 +430,25 @@
     {
       id: 'numbers',
       name: '数値/BigInt',
+      nameKey: 'tests.defs.numbers.name',
       description: '浮動小数とBigIntの演算、Math拡張を試験します。',
+      descriptionKey: 'tests.defs.numbers.description',
       async run() {
         const big = 2n ** 40n;
         const big2 = big / 256n;
-        if (big2 !== 2n ** 32n) throw new Error('BigInt演算が期待どおりではありません');
+        if (big2 !== 2n ** 32n) throw new Error(t('tests.defs.numbers.errors.bigInt', 'BigInt演算が期待どおりではありません'));
         const precise = Math.fround(Math.PI * Math.E);
         const hypot = Math.hypot(3, 4, 12);
-        if (Math.abs(hypot - 13) > 1e-6) throw new Error('Math.hypot結果に誤差が大きいです');
+        if (Math.abs(hypot - 13) > 1e-6) throw new Error(t('tests.defs.numbers.errors.hypot', 'Math.hypot結果に誤差が大きいです'));
         return `BigInt OK / fround=${precise.toFixed(4)}`;
       }
     },
     {
       id: 'json',
       name: 'JSON & structuredClone',
+      nameKey: 'tests.defs.json.name',
       description: 'JSONシリアライズとstructuredCloneをチェックします。',
+      descriptionKey: 'tests.defs.json.description',
       async run() {
         const obj = {
           count: 12,
@@ -394,11 +457,11 @@
         };
         const json = JSON.stringify(obj);
         const restored = JSON.parse(json);
-        if (!restored.nested || restored.nested[2].label !== 'X') throw new Error('JSON復元に失敗しました');
+        if (!restored.nested || restored.nested[2].label !== 'X') throw new Error(t('tests.defs.json.errors.restore', 'JSON復元に失敗しました'));
         if (typeof structuredClone === 'function') {
           const cloned = structuredClone(obj);
           if (!(cloned.map instanceof Map) || cloned.map.get(1) !== 'one') {
-            throw new Error('structuredCloneがMapを保持できません');
+            throw new Error(t('tests.defs.json.errors.clone', 'structuredCloneがMapを保持できません'));
           }
         }
         return `JSON長=${json.length}`;
@@ -407,7 +470,9 @@
     {
       id: 'intl',
       name: 'Intlフォーマット',
+      nameKey: 'tests.defs.intl.name',
       description: 'Intl.DateTimeFormatとNumberFormatを検証します。',
+      descriptionKey: 'tests.defs.intl.description',
       async run() {
         const i18n = window.I18n;
         const locale = (i18n?.getLocale?.() || i18n?.getDefaultLocale?.() || 'ja').toString();
@@ -416,17 +481,19 @@
           ? i18n.formatNumber(123456.789, { style: 'currency', currency: 'JPY' })
           : new Intl.NumberFormat(locale, { style: 'currency', currency: 'JPY' }).format(123456.789);
         const formattedDate = dateFmt.format(new Date('2023-05-01T12:34:56Z'));
-        if (!formattedDate.includes('5月')) throw new Error('日付フォーマットが想定外です');
-        if (!formattedNumber.includes('￥')) throw new Error('通貨フォーマットが想定外です');
+        if (!formattedDate.includes('5月')) throw new Error(t('tests.defs.intl.errors.date', '日付フォーマットが想定外です'));
+        if (!formattedNumber.includes('￥')) throw new Error(t('tests.defs.intl.errors.currency', '通貨フォーマットが想定外です'));
         return `${formattedDate} / ${formattedNumber}`;
       }
     },
     {
       id: 'crypto',
       name: 'Crypto API',
+      nameKey: 'tests.defs.crypto.name',
       description: '暗号学的乱数と微小なハッシュ処理を行います。',
+      descriptionKey: 'tests.defs.crypto.description',
       async run() {
-        if (!window.crypto || !crypto.getRandomValues) throw new Error('crypto.getRandomValuesが利用できません');
+        if (!window.crypto || !crypto.getRandomValues) throw new Error(t('tests.defs.crypto.errors.random', 'crypto.getRandomValuesが利用できません'));
         const bytes = new Uint8Array(32);
         crypto.getRandomValues(bytes);
         const digest = await crypto.subtle.digest('SHA-256', bytes);
@@ -437,7 +504,9 @@
     {
       id: 'storage',
       name: 'Storage API',
+      nameKey: 'tests.defs.storage.name',
       description: 'localStorage/sessionStorage の読み書きを確認します。',
+      descriptionKey: 'tests.defs.storage.description',
       async run() {
         const key = `tester-${Date.now()}-${Math.random()}`;
         try {
@@ -447,9 +516,9 @@
           const sessionValue = sessionStorage.getItem(key);
           localStorage.removeItem(key);
           sessionStorage.removeItem(key);
-          if (value !== 'ok' || sessionValue !== 'ok-session') throw new Error('Storage読み書き失敗');
+          if (value !== 'ok' || sessionValue !== 'ok-session') throw new Error(t('tests.defs.storage.errors.read', 'Storage読み書き失敗'));
         } catch (err) {
-          throw new Error('Storage利用がブロックされています');
+          throw new Error(t('tests.defs.storage.errors.blocked', 'Storage利用がブロックされています'));
         }
         return 'localStorage / sessionStorage OK';
       }
@@ -457,7 +526,9 @@
     {
       id: 'canvas',
       name: 'Canvas & Offscreen',
+      nameKey: 'tests.defs.canvas.name',
       description: 'Canvas描画とOffscreenCanvasの存在を検査します。',
+      descriptionKey: 'tests.defs.canvas.description',
       async run() {
         const canvas = document.createElement('canvas');
         canvas.width = 64;
@@ -473,7 +544,7 @@
         ctx.arc(32, 32, 22, 0, Math.PI * 2);
         ctx.fill();
         const data = ctx.getImageData(32, 32, 1, 1).data;
-        if (!data || data.length < 3) throw new Error('Canvasピクセル取得に失敗');
+        if (!data || data.length < 3) throw new Error(t('tests.defs.canvas.errors.sample', 'Canvasピクセル取得に失敗'));
         const hasOffscreen = typeof OffscreenCanvas !== 'undefined';
         return `中心RGB=(${data[0]},${data[1]},${data[2]}) / Offscreen=${hasOffscreen ? 'YES' : 'NO'}`;
       }
@@ -493,8 +564,130 @@
     let storyBlocks = [];
     let storyRunToken = 0;
     let customAlertImpl = defaultAlertImpl;
-    let customAlertStatus = '';
+    let alertStatusEl = null;
+    let varBodyEl = null;
+    let variablesEmpty = true;
+    let alertStatusState = {
+      key: 'blocks.alert.statusDefault',
+      fallback: '既定: ログに表示します。alert() に変えることも可能です。',
+      params: null
+    };
+    let detachLocaleListener = null;
     let lastAlertTestAwarded = false;
+
+    const localizationBindings = [];
+
+    function normalizeKey(key, options) {
+      if (!key) return null;
+      const absolute = options && options.absolute;
+      if (absolute) return key;
+      if (typeof key === 'string' && (key === I18N_PREFIX || key.startsWith(`${I18N_PREFIX}.`))) {
+        return key;
+      }
+      return `${I18N_PREFIX}.${key}`;
+    }
+
+    function evaluateParams(binding) {
+      if (!binding) return undefined;
+      if (typeof binding.params === 'function') {
+        try {
+          return binding.params();
+        } catch (error) {
+          console.warn('[tester] Failed to evaluate localization params:', error);
+          return undefined;
+        }
+      }
+      return binding.params;
+    }
+
+    function applyBinding(binding) {
+      if (!binding || !binding.element) return;
+      const key = normalizeKey(binding.key, binding);
+      const params = evaluateParams(binding);
+      const value = key
+        ? translateKey(key, binding.fallback, params)
+        : computeFallbackText(typeof binding.computeFallback === 'function'
+            ? () => binding.computeFallback(params)
+            : binding.fallback);
+      if (binding.type === 'text') {
+        binding.element.textContent = value;
+      } else if (binding.type === 'html') {
+        binding.element.innerHTML = value;
+      } else if (binding.type === 'attr' && binding.attr) {
+        if (value === undefined || value === null) {
+          binding.element.removeAttribute(binding.attr);
+        } else {
+          binding.element.setAttribute(binding.attr, value);
+        }
+      } else if (binding.type === 'value') {
+        binding.element.value = value;
+      }
+    }
+
+    function registerBinding(binding) {
+      if (!binding || !binding.element) return;
+      localizationBindings.push(binding);
+      applyBinding(binding);
+    }
+
+    function bindText(element, key, fallback, params, options) {
+      if (!element) return;
+      registerBinding({ element, key, fallback, params, type: 'text', ...(options || {}) });
+    }
+
+    function bindHtml(element, key, fallback, params, options) {
+      if (!element) return;
+      registerBinding({ element, key, fallback, params, type: 'html', ...(options || {}) });
+    }
+
+    function bindAttr(element, attr, key, fallback, params, options) {
+      if (!element) return;
+      registerBinding({ element, key, fallback, params, type: 'attr', attr, ...(options || {}) });
+    }
+
+    function bindPlaceholder(element, key, fallback, params, options) {
+      bindAttr(element, 'placeholder', key, fallback, params, options);
+    }
+
+    function bindValue(element, key, fallback, params, options) {
+      if (!element) return;
+      registerBinding({ element, key, fallback, params, type: 'value', ...(options || {}) });
+    }
+
+    function translateImmediate(key, fallback, params, options) {
+      const normalized = normalizeKey(key, options);
+      return normalized ? translateKey(normalized, fallback, params) : computeFallbackText(fallback);
+    }
+
+    function setImmediateText(element, key, fallback, params, options) {
+      if (!element) return;
+      element.textContent = translateImmediate(key, fallback, params, options);
+    }
+
+    function refreshLocalization() {
+      for (let i = localizationBindings.length - 1; i >= 0; i -= 1) {
+        const binding = localizationBindings[i];
+        if (!binding || !binding.element || (typeof binding.element.isConnected === 'boolean' && !binding.element.isConnected)) {
+          localizationBindings.splice(i, 1);
+          continue;
+        }
+        applyBinding(binding);
+      }
+      refreshAlertStatus();
+      if (variablesEmpty && varBodyEl) {
+        setImmediateText(varBodyEl, 'blocks.variables.empty', '(空)');
+      }
+    }
+
+    function setAlertStatus(key, fallback, params, options) {
+      alertStatusState = { key, fallback, params, options };
+      refreshAlertStatus();
+    }
+
+    function refreshAlertStatus() {
+      if (!alertStatusEl) return;
+      setImmediateText(alertStatusEl, alertStatusState.key, alertStatusState.fallback, alertStatusState.params, alertStatusState.options);
+    }
 
     const container = document.createElement('div');
     container.className = 'mini-tester-root';
@@ -503,10 +696,10 @@
     header.className = 'mini-tester-header';
     const title = document.createElement('div');
     title.className = 'mini-tester-title';
-    title.textContent = 'JSテスター / MiniExp MOD';
+    bindText(title, 'title', 'JSテスター / MiniExp MOD');
     const subtitle = document.createElement('div');
     subtitle.className = 'mini-tester-sub';
-    subtitle.textContent = 'JavaScript機能のセルフチェック、CPUベンチマーク、ブロック式アドベンチャーメーカーを収録。';
+    bindText(subtitle, 'subtitle', 'JavaScript機能のセルフチェック、CPUベンチマーク、ブロック式アドベンチャーメーカーを収録。');
     header.appendChild(title);
     header.appendChild(subtitle);
 
@@ -517,10 +710,14 @@
     const main = document.createElement('div');
     main.className = 'mini-tester-main';
 
-    function makeSection(id, label, element) {
+    function makeSection(id, labelKey, fallback, element, options) {
       const btn = document.createElement('button');
       btn.className = 'mini-tester-tab-btn';
-      btn.textContent = label;
+      if (labelKey) {
+        bindText(btn, labelKey, fallback, null, options);
+      } else {
+        btn.textContent = computeFallbackText(fallback);
+      }
       btn.addEventListener('click', () => {
         if (destroyed) return;
         currentSection = id;
@@ -554,12 +751,21 @@
     const benchElement = buildBenchmarkSection();
     const blockElement = buildBlocksSection();
 
-    makeSection('tests', '機能テスト', testsElement);
-    makeSection('benchmark', 'CPUベンチマーク', benchElement);
-    makeSection('blocks', 'ブロックアドベンチャー', blockElement);
+    makeSection('tests', 'tabs.tests', '機能テスト', testsElement);
+    makeSection('benchmark', 'tabs.benchmark', 'CPUベンチマーク', benchElement);
+    makeSection('blocks', 'tabs.blocks', 'ブロックアドベンチャー', blockElement);
     refreshTabs();
 
     root.appendChild(container);
+
+    refreshLocalization();
+    if (I18N && typeof I18N.onLocaleChanged === 'function') {
+      detachLocaleListener = I18N.onLocaleChanged(() => {
+        if (!destroyed) {
+          refreshLocalization();
+        }
+      });
+    }
 
     function defaultAlertImpl(message) {
       window.alert(message);
@@ -577,16 +783,16 @@
       wrapper.className = 'mini-tester-card';
 
       const heading = document.createElement('h3');
-      heading.textContent = 'JavaScriptセルフチェックラボ';
+      bindText(heading, 'tests.heading', 'JavaScriptセルフチェックラボ');
       wrapper.appendChild(heading);
 
       const description = document.createElement('p');
-      description.textContent = 'ブラウザが提供する代表的な機能をワンタップで検査できます。結果を共有すればデバッグにも役立ちます。';
+      bindText(description, 'tests.description', 'ブラウザが提供する代表的な機能をワンタップで検査できます。結果を共有すればデバッグにも役立ちます。');
       wrapper.appendChild(description);
 
       const runAllBtn = document.createElement('button');
       runAllBtn.className = 'mini-tester-button';
-      runAllBtn.textContent = 'すべて実行';
+      bindText(runAllBtn, 'tests.runAll', 'すべて実行');
       runAllBtn.addEventListener('click', async () => {
         if (destroyed || paused) return;
         runAllBtn.disabled = true;
@@ -604,19 +810,27 @@
         item.className = 'mini-tester-test-item';
 
         const title = document.createElement('strong');
-        title.textContent = def.name;
+        if (def.nameKey) {
+          bindText(title, def.nameKey, def.name);
+        } else {
+          title.textContent = def.name;
+        }
         item.appendChild(title);
 
         const desc = document.createElement('div');
         desc.className = 'mini-tester-test-desc';
-        desc.textContent = def.description;
+        if (def.descriptionKey) {
+          bindText(desc, def.descriptionKey, def.description);
+        } else {
+          desc.textContent = def.description;
+        }
         item.appendChild(desc);
 
         const actions = document.createElement('div');
         actions.className = 'mini-tester-test-actions';
         const btn = document.createElement('button');
         btn.className = 'mini-tester-button secondary';
-        btn.textContent = 'テスト実行';
+        bindText(btn, 'tests.runSingle', 'テスト実行');
         const resultEl = document.createElement('div');
         resultEl.className = 'mini-tester-test-result';
         actions.appendChild(btn);
@@ -626,7 +840,7 @@
         btn.addEventListener('click', async () => {
           if (destroyed || paused) return;
           btn.disabled = true;
-          resultEl.textContent = '実行中…';
+          setImmediateText(resultEl, 'tests.running', '実行中…');
           try {
             const res = await def.run();
             testResults[def.id] = { ok: true, message: res, at: Date.now() };
@@ -651,7 +865,7 @@
           const btn = entry.querySelector('button');
           const resultEl = entry.querySelector('.mini-tester-test-result');
           btn.disabled = true;
-          resultEl.textContent = '実行中…';
+          setImmediateText(resultEl, 'tests.running', '実行中…');
           try {
             const res = await def.run();
             testResults[def.id] = { ok: true, message: res, at: Date.now() };
@@ -675,11 +889,11 @@
       wrapper.className = 'mini-tester-card';
 
       const heading = document.createElement('h3');
-      heading.textContent = 'CPUベンチマーク - 1秒間のインクリメント回数';
+      bindText(heading, 'benchmark.heading', 'CPUベンチマーク - 1秒間のインクリメント回数');
       wrapper.appendChild(heading);
 
       const description = document.createElement('p');
-      description.textContent = '整数に1を加算し続け、1秒間で何回ループできるか計測します。ブラウザや端末の瞬間的な性能をチェックしましょう。';
+      bindText(description, 'benchmark.description', '整数に1を加算し続け、1秒間で何回ループできるか計測します。ブラウザや端末の瞬間的な性能をチェックしましょう。');
       wrapper.appendChild(description);
 
       const benchDisplay = document.createElement('div');
@@ -692,9 +906,9 @@
       currentValue.className = 'mini-tester-bench-value';
       currentValue.textContent = '—';
       const currentLabel = document.createElement('div');
-      currentLabel.textContent = '最新結果 (回/秒)';
+      bindText(currentLabel, 'benchmark.labels.current', '最新結果 (回/秒)');
       currentLabel.style.fontSize = '12px';
-      currentLabel.style.color = 'rgba(226,232,240,0.7)';
+      currentLabel.style.color = '#64748b';
       currentBox.appendChild(currentValue);
       currentBox.appendChild(currentLabel);
 
@@ -704,9 +918,9 @@
       bestValue.className = 'mini-tester-bench-value';
       bestValue.textContent = '—';
       const bestLabel = document.createElement('div');
-      bestLabel.textContent = '自己ベスト (回/秒)';
+      bindText(bestLabel, 'benchmark.labels.best', '自己ベスト (回/秒)');
       bestLabel.style.fontSize = '12px';
-      bestLabel.style.color = 'rgba(226,232,240,0.7)';
+      bestLabel.style.color = '#64748b';
       bestBox.appendChild(bestValue);
       bestBox.appendChild(bestLabel);
 
@@ -716,9 +930,9 @@
       streakValue.className = 'mini-tester-bench-value';
       streakValue.textContent = '0';
       const streakLabel = document.createElement('div');
-      streakLabel.textContent = '累計実行回数';
+      bindText(streakLabel, 'benchmark.labels.runs', '累計実行回数');
       streakLabel.style.fontSize = '12px';
-      streakLabel.style.color = 'rgba(226,232,240,0.7)';
+      streakLabel.style.color = '#64748b';
       streakBox.appendChild(streakValue);
       streakBox.appendChild(streakLabel);
 
@@ -734,13 +948,13 @@
 
       const runBtn = document.createElement('button');
       runBtn.className = 'mini-tester-button';
-      runBtn.textContent = '計測スタート (1秒)';
+      bindText(runBtn, 'benchmark.start', '計測スタート (1秒)');
       actions.appendChild(runBtn);
 
       const stopHint = document.createElement('div');
       stopHint.style.fontSize = '12px';
-      stopHint.style.color = 'rgba(226,232,240,0.7)';
-      stopHint.textContent = '計測中はUIが1秒間固まる場合があります。';
+      stopHint.style.color = '#64748b';
+      bindText(stopHint, 'benchmark.notice', '計測中はUIが1秒間固まる場合があります。');
       actions.appendChild(stopHint);
 
       wrapper.appendChild(actions);
@@ -753,7 +967,7 @@
         if (destroyed || paused || benchmarkRunning) return;
         benchmarkRunning = true;
         runBtn.disabled = true;
-        appendLog('計測を開始します…');
+        appendLog(t('benchmark.log.start', '計測を開始します…'));
         await waitFrames(2);
         const result = runBenchmark();
         benchmarkRunning = false;
@@ -764,10 +978,10 @@
         if (result.countPerSec > bestBenchmark) {
           bestBenchmark = result.countPerSec;
           bestValue.textContent = formatNumber(bestBenchmark);
-          appendLog(`新記録: ${formatNumber(bestBenchmark)} 回/秒`);
+          appendLog(t('benchmark.log.record', '新記録: {value} 回/秒', { value: formatNumber(bestBenchmark) }));
           safeAwardXp(Math.min(50, Math.floor(result.countPerSec / 500000)), 'tester:benchmark-record');
         } else {
-          appendLog(`結果: ${formatNumber(result.countPerSec)} 回/秒`);
+          appendLog(t('benchmark.log.result', '結果: {value} 回/秒', { value: formatNumber(result.countPerSec) }));
           safeAwardXp(Math.min(15, Math.floor(result.countPerSec / 1000000) + 1), 'tester:benchmark');
         }
       });
@@ -813,12 +1027,12 @@
       blockControls.style.gap = '8px';
       const addBtn = document.createElement('button');
       addBtn.className = 'mini-tester-button';
-      addBtn.textContent = 'ブロックを追加';
+      bindText(addBtn, 'blocks.controls.add', 'ブロックを追加');
       blockControls.appendChild(addBtn);
 
       const clearBtn = document.createElement('button');
       clearBtn.className = 'mini-tester-button secondary';
-      clearBtn.textContent = '全削除';
+      bindText(clearBtn, 'blocks.controls.clear', '全削除');
       blockControls.appendChild(clearBtn);
 
       left.appendChild(blockControls);
@@ -830,13 +1044,13 @@
       const alertCard = document.createElement('div');
       alertCard.className = 'mini-tester-card mini-tester-alert-editor';
       const alertTitle = document.createElement('h3');
-      alertTitle.textContent = 'カスタムAlert関数';
+      bindText(alertTitle, 'blocks.alert.title', 'カスタムAlert関数');
       alertCard.appendChild(alertTitle);
       const alertDesc = document.createElement('p');
-      alertDesc.textContent = 'message, context を受け取る関数本体を記述します。context.flags や context.log を使って高度な演出が可能です。';
+      bindText(alertDesc, 'blocks.alert.description', 'message, context を受け取る関数本体を記述します。context.flags や context.log を使って高度な演出が可能です。');
       alertCard.appendChild(alertDesc);
       const alertTextarea = document.createElement('textarea');
-      alertTextarea.value = `// message: string\n// context: { flags, log, awardXp }\nconst box = document.createElement('div');\nbox.textContent = message;\nbox.style.padding = '16px';\nbox.style.background = 'rgba(96,165,250,0.15)';\nbox.style.border = '1px solid rgba(96,165,250,0.4)';\nbox.style.borderRadius = '12px';\nbox.style.margin = '6px 0';\ncontext.log(box);\n`;
+      alertTextarea.value = t('blocks.alert.template', () => `// message: string\n// context: { flags, log, awardXp }\nconst box = document.createElement('div');\nbox.textContent = message;\nbox.style.padding = '16px';\nbox.style.background = 'rgba(96,165,250,0.15)';\nbox.style.border = '1px solid rgba(96,165,250,0.4)';\nbox.style.borderRadius = '12px';\nbox.style.margin = '6px 0';\ncontext.log(box);\n`);
       alertCard.appendChild(alertTextarea);
       const alertActions = document.createElement('div');
       alertActions.style.display = 'flex';
@@ -844,16 +1058,17 @@
       alertActions.style.marginTop = '8px';
       const alertApply = document.createElement('button');
       alertApply.className = 'mini-tester-button';
-      alertApply.textContent = '更新';
+      bindText(alertApply, 'blocks.alert.apply', '更新');
       const alertTest = document.createElement('button');
       alertTest.className = 'mini-tester-button secondary';
-      alertTest.textContent = 'テスト実行';
+      bindText(alertTest, 'blocks.alert.test', 'テスト実行');
       alertActions.appendChild(alertApply);
       alertActions.appendChild(alertTest);
       alertCard.appendChild(alertActions);
       const alertStatus = document.createElement('div');
       alertStatus.className = 'mini-tester-alert-status';
-      alertStatus.textContent = '既定: ログに表示します。alert() に変えることも可能です。';
+      alertStatusEl = alertStatus;
+      setAlertStatus('blocks.alert.statusDefault', '既定: ログに表示します。alert() に変えることも可能です。');
       alertCard.appendChild(alertStatus);
       right.appendChild(alertCard);
 
@@ -864,17 +1079,17 @@
       storyHeader.style.justifyContent = 'space-between';
       storyHeader.style.alignItems = 'center';
       const storyTitle = document.createElement('h3');
-      storyTitle.textContent = 'ブロックストーリーランナー';
+      bindText(storyTitle, 'blocks.story.title', 'ブロックストーリーランナー');
       storyHeader.appendChild(storyTitle);
       const storyButtons = document.createElement('div');
       storyButtons.style.display = 'flex';
       storyButtons.style.gap = '8px';
       const runStoryBtn = document.createElement('button');
       runStoryBtn.className = 'mini-tester-button';
-      runStoryBtn.textContent = 'ストーリー再生';
+      bindText(runStoryBtn, 'blocks.story.play', 'ストーリー再生');
       const stopStoryBtn = document.createElement('button');
       stopStoryBtn.className = 'mini-tester-button secondary';
-      stopStoryBtn.textContent = '停止';
+      bindText(stopStoryBtn, 'blocks.story.stop', '停止');
       storyButtons.appendChild(runStoryBtn);
       storyButtons.appendChild(stopStoryBtn);
       storyHeader.appendChild(storyButtons);
@@ -887,10 +1102,12 @@
       const variableCard = document.createElement('div');
       variableCard.className = 'mini-tester-variables';
       const varTitle = document.createElement('div');
-      varTitle.textContent = '変数ビュー (flags)';
+      bindText(varTitle, 'blocks.variables.title', '変数ビュー (flags)');
       variableCard.appendChild(varTitle);
       const varBody = document.createElement('div');
-      varBody.textContent = '(空)';
+      varBodyEl = varBody;
+      variablesEmpty = true;
+      setImmediateText(varBody, 'blocks.variables.empty', '(空)');
       variableCard.appendChild(varBody);
       storyCard.appendChild(variableCard);
 
@@ -914,29 +1131,27 @@
           customAlertImpl = (message, context) => {
             return fn.call(context, message, context);
           };
-          customAlertStatus = '✅ カスタムalertを適用しました。';
-          alertStatus.textContent = customAlertStatus;
+          setAlertStatus('blocks.alert.statusApplied', '✅ カスタムalertを適用しました。');
         } catch (err) {
-          customAlertStatus = `❌ エラー: ${err.message}`;
-          alertStatus.textContent = customAlertStatus;
+          setAlertStatus('blocks.alert.statusError', () => `❌ エラー: ${err.message}`, { message: err.message });
         }
       });
 
       alertTest.addEventListener('click', () => {
         if (destroyed) return;
         try {
-          customAlertImpl('カスタムalertのテストです。', {
+          customAlertImpl(t('blocks.alert.testMessage', 'カスタムalertのテストです。'), {
             flags: {},
             log: el => appendStoryLog(el, 'alert-test'),
             awardXp: (n, reason) => safeAwardXp(n, reason || 'tester:alert-test')
           });
-          alertStatus.textContent = '✅ テストメッセージを送信しました。';
+          setAlertStatus('blocks.alert.statusTestSent', '✅ テストメッセージを送信しました。');
           if (!lastAlertTestAwarded) {
             safeAwardXp(3, 'tester:alert-first');
             lastAlertTestAwarded = true;
           }
         } catch (err) {
-          alertStatus.textContent = `❌ 実行エラー: ${err.message}`;
+          setAlertStatus('blocks.alert.statusTestError', () => `❌ 実行エラー: ${err.message}`, { message: err.message });
         }
       });
 
@@ -947,7 +1162,7 @@
         storyRunToken++;
         const token = storyRunToken;
         storyLog.innerHTML = '';
-        appendStoryLog(`▶ ストーリー開始 (${storyBlocks.length} ブロック)`);
+        appendStoryLog(t('blocks.story.logStart', '▶ ストーリー開始 ({count} ブロック)', { count: storyBlocks.length }));
         const context = {
           flags: {},
           lastChoice: null,
@@ -960,17 +1175,17 @@
         try {
           await runStory(context, token);
         } catch (err) {
-          appendStoryLog(`⚠ 実行中断: ${err.message}`);
+          appendStoryLog(t('blocks.story.logAborted', () => `⚠ 実行中断: ${err.message}`, { message: err.message }));
         }
         runStoryBtn.disabled = false;
         stopStoryBtn.disabled = true;
-        appendStoryLog('■ ストーリー終了');
+        appendStoryLog(t('blocks.story.logEnd', '■ ストーリー終了'));
       });
 
       stopStoryBtn.addEventListener('click', () => {
         storyRunToken++;
         stopStoryBtn.disabled = true;
-        appendStoryLog('■ ユーザーが停止しました');
+        appendStoryLog(t('blocks.story.logUserStop', '■ ユーザーが停止しました'));
       });
       stopStoryBtn.disabled = true;
       function addBlock(type = 'text') {
@@ -983,11 +1198,11 @@
           case 'choice':
             return {
               type: 'choice',
-              question: 'どうする？',
+              question: t('blocks.defaults.choiceQuestion', 'どうする？'),
               storeAs: 'choice',
               options: [
-                { label: '進む', target: '', value: 'go' },
-                { label: 'やめる', target: '', value: 'stop' }
+                { label: t('blocks.defaults.choiceGo', '進む'), target: '', value: 'go' },
+                { label: t('blocks.defaults.choiceStop', 'やめる'), target: '', value: 'stop' }
               ]
             };
           case 'set':
@@ -1000,17 +1215,17 @@
             return {
               type: 'control',
               mode: 'confirm',
-              message: '進みますか？',
+              message: t('blocks.defaults.controlMessage', '進みますか？'),
               storeAs: 'answer',
-              yesLabel: 'はい',
+              yesLabel: t('blocks.defaults.yes', 'はい'),
               yesValue: 'yes',
               yesTarget: '',
-              noLabel: 'いいえ',
+              noLabel: t('blocks.defaults.no', 'いいえ'),
               noValue: 'no',
               noTarget: ''
             };
           default:
-            return { type: 'text', text: 'メッセージ', delivery: 'log', next: '' };
+            return { type: 'text', text: t('blocks.defaults.message', 'メッセージ'), delivery: 'log', next: '' };
         }
       }
 
@@ -1028,11 +1243,19 @@
           header.appendChild(label);
 
           const typeSelect = document.createElement('select');
-          ['text', 'choice', 'set', 'jump', 'award', 'control'].forEach(t => {
+          const typeLabels = {
+            text: t('blocks.types.text', 'text'),
+            choice: t('blocks.types.choice', 'choice'),
+            set: t('blocks.types.set', 'set'),
+            jump: t('blocks.types.jump', 'jump'),
+            award: t('blocks.types.award', 'award'),
+            control: t('blocks.types.control', 'control')
+          };
+          ['text', 'choice', 'set', 'jump', 'award', 'control'].forEach(tType => {
             const option = document.createElement('option');
-            option.value = t;
-            option.textContent = t;
-            if (block.type === t) option.selected = true;
+            option.value = tType;
+            option.textContent = typeLabels[tType] || tType;
+            if (block.type === tType) option.selected = true;
             typeSelect.appendChild(option);
           });
           header.appendChild(typeSelect);
@@ -1124,14 +1347,18 @@
       function renderTextBlock(block, body, index) {
         const textarea = document.createElement('textarea');
         textarea.value = block.text || '';
-        textarea.placeholder = '表示するメッセージ';
+        bindPlaceholder(textarea, 'blocks.text.placeholder', '表示するメッセージ');
         textarea.addEventListener('input', () => {
           block.text = textarea.value;
         });
         body.appendChild(textarea);
 
         const delivery = document.createElement('select');
-        [['log', 'ログに出力'], ['alert', 'カスタムalert'], ['both', '両方']].forEach(([value, label]) => {
+        [
+          ['log', t('blocks.text.delivery.log', 'ログに出力')],
+          ['alert', t('blocks.text.delivery.alert', 'カスタムalert')],
+          ['both', t('blocks.text.delivery.both', '両方')]
+        ].forEach(([value, label]) => {
           const option = document.createElement('option');
           option.value = value;
           option.textContent = label;
@@ -1148,16 +1375,16 @@
         nextRow.style.gap = '6px';
         nextRow.style.marginTop = '6px';
         const nextLabel = document.createElement('div');
-        nextLabel.textContent = '次に進むブロック (# または空)';
+        bindText(nextLabel, 'blocks.text.nextLabel', '次に進むブロック (# または空)');
         nextLabel.style.fontSize = '11px';
-        nextLabel.style.color = 'rgba(226,232,240,0.7)';
+        nextLabel.style.color = '#64748b';
         nextRow.appendChild(nextLabel);
         body.appendChild(nextRow);
 
         const nextInput = document.createElement('input');
         nextInput.type = 'number';
         nextInput.min = '0';
-        nextInput.placeholder = '空なら自動で次';
+        bindPlaceholder(nextInput, 'blocks.text.nextPlaceholder', '空なら自動で次');
         nextInput.value = block.next ?? '';
         nextInput.addEventListener('input', () => {
           block.next = nextInput.value;
@@ -1168,13 +1395,13 @@
       function renderChoiceBlock(block, body, index) {
         const question = document.createElement('textarea');
         question.value = block.question || '';
-        question.placeholder = '選択肢の前に表示する文章';
+        bindPlaceholder(question, 'blocks.choice.questionPlaceholder', '選択肢の前に表示する文章');
         question.addEventListener('input', () => { block.question = question.value; });
         body.appendChild(question);
 
         const storeAs = document.createElement('input');
         storeAs.type = 'text';
-        storeAs.placeholder = '選択した値を保存する変数名 (例: choice)';
+        bindPlaceholder(storeAs, 'blocks.choice.storePlaceholder', '選択した値を保存する変数名 (例: choice)');
         storeAs.value = block.storeAs || 'choice';
         storeAs.addEventListener('input', () => { block.storeAs = storeAs.value; });
         body.appendChild(storeAs);
@@ -1198,21 +1425,21 @@
             const labelInput = document.createElement('input');
             labelInput.type = 'text';
             labelInput.value = opt.label || '';
-            labelInput.placeholder = 'ボタン表示';
+            bindPlaceholder(labelInput, 'blocks.choice.labelPlaceholder', 'ボタン表示');
             labelInput.addEventListener('input', () => { opt.label = labelInput.value; });
             row.appendChild(labelInput);
 
             const valueInput = document.createElement('input');
             valueInput.type = 'text';
             valueInput.value = opt.value ?? '';
-            valueInput.placeholder = '保存する値';
+            bindPlaceholder(valueInput, 'blocks.choice.valuePlaceholder', '保存する値');
             valueInput.addEventListener('input', () => { opt.value = valueInput.value; });
             row.appendChild(valueInput);
 
             const targetInput = document.createElement('input');
             targetInput.type = 'number';
             targetInput.min = '0';
-            targetInput.placeholder = '次の#';
+            bindPlaceholder(targetInput, 'blocks.choice.targetPlaceholder', '次の#');
             targetInput.value = opt.target ?? '';
             targetInput.addEventListener('input', () => { opt.target = targetInput.value; });
             row.appendChild(targetInput);
@@ -1233,9 +1460,9 @@
 
         const addOptionBtn = document.createElement('button');
         addOptionBtn.className = 'mini-tester-button secondary';
-        addOptionBtn.textContent = '選択肢を追加';
+        bindText(addOptionBtn, 'blocks.choice.addOption', '選択肢を追加');
         addOptionBtn.addEventListener('click', () => {
-          block.options.push({ label: '新しい選択肢', value: '', target: '' });
+          block.options.push({ label: t('blocks.choice.newOption', '新しい選択肢'), value: '', target: '' });
           renderOptions();
         });
         body.appendChild(addOptionBtn);
@@ -1245,21 +1472,21 @@
       function renderSetBlock(block, body, index) {
         const nameInput = document.createElement('input');
         nameInput.type = 'text';
-        nameInput.placeholder = '変数名';
+        bindPlaceholder(nameInput, 'blocks.set.namePlaceholder', '変数名');
         nameInput.value = block.name || 'flag';
         nameInput.addEventListener('input', () => { block.name = nameInput.value; });
         body.appendChild(nameInput);
 
         const valueInput = document.createElement('input');
         valueInput.type = 'text';
-        valueInput.placeholder = '値 (文字列)';
+        bindPlaceholder(valueInput, 'blocks.set.valuePlaceholder', '値 (文字列)');
         valueInput.value = block.value ?? '';
         valueInput.addEventListener('input', () => { block.value = valueInput.value; });
         body.appendChild(valueInput);
 
         const nextInput = document.createElement('input');
         nextInput.type = 'number';
-        nextInput.placeholder = '次のブロック (空=順番通り)';
+        bindPlaceholder(nextInput, 'blocks.set.nextPlaceholder', '次のブロック (空=順番通り)');
         nextInput.value = block.next ?? '';
         nextInput.addEventListener('input', () => { block.next = nextInput.value; });
         body.appendChild(nextInput);
@@ -1268,28 +1495,28 @@
       function renderJumpBlock(block, body, index) {
         const nameInput = document.createElement('input');
         nameInput.type = 'text';
-        nameInput.placeholder = '判定する変数名';
+        bindPlaceholder(nameInput, 'blocks.jump.namePlaceholder', '判定する変数名');
         nameInput.value = block.name || '';
         nameInput.addEventListener('input', () => { block.name = nameInput.value; });
         body.appendChild(nameInput);
 
         const equalsInput = document.createElement('input');
         equalsInput.type = 'text';
-        equalsInput.placeholder = '比較値 (文字列)';
+        bindPlaceholder(equalsInput, 'blocks.jump.equalsPlaceholder', '比較値 (文字列)');
         equalsInput.value = block.equals ?? '';
         equalsInput.addEventListener('input', () => { block.equals = equalsInput.value; });
         body.appendChild(equalsInput);
 
         const targetInput = document.createElement('input');
         targetInput.type = 'number';
-        targetInput.placeholder = '一致した時のブロック#';
+        bindPlaceholder(targetInput, 'blocks.jump.targetPlaceholder', '一致した時のブロック#');
         targetInput.value = block.target ?? '';
         targetInput.addEventListener('input', () => { block.target = targetInput.value; });
         body.appendChild(targetInput);
 
         const elseInput = document.createElement('input');
         elseInput.type = 'number';
-        elseInput.placeholder = '不一致の時のブロック# (空=次)';
+        bindPlaceholder(elseInput, 'blocks.jump.elsePlaceholder', '不一致の時のブロック# (空=次)');
         elseInput.value = block.elseTarget ?? '';
         elseInput.addEventListener('input', () => { block.elseTarget = elseInput.value; });
         body.appendChild(elseInput);
@@ -1298,14 +1525,14 @@
       function renderAwardBlock(block, body, index) {
         const amountInput = document.createElement('input');
         amountInput.type = 'number';
-        amountInput.placeholder = '付与するEXP (負数も可)';
+        bindPlaceholder(amountInput, 'blocks.award.amountPlaceholder', '付与するEXP (負数も可)');
         amountInput.value = block.amount ?? 0;
         amountInput.addEventListener('input', () => { block.amount = Number(amountInput.value || 0); });
         body.appendChild(amountInput);
 
         const nextInput = document.createElement('input');
         nextInput.type = 'number';
-        nextInput.placeholder = '次のブロック (空=順番通り)';
+        bindPlaceholder(nextInput, 'blocks.award.nextPlaceholder', '次のブロック (空=順番通り)');
         nextInput.value = block.next ?? '';
         nextInput.addEventListener('input', () => { block.next = nextInput.value; });
         body.appendChild(nextInput);
@@ -1318,14 +1545,14 @@
         modeRow.style.gap = '6px';
         modeRow.style.alignItems = 'center';
         const modeLabel = document.createElement('span');
-        modeLabel.textContent = '種類';
+        bindText(modeLabel, 'blocks.control.modeLabel', '種類');
         modeLabel.style.fontSize = '12px';
-        modeLabel.style.color = 'rgba(226,232,240,0.8)';
+        modeLabel.style.color = '#64748b';
         modeRow.appendChild(modeLabel);
         const modeSelect = document.createElement('select');
         [
-          ['confirm', '確認 (はい/いいえ)'],
-          ['prompt', '入力ボックス']
+          ['confirm', t('blocks.control.modeConfirm', '確認 (はい/いいえ)')],
+          ['prompt', t('blocks.control.modePrompt', '入力ボックス')]
         ].forEach(([value, label]) => {
           const option = document.createElement('option');
           option.value = value;
@@ -1344,63 +1571,63 @@
 
         const renderConfirmFields = () => {
           if (!('storeAs' in block)) block.storeAs = 'answer';
-          if (!('message' in block)) block.message = '進みますか？';
-          if (!('yesLabel' in block)) block.yesLabel = 'はい';
-          if (!('noLabel' in block)) block.noLabel = 'いいえ';
+          if (!('message' in block)) block.message = t('blocks.defaults.controlMessage', '進みますか？');
+          if (!('yesLabel' in block)) block.yesLabel = t('blocks.defaults.yes', 'はい');
+          if (!('noLabel' in block)) block.noLabel = t('blocks.defaults.no', 'いいえ');
           if (!('yesValue' in block)) block.yesValue = 'yes';
           if (!('noValue' in block)) block.noValue = 'no';
 
           const textarea = document.createElement('textarea');
           textarea.value = block.message || '';
-          textarea.placeholder = '表示するメッセージ';
+          bindPlaceholder(textarea, 'blocks.control.messagePlaceholder', '表示するメッセージ');
           textarea.addEventListener('input', () => { block.message = textarea.value; });
           dynamic.appendChild(textarea);
 
           const storeInput = document.createElement('input');
           storeInput.type = 'text';
-          storeInput.placeholder = '結果を保存する変数名 (空=保存しない)';
+          bindPlaceholder(storeInput, 'blocks.control.storePlaceholder', '結果を保存する変数名 (空=保存しない)');
           storeInput.value = block.storeAs || '';
           storeInput.addEventListener('input', () => { block.storeAs = storeInput.value; });
           dynamic.appendChild(storeInput);
 
           const yesLabel = document.createElement('input');
           yesLabel.type = 'text';
-          yesLabel.placeholder = 'はいボタンの表示';
+          bindPlaceholder(yesLabel, 'blocks.control.yesLabel', 'はいボタンの表示');
           yesLabel.value = block.yesLabel || '';
           yesLabel.addEventListener('input', () => { block.yesLabel = yesLabel.value; });
           dynamic.appendChild(yesLabel);
 
           const yesValue = document.createElement('input');
           yesValue.type = 'text';
-          yesValue.placeholder = 'はいを押した時に保存する値';
+          bindPlaceholder(yesValue, 'blocks.control.yesValue', 'はいを押した時に保存する値');
           yesValue.value = block.yesValue ?? '';
           yesValue.addEventListener('input', () => { block.yesValue = yesValue.value; });
           dynamic.appendChild(yesValue);
 
           const yesTarget = document.createElement('input');
           yesTarget.type = 'number';
-          yesTarget.placeholder = 'はいの次ブロック# (空=次)';
+          bindPlaceholder(yesTarget, 'blocks.control.yesTarget', 'はいの次ブロック# (空=次)');
           yesTarget.value = block.yesTarget ?? '';
           yesTarget.addEventListener('input', () => { block.yesTarget = yesTarget.value; });
           dynamic.appendChild(yesTarget);
 
           const noLabel = document.createElement('input');
           noLabel.type = 'text';
-          noLabel.placeholder = 'いいえボタンの表示';
+          bindPlaceholder(noLabel, 'blocks.control.noLabel', 'いいえボタンの表示');
           noLabel.value = block.noLabel || '';
           noLabel.addEventListener('input', () => { block.noLabel = noLabel.value; });
           dynamic.appendChild(noLabel);
 
           const noValue = document.createElement('input');
           noValue.type = 'text';
-          noValue.placeholder = 'いいえを押した時に保存する値';
+          bindPlaceholder(noValue, 'blocks.control.noValue', 'いいえを押した時に保存する値');
           noValue.value = block.noValue ?? '';
           noValue.addEventListener('input', () => { block.noValue = noValue.value; });
           dynamic.appendChild(noValue);
 
           const noTarget = document.createElement('input');
           noTarget.type = 'number';
-          noTarget.placeholder = 'いいえの次ブロック# (空=次)';
+          bindPlaceholder(noTarget, 'blocks.control.noTarget', 'いいえの次ブロック# (空=次)');
           noTarget.value = block.noTarget ?? '';
           noTarget.addEventListener('input', () => { block.noTarget = noTarget.value; });
           dynamic.appendChild(noTarget);
@@ -1408,30 +1635,33 @@
 
         const renderPromptFields = () => {
           if (!('storeAs' in block)) block.storeAs = 'input';
-          if (!('message' in block)) block.message = '名前を入力してください';
+          if (!('message' in block)) block.message = t('blocks.defaults.prompt', '名前を入力してください');
           if (!('defaultValue' in block)) block.defaultValue = '';
           if (!('defaultFrom' in block)) block.defaultFrom = '';
           if (!('allowEmpty' in block)) block.allowEmpty = false;
-          if (!('okLabel' in block)) block.okLabel = '決定';
-          if (!('cancelLabel' in block)) block.cancelLabel = 'キャンセル';
+          if (!('okLabel' in block)) block.okLabel = t('blocks.control.okLabel', '決定');
+          if (!('cancelLabel' in block)) block.cancelLabel = t('blocks.control.cancelLabel', 'キャンセル');
           if (!('cancelValue' in block)) block.cancelValue = 'cancel';
           if (!('inputType' in block)) block.inputType = 'text';
 
           const textarea = document.createElement('textarea');
           textarea.value = block.message || '';
-          textarea.placeholder = '入力ボックスの前に表示する文章';
+          bindPlaceholder(textarea, 'blocks.prompt.messagePlaceholder', '入力ボックスの前に表示する文章');
           textarea.addEventListener('input', () => { block.message = textarea.value; });
           dynamic.appendChild(textarea);
 
           const storeInput = document.createElement('input');
           storeInput.type = 'text';
-          storeInput.placeholder = '入力値を保存する変数名';
+          bindPlaceholder(storeInput, 'blocks.prompt.storePlaceholder', '入力値を保存する変数名');
           storeInput.value = block.storeAs || '';
           storeInput.addEventListener('input', () => { block.storeAs = storeInput.value; });
           dynamic.appendChild(storeInput);
 
           const typeSelect = document.createElement('select');
-          [['text', 'テキスト'], ['number', '数値']].forEach(([value, label]) => {
+          [
+            ['text', t('blocks.prompt.inputTypeText', 'テキスト')],
+            ['number', t('blocks.prompt.inputTypeNumber', '数値')]
+          ].forEach(([value, label]) => {
             const option = document.createElement('option');
             option.value = value;
             option.textContent = label;
@@ -1443,14 +1673,14 @@
 
           const defaultInput = document.createElement('input');
           defaultInput.type = 'text';
-          defaultInput.placeholder = '既定値 (固定文字列)';
+          bindPlaceholder(defaultInput, 'blocks.prompt.defaultValue', '既定値 (固定文字列)');
           defaultInput.value = block.defaultValue ?? '';
           defaultInput.addEventListener('input', () => { block.defaultValue = defaultInput.value; });
           dynamic.appendChild(defaultInput);
 
           const fromInput = document.createElement('input');
           fromInput.type = 'text';
-          fromInput.placeholder = '既定値を読み込む変数名 (空=固定)';
+          bindPlaceholder(fromInput, 'blocks.prompt.defaultFrom', '既定値を読み込む変数名 (空=固定)');
           fromInput.value = block.defaultFrom || '';
           fromInput.addEventListener('input', () => { block.defaultFrom = fromInput.value; });
           dynamic.appendChild(fromInput);
@@ -1465,41 +1695,41 @@
           allowEmptyCheckbox.addEventListener('change', () => { block.allowEmpty = allowEmptyCheckbox.checked; });
           allowEmptyLabel.appendChild(allowEmptyCheckbox);
           const allowEmptyText = document.createElement('span');
-          allowEmptyText.textContent = '空入力を許可';
+          bindText(allowEmptyText, 'blocks.prompt.allowEmpty', '空入力を許可');
           allowEmptyLabel.appendChild(allowEmptyText);
           dynamic.appendChild(allowEmptyLabel);
 
           const okLabelInput = document.createElement('input');
           okLabelInput.type = 'text';
-          okLabelInput.placeholder = '決定ボタンの表示';
+          bindPlaceholder(okLabelInput, 'blocks.prompt.okLabel', '決定ボタンの表示');
           okLabelInput.value = block.okLabel || '';
           okLabelInput.addEventListener('input', () => { block.okLabel = okLabelInput.value; });
           dynamic.appendChild(okLabelInput);
 
           const okTarget = document.createElement('input');
           okTarget.type = 'number';
-          okTarget.placeholder = '決定後のブロック# (空=次)';
+          bindPlaceholder(okTarget, 'blocks.prompt.okTarget', '決定後のブロック# (空=次)');
           okTarget.value = block.okTarget ?? '';
           okTarget.addEventListener('input', () => { block.okTarget = okTarget.value; });
           dynamic.appendChild(okTarget);
 
           const cancelLabelInput = document.createElement('input');
           cancelLabelInput.type = 'text';
-          cancelLabelInput.placeholder = 'キャンセルボタンの表示';
+          bindPlaceholder(cancelLabelInput, 'blocks.prompt.cancelLabel', 'キャンセルボタンの表示');
           cancelLabelInput.value = block.cancelLabel || '';
           cancelLabelInput.addEventListener('input', () => { block.cancelLabel = cancelLabelInput.value; });
           dynamic.appendChild(cancelLabelInput);
 
           const cancelValueInput = document.createElement('input');
           cancelValueInput.type = 'text';
-          cancelValueInput.placeholder = 'キャンセル時に保存する値';
+          bindPlaceholder(cancelValueInput, 'blocks.prompt.cancelValue', 'キャンセル時に保存する値');
           cancelValueInput.value = block.cancelValue ?? '';
           cancelValueInput.addEventListener('input', () => { block.cancelValue = cancelValueInput.value; });
           dynamic.appendChild(cancelValueInput);
 
           const cancelTarget = document.createElement('input');
           cancelTarget.type = 'number';
-          cancelTarget.placeholder = 'キャンセル後のブロック# (空=次)';
+          bindPlaceholder(cancelTarget, 'blocks.prompt.cancelTarget', 'キャンセル後のブロック# (空=次)');
           cancelTarget.value = block.cancelTarget ?? '';
           cancelTarget.addEventListener('input', () => { block.cancelTarget = cancelTarget.value; });
           dynamic.appendChild(cancelTarget);
@@ -1537,9 +1767,11 @@
       function updateVariables(flags) {
         const keys = Object.keys(flags || {});
         if (!keys.length) {
-          varBody.textContent = '(空)';
+          variablesEmpty = true;
+          setImmediateText(varBody, 'blocks.variables.empty', '(空)');
           return;
         }
+        variablesEmpty = false;
         varBody.textContent = '';
         const list = document.createElement('div');
         list.style.display = 'flex';
@@ -1555,14 +1787,14 @@
 
       async function runStory(context, token) {
         if (!storyBlocks.length) {
-          appendStoryLog('⚠ ブロックが1つもありません。');
+          appendStoryLog(t('blocks.story.logEmpty', '⚠ ブロックが1つもありません。'));
           return;
         }
         let stepCount = 0;
         let index = 0;
         const maxSteps = 999;
         while (!destroyed && storyRunToken === token && index >= 0 && index < storyBlocks.length) {
-          if (stepCount++ > maxSteps) throw new Error('ステップ回数が多すぎます。ループしていませんか？');
+          if (stepCount++ > maxSteps) throw new Error(t('blocks.errors.tooManySteps', 'ステップ回数が多すぎます。ループしていませんか？'));
           const block = storyBlocks[index];
           renderBlocks(index);
           switch (block.type) {
@@ -1585,7 +1817,14 @@
               const value = context.flags[name];
               const expected = block.equals ?? '';
               const matches = String(value) === String(expected);
-              appendStoryLog(`[JUMP] ${name}=${JSON.stringify(value)} => ${matches ? '一致' : '不一致'}`);
+              const status = matches
+                ? t('blocks.logs.jumpMatch', '一致')
+                : t('blocks.logs.jumpMismatch', '不一致');
+              appendStoryLog(t('blocks.logs.jump', '[JUMP] {name}={value} => {status}', {
+                name,
+                value: JSON.stringify(value),
+                status
+              }));
               index = matches ? resolveIndex(block.target, index + 1) : resolveIndex(block.elseTarget, index + 1);
               break;
             case 'award':
@@ -1624,7 +1863,7 @@
               context
             });
           } catch (err) {
-            appendStoryLog(`❌ alert実行エラー: ${err.message}`);
+            appendStoryLog(t('blocks.logs.alertError', () => `❌ alert実行エラー: ${err.message}`, { message: err.message }));
           }
         }
       }
@@ -1653,7 +1892,9 @@
             }
           };
 
-          const labelText = mode === 'prompt' ? '入力' : '確認';
+          const labelText = mode === 'prompt'
+            ? t('blocks.control.labelPrompt', '入力')
+            : t('blocks.control.labelConfirm', '確認');
           const messageLine = document.createElement('div');
           messageLine.className = 'mini-tester-control-message';
           const labelSpan = document.createElement('span');
@@ -1697,9 +1938,9 @@
             const actions = document.createElement('div');
             actions.className = 'mini-tester-control-actions';
             const okBtn = document.createElement('button');
-            okBtn.textContent = block.okLabel || '決定';
+            okBtn.textContent = block.okLabel || t('blocks.control.okLabel', '決定');
             const cancelBtn = document.createElement('button');
-            cancelBtn.textContent = block.cancelLabel || 'キャンセル';
+            cancelBtn.textContent = block.cancelLabel || t('blocks.control.cancelLabel', 'キャンセル');
             actions.appendChild(okBtn);
             actions.appendChild(cancelBtn);
             container.appendChild(actions);
@@ -1708,7 +1949,7 @@
               if (storyRunToken !== token || settled) return;
               const raw = input.value;
               if (!block.allowEmpty && raw === '') {
-                error.textContent = '値を入力してください。';
+                setImmediateText(error, 'blocks.control.errorRequired', '値を入力してください。');
                 input.focus();
                 return;
               }
@@ -1716,7 +1957,7 @@
               if ((block.inputType || 'text') === 'number' && raw !== '') {
                 storedValue = Number(raw);
                 if (!Number.isFinite(storedValue)) {
-                  error.textContent = '数値を入力してください。';
+                  setImmediateText(error, 'blocks.control.errorNumber', '数値を入力してください。');
                   input.focus();
                   return;
                 }
@@ -1727,8 +1968,13 @@
                 updateVariables(context.flags);
               }
               const summaryText = block.storeAs
-                ? `▶ ${block.storeAs} = ${JSON.stringify(storedValue)}`
-                : `▶ 値 = ${JSON.stringify(storedValue)}`;
+                ? t('blocks.control.summaryStored', '▶ {variable} = {value}', {
+                  variable: block.storeAs,
+                  value: JSON.stringify(storedValue)
+                })
+                : t('blocks.control.summaryValueOnly', '▶ 値 = {value}', {
+                  value: JSON.stringify(storedValue)
+                });
               makeSummary(labelText, block.message || '', summaryText);
               finish(resolveIndex(block.okTarget, currentIndex + 1));
             });
@@ -1741,8 +1987,11 @@
                 updateVariables(context.flags);
               }
               const summaryText = block.storeAs
-                ? `▶ キャンセル (${block.storeAs} = ${JSON.stringify(cancelValue)})`
-                : '▶ 入力をキャンセル';
+                ? t('blocks.control.summaryCancelStored', '▶ キャンセル ({variable} = {value})', {
+                  variable: block.storeAs,
+                  value: JSON.stringify(cancelValue)
+                })
+                : t('blocks.control.summaryCancel', '▶ 入力をキャンセル');
               makeSummary(labelText, block.message || '', summaryText);
               finish(resolveIndex(block.cancelTarget, currentIndex + 1));
             });
@@ -1750,9 +1999,9 @@
             const actions = document.createElement('div');
             actions.className = 'mini-tester-control-actions';
             const yesBtn = document.createElement('button');
-            yesBtn.textContent = block.yesLabel || 'はい';
+            yesBtn.textContent = block.yesLabel || t('blocks.defaults.yes', 'はい');
             const noBtn = document.createElement('button');
-            noBtn.textContent = block.noLabel || 'いいえ';
+            noBtn.textContent = block.noLabel || t('blocks.defaults.no', 'いいえ');
             actions.appendChild(yesBtn);
             actions.appendChild(noBtn);
             container.appendChild(actions);
@@ -1764,20 +2013,24 @@
                 updateVariables(context.flags);
               }
               const summary = block.storeAs
-                ? `▶ ${label} を選択 → ${block.storeAs} = ${JSON.stringify(storedValue)}`
-                : `▶ ${label} を選択`;
+                ? t('blocks.control.summaryChoiceStored', '▶ {label} を選択 → {variable} = {value}', {
+                  label,
+                  variable: block.storeAs,
+                  value: JSON.stringify(storedValue)
+                })
+                : t('blocks.control.summaryChoice', '▶ {label} を選択', { label });
               makeSummary(labelText, block.message || '', summary);
               finish(resolveIndex(target, currentIndex + 1));
             };
 
             yesBtn.addEventListener('click', () => {
               const value = block.yesValue ?? block.yesLabel ?? 'yes';
-              choose(block.yesLabel || 'はい', value, block.yesTarget);
+              choose(block.yesLabel || t('blocks.defaults.yes', 'はい'), value, block.yesTarget);
             });
 
             noBtn.addEventListener('click', () => {
               const value = block.noValue ?? block.noLabel ?? 'no';
-              choose(block.noLabel || 'いいえ', value, block.noTarget);
+              choose(block.noLabel || t('blocks.defaults.no', 'いいえ'), value, block.noTarget);
             });
           }
 
@@ -1801,20 +2054,24 @@
         return new Promise((resolve, reject) => {
           const container = document.createElement('div');
           const label = document.createElement('div');
-          label.innerHTML = `<span class="label">選択</span>${block.question || ''}`;
+          const badge = document.createElement('span');
+          badge.className = 'label';
+          bindText(badge, 'blocks.choice.logLabel', '選択');
+          label.appendChild(badge);
+          label.appendChild(document.createTextNode(block.question || ''));
           container.appendChild(label);
           const choices = document.createElement('div');
           choices.className = 'mini-tester-choice-container';
           (block.options || []).forEach(opt => {
             const btn = document.createElement('button');
-            btn.textContent = opt.label || '選択';
+            btn.textContent = opt.label || t('blocks.choice.buttonFallback', '選択');
             btn.addEventListener('click', () => {
               if (storyRunToken !== token) return;
               const value = opt.value ?? opt.label ?? '';
               context.flags[block.storeAs || 'choice'] = value;
               context.lastChoice = value;
               updateVariables(context.flags);
-              appendStoryLog(`▶ 選択: ${value}`);
+              appendStoryLog(t('blocks.choice.logSelection', '▶ 選択: {value}', { value }));
               container.remove();
               resolve(resolveIndex(opt.target, null));
             });
@@ -1822,7 +2079,7 @@
           });
           if (!choices.children.length) {
             const notice = document.createElement('div');
-            notice.textContent = '※ 選択肢が設定されていません';
+            bindText(notice, 'blocks.choice.noOptions', '※ 選択肢が設定されていません');
             choices.appendChild(notice);
           }
           container.appendChild(choices);
@@ -1859,7 +2116,8 @@
       blockSectionApi = {
         reset() {
           storyLog.innerHTML = '';
-          varBody.textContent = '(空)';
+          variablesEmpty = true;
+          setImmediateText(varBody, 'blocks.variables.empty', '(空)');
           renderBlocks();
         }
       };
@@ -1887,6 +2145,7 @@
       storyRunToken++;
       customAlertImpl = defaultAlertImpl;
       lastAlertTestAwarded = false;
+      setAlertStatus('blocks.alert.statusDefault', '既定: ログに表示します。alert() に変えることも可能です。');
       if (blockSectionApi && blockSectionApi.reset) blockSectionApi.reset();
     }
 
@@ -1897,6 +2156,12 @@
       destroy() {
         destroyed = true;
         storyRunToken++;
+        if (typeof detachLocaleListener === 'function') {
+          try { detachLocaleListener(); } catch {}
+          detachLocaleListener = null;
+        }
+        alertStatusEl = null;
+        varBodyEl = null;
         try { container.remove(); } catch {}
         blockSectionApi = null;
       }

--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -829,7 +829,222 @@
           },
           "tester": {
             "name": "JS Tester",
-            "description": "Benchmark JavaScript features and build block adventures for EXP."
+            "description": "Benchmark JavaScript features and build block adventures for EXP.",
+            "title": "JS Tester / MiniExp MOD",
+            "subtitle": "Run JavaScript self-checks, CPU benchmarks, and a block-based adventure maker.",
+            "tabs": {
+              "tests": "Feature Tests",
+              "benchmark": "CPU Benchmark",
+              "blocks": "Block Adventure"
+            },
+            "tests": {
+              "heading": "JavaScript Self-Check Lab",
+              "description": "Quickly verify representative browser features with one tap. Share the output to streamline debugging.",
+              "runAll": "Run All",
+              "runSingle": "Run Test",
+              "running": "Running…",
+              "defs": {
+                "numbers": {
+                  "name": "Numbers/BigInt",
+                  "description": "Exercise floating-point math, BigInt, and Math helpers.",
+                  "errors": {
+                    "bigInt": "BigInt arithmetic did not match expectations",
+                    "hypot": "Math.hypot returned an unexpected value"
+                  }
+                },
+                "json": {
+                  "name": "JSON & structuredClone",
+                  "description": "Validate JSON serialization and structuredClone behavior.",
+                  "errors": {
+                    "restore": "Failed to restore from JSON",
+                    "clone": "structuredClone could not preserve the Map"
+                  }
+                },
+                "intl": {
+                  "name": "Intl Formatting",
+                  "description": "Confirm Intl.DateTimeFormat and NumberFormat output.",
+                  "errors": {
+                    "date": "Date formatting differed from expectations",
+                    "currency": "Currency formatting differed from expectations"
+                  }
+                },
+                "crypto": {
+                  "name": "Crypto API",
+                  "description": "Generate cryptographic randomness and hash a sample buffer.",
+                  "errors": {
+                    "random": "crypto.getRandomValues is unavailable"
+                  }
+                },
+                "storage": {
+                  "name": "Storage API",
+                  "description": "Verify localStorage/sessionStorage read and write operations.",
+                  "errors": {
+                    "read": "Storage read/write failed",
+                    "blocked": "Storage access is blocked"
+                  }
+                },
+                "canvas": {
+                  "name": "Canvas & Offscreen",
+                  "description": "Render to Canvas and check for OffscreenCanvas support.",
+                  "errors": {
+                    "sample": "Failed to sample a Canvas pixel"
+                  }
+                }
+              }
+            },
+            "benchmark": {
+              "heading": "CPU Benchmark – increments per second",
+              "description": "Keep adding 1 to an integer for one second to gauge burst performance.",
+              "labels": {
+                "current": "Latest (ops/sec)",
+                "best": "Personal best (ops/sec)",
+                "runs": "Total runs"
+              },
+              "start": "Start benchmark (1 sec)",
+              "notice": "The UI may freeze for one second while the benchmark runs.",
+              "log": {
+                "start": "Starting benchmark…",
+                "record": "New record: {value} ops/sec",
+                "result": "Result: {value} ops/sec"
+              }
+            },
+            "blocks": {
+              "controls": {
+                "add": "Add block",
+                "clear": "Clear all"
+              },
+              "alert": {
+                "title": "Custom Alert Function",
+                "description": "Write the body of a function that receives message and context. Use context.flags and context.log for richer effects.",
+                "template": "// message: string\\n// context: { flags, log, awardXp }\\nconst box = document.createElement('div');\\nbox.textContent = message;\\nbox.style.padding = '16px';\\nbox.style.background = 'rgba(96,165,250,0.15)';\\nbox.style.border = '1px solid rgba(96,165,250,0.4)';\\nbox.style.borderRadius = '12px';\\nbox.style.margin = '6px 0';\\ncontext.log(box);\\n",
+                "apply": "Apply",
+                "test": "Test Run",
+                "statusDefault": "Default: write to the log. You can switch back to alert().",
+                "statusApplied": "✅ Applied custom alert handler.",
+                "statusError": "❌ Error: {message}",
+                "testMessage": "This is a custom alert test.",
+                "statusTestSent": "✅ Sent a test message.",
+                "statusTestError": "❌ Runtime error: {message}"
+              },
+              "story": {
+                "title": "Block Story Runner",
+                "play": "Play Story",
+                "stop": "Stop",
+                "logStart": "▶ Story started ({count} blocks)",
+                "logAborted": "⚠ Execution aborted: {message}",
+                "logEnd": "■ Story finished",
+                "logUserStop": "■ Stopped by user",
+                "logEmpty": "⚠ No blocks defined."
+              },
+              "variables": {
+                "title": "Flag Viewer (flags)",
+                "empty": "(empty)"
+              },
+              "defaults": {
+                "choiceQuestion": "What will you do?",
+                "choiceGo": "Go",
+                "choiceStop": "Stop",
+                "controlMessage": "Proceed?",
+                "yes": "Yes",
+                "no": "No",
+                "message": "Message",
+                "prompt": "Please enter your name"
+              },
+              "text": {
+                "placeholder": "Message to display",
+                "delivery": {
+                  "log": "Send to log",
+                  "alert": "Custom alert",
+                  "both": "Both"
+                },
+                "nextLabel": "Next block (# or blank)",
+                "nextPlaceholder": "Leave blank to auto-advance"
+              },
+              "choice": {
+                "questionPlaceholder": "Text shown above the choices",
+                "storePlaceholder": "Variable to store the choice (e.g. choice)",
+                "labelPlaceholder": "Button label",
+                "valuePlaceholder": "Stored value",
+                "targetPlaceholder": "Next block #",
+                "addOption": "Add choice",
+                "newOption": "New option",
+                "logLabel": "Choice",
+                "buttonFallback": "Select",
+                "logSelection": "▶ Choice: {value}",
+                "noOptions": "※ No choices configured"
+              },
+              "set": {
+                "namePlaceholder": "Variable name",
+                "valuePlaceholder": "Value (string)",
+                "nextPlaceholder": "Next block (blank = sequential)"
+              },
+              "jump": {
+                "namePlaceholder": "Variable to compare",
+                "equalsPlaceholder": "Comparison value (string)",
+                "targetPlaceholder": "Block # on match",
+                "elsePlaceholder": "Block # on mismatch (blank = next)"
+              },
+              "award": {
+                "amountPlaceholder": "EXP to grant (negatives allowed)",
+                "nextPlaceholder": "Next block (blank = sequential)"
+              },
+              "types": {
+                "text": "Text",
+                "choice": "Choice",
+                "set": "Set",
+                "jump": "Jump",
+                "award": "Award",
+                "control": "Control"
+              },
+              "control": {
+                "modeLabel": "Type",
+                "modeConfirm": "Confirm (Yes/No)",
+                "modePrompt": "Input field",
+                "messagePlaceholder": "Message to display",
+                "storePlaceholder": "Variable name to store result (blank = none)",
+                "yesLabel": "Label for the Yes button",
+                "yesValue": "Value stored when Yes is chosen",
+                "yesTarget": "Next block # after Yes (blank = next)",
+                "noLabel": "Label for the No button",
+                "noValue": "Value stored when No is chosen",
+                "noTarget": "Next block # after No (blank = next)",
+                "labelPrompt": "Input",
+                "labelConfirm": "Confirm",
+                "okLabel": "Confirm",
+                "cancelLabel": "Cancel",
+                "errorRequired": "Please enter a value.",
+                "errorNumber": "Enter a valid number.",
+                "summaryStored": "▶ {variable} = {value}",
+                "summaryValueOnly": "▶ Value = {value}",
+                "summaryCancelStored": "▶ Cancel ({variable} = {value})",
+                "summaryCancel": "▶ Input cancelled",
+                "summaryChoiceStored": "▶ Selected {label} → {variable} = {value}",
+                "summaryChoice": "▶ Selected {label}"
+              },
+              "prompt": {
+                "messagePlaceholder": "Text shown before the input field",
+                "storePlaceholder": "Variable name for the input",
+                "inputTypeText": "Text",
+                "inputTypeNumber": "Number",
+                "defaultValue": "Default value (literal)",
+                "defaultFrom": "Variable providing default (blank = literal)",
+                "allowEmpty": "Allow empty input",
+                "okLabel": "Label for confirm button",
+                "okTarget": "Block # after confirm (blank = next)",
+                "cancelLabel": "Label for cancel button",
+                "cancelValue": "Value stored on cancel",
+                "cancelTarget": "Block # after cancel (blank = next)"
+              },
+              "logs": {
+                "jumpMatch": "match",
+                "jumpMismatch": "no match",
+                "jump": "[JUMP] {name}={value} => {status}",
+                "alertError": "❌ Alert error: {message}"
+              },
+              "errors": {
+                "tooManySteps": "Too many steps executed. Possibly looping?"
+              }
+            }
           },
           "system": {
             "name": "System Inspector",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -829,7 +829,222 @@
           },
           "tester": {
             "name": "JSテスター",
-            "description": "JS機能テストとCPUベンチマーク、ブロック式アドベンチャー作成ツール"
+            "description": "JS機能テストとCPUベンチマーク、ブロック式アドベンチャー作成ツール",
+            "title": "JSテスター / MiniExp MOD",
+            "subtitle": "JavaScript機能のセルフチェック、CPUベンチマーク、ブロック式アドベンチャーメーカーを収録。",
+            "tabs": {
+              "tests": "機能テスト",
+              "benchmark": "CPUベンチマーク",
+              "blocks": "ブロックアドベンチャー"
+            },
+            "tests": {
+              "heading": "JavaScriptセルフチェックラボ",
+              "description": "ブラウザが提供する代表的な機能をワンタップで検査できます。結果を共有すればデバッグにも役立ちます。",
+              "runAll": "すべて実行",
+              "runSingle": "テスト実行",
+              "running": "実行中…",
+              "defs": {
+                "numbers": {
+                  "name": "数値/BigInt",
+                  "description": "浮動小数とBigIntの演算、Math拡張を試験します。",
+                  "errors": {
+                    "bigInt": "BigInt演算が期待どおりではありません",
+                    "hypot": "Math.hypot結果に誤差が大きいです"
+                  }
+                },
+                "json": {
+                  "name": "JSON & structuredClone",
+                  "description": "JSONシリアライズとstructuredCloneをチェックします。",
+                  "errors": {
+                    "restore": "JSON復元に失敗しました",
+                    "clone": "structuredCloneがMapを保持できません"
+                  }
+                },
+                "intl": {
+                  "name": "Intlフォーマット",
+                  "description": "Intl.DateTimeFormatとNumberFormatを検証します。",
+                  "errors": {
+                    "date": "日付フォーマットが想定外です",
+                    "currency": "通貨フォーマットが想定外です"
+                  }
+                },
+                "crypto": {
+                  "name": "Crypto API",
+                  "description": "暗号学的乱数と微小なハッシュ処理を行います。",
+                  "errors": {
+                    "random": "crypto.getRandomValuesが利用できません"
+                  }
+                },
+                "storage": {
+                  "name": "Storage API",
+                  "description": "localStorage/sessionStorage の読み書きを確認します。",
+                  "errors": {
+                    "read": "Storage読み書き失敗",
+                    "blocked": "Storage利用がブロックされています"
+                  }
+                },
+                "canvas": {
+                  "name": "Canvas & Offscreen",
+                  "description": "Canvas描画とOffscreenCanvasの存在を検査します。",
+                  "errors": {
+                    "sample": "Canvasピクセル取得に失敗"
+                  }
+                }
+              }
+            },
+            "benchmark": {
+              "heading": "CPUベンチマーク - 1秒間のインクリメント回数",
+              "description": "整数に1を加算し続け、1秒間で何回ループできるか計測します。ブラウザや端末の瞬間的な性能をチェックしましょう。",
+              "labels": {
+                "current": "最新結果 (回/秒)",
+                "best": "自己ベスト (回/秒)",
+                "runs": "累計実行回数"
+              },
+              "start": "計測スタート (1秒)",
+              "notice": "計測中はUIが1秒間固まる場合があります。",
+              "log": {
+                "start": "計測を開始します…",
+                "record": "新記録: {value} 回/秒",
+                "result": "結果: {value} 回/秒"
+              }
+            },
+            "blocks": {
+              "controls": {
+                "add": "ブロックを追加",
+                "clear": "全削除"
+              },
+              "alert": {
+                "title": "カスタムAlert関数",
+                "description": "message, context を受け取る関数本体を記述します。context.flags や context.log を使って高度な演出が可能です。",
+                "template": "// message: string\\n// context: { flags, log, awardXp }\\nconst box = document.createElement('div');\\nbox.textContent = message;\\nbox.style.padding = '16px';\\nbox.style.background = 'rgba(96,165,250,0.15)';\\nbox.style.border = '1px solid rgba(96,165,250,0.4)';\\nbox.style.borderRadius = '12px';\\nbox.style.margin = '6px 0';\\ncontext.log(box);\\n",
+                "apply": "更新",
+                "test": "テスト実行",
+                "statusDefault": "既定: ログに表示します。alert() に変えることも可能です。",
+                "statusApplied": "✅ カスタムalertを適用しました。",
+                "statusError": "❌ エラー: {message}",
+                "testMessage": "カスタムalertのテストです。",
+                "statusTestSent": "✅ テストメッセージを送信しました。",
+                "statusTestError": "❌ 実行エラー: {message}"
+              },
+              "story": {
+                "title": "ブロックストーリーランナー",
+                "play": "ストーリー再生",
+                "stop": "停止",
+                "logStart": "▶ ストーリー開始 ({count} ブロック)",
+                "logAborted": "⚠ 実行中断: {message}",
+                "logEnd": "■ ストーリー終了",
+                "logUserStop": "■ ユーザーが停止しました",
+                "logEmpty": "⚠ ブロックが1つもありません。"
+              },
+              "variables": {
+                "title": "変数ビュー (flags)",
+                "empty": "(空)"
+              },
+              "defaults": {
+                "choiceQuestion": "どうする？",
+                "choiceGo": "進む",
+                "choiceStop": "やめる",
+                "controlMessage": "進みますか？",
+                "yes": "はい",
+                "no": "いいえ",
+                "message": "メッセージ",
+                "prompt": "名前を入力してください"
+              },
+              "text": {
+                "placeholder": "表示するメッセージ",
+                "delivery": {
+                  "log": "ログに出力",
+                  "alert": "カスタムalert",
+                  "both": "両方"
+                },
+                "nextLabel": "次に進むブロック (# または空)",
+                "nextPlaceholder": "空なら自動で次"
+              },
+              "choice": {
+                "questionPlaceholder": "選択肢の前に表示する文章",
+                "storePlaceholder": "選択した値を保存する変数名 (例: choice)",
+                "labelPlaceholder": "ボタン表示",
+                "valuePlaceholder": "保存する値",
+                "targetPlaceholder": "次の#",
+                "addOption": "選択肢を追加",
+                "newOption": "新しい選択肢",
+                "logLabel": "選択",
+                "buttonFallback": "選択",
+                "logSelection": "▶ 選択: {value}",
+                "noOptions": "※ 選択肢が設定されていません"
+              },
+              "set": {
+                "namePlaceholder": "変数名",
+                "valuePlaceholder": "値 (文字列)",
+                "nextPlaceholder": "次のブロック (空=順番通り)"
+              },
+              "jump": {
+                "namePlaceholder": "判定する変数名",
+                "equalsPlaceholder": "比較値 (文字列)",
+                "targetPlaceholder": "一致した時のブロック#",
+                "elsePlaceholder": "不一致の時のブロック# (空=次)"
+              },
+              "award": {
+                "amountPlaceholder": "付与するEXP (負数も可)",
+                "nextPlaceholder": "次のブロック (空=順番通り)"
+              },
+              "types": {
+                "text": "text",
+                "choice": "choice",
+                "set": "set",
+                "jump": "jump",
+                "award": "award",
+                "control": "control"
+              },
+              "control": {
+                "modeLabel": "種類",
+                "modeConfirm": "確認 (はい/いいえ)",
+                "modePrompt": "入力ボックス",
+                "messagePlaceholder": "表示するメッセージ",
+                "storePlaceholder": "結果を保存する変数名 (空=保存しない)",
+                "yesLabel": "はいボタンの表示",
+                "yesValue": "はいを押した時に保存する値",
+                "yesTarget": "はいの次ブロック# (空=次)",
+                "noLabel": "いいえボタンの表示",
+                "noValue": "いいえを押した時に保存する値",
+                "noTarget": "いいえの次ブロック# (空=次)",
+                "labelPrompt": "入力",
+                "labelConfirm": "確認",
+                "okLabel": "決定",
+                "cancelLabel": "キャンセル",
+                "errorRequired": "値を入力してください。",
+                "errorNumber": "数値を入力してください。",
+                "summaryStored": "▶ {variable} = {value}",
+                "summaryValueOnly": "▶ 値 = {value}",
+                "summaryCancelStored": "▶ キャンセル ({variable} = {value})",
+                "summaryCancel": "▶ 入力をキャンセル",
+                "summaryChoiceStored": "▶ {label} を選択 → {variable} = {value}",
+                "summaryChoice": "▶ {label} を選択"
+              },
+              "prompt": {
+                "messagePlaceholder": "入力ボックスの前に表示する文章",
+                "storePlaceholder": "入力値を保存する変数名",
+                "inputTypeText": "テキスト",
+                "inputTypeNumber": "数値",
+                "defaultValue": "既定値 (固定文字列)",
+                "defaultFrom": "既定値を読み込む変数名 (空=固定)",
+                "allowEmpty": "空入力を許可",
+                "okLabel": "決定ボタンの表示",
+                "okTarget": "決定後のブロック# (空=次)",
+                "cancelLabel": "キャンセルボタンの表示",
+                "cancelValue": "キャンセル時に保存する値",
+                "cancelTarget": "キャンセル後のブロック# (空=次)"
+              },
+              "logs": {
+                "jumpMatch": "一致",
+                "jumpMismatch": "不一致",
+                "jump": "[JUMP] {name}={value} => {status}",
+                "alertError": "❌ alert実行エラー: {message}"
+              },
+              "errors": {
+                "tooManySteps": "ステップ回数が多すぎます。ループしていませんか？"
+              }
+            }
           },
           "system": {
             "name": "システム",

--- a/style.css
+++ b/style.css
@@ -1,12 +1,58 @@
 body {
-    font-family: sans-serif;
+    font-family: 'Segoe UI', 'Hiragino Sans', 'Noto Sans JP', sans-serif;
     display: flex;
     flex-direction: column;
     align-items: center;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 50%, #f093fb 100%);
+    color: #0f172a;
+    background: linear-gradient(120deg, #e0f2fe 0%, #ede9fe 45%, #f5f3ff 100%);
     min-height: 100vh;
     margin: 0;
-    padding: 20px;
+    padding: 24px;
+    line-height: 1.6;
+}
+
+.site-header {
+    width: 100%;
+    max-width: 980px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+    padding: 18px 24px;
+    margin-bottom: 20px;
+    background: rgba(255, 255, 255, 0.88);
+    border-radius: 18px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    box-shadow: 0 20px 44px rgba(148, 163, 184, 0.25);
+}
+
+.site-header h1 {
+    margin: 0;
+    font-size: 28px;
+    letter-spacing: 0.04em;
+}
+
+.language-switcher {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 0.95rem;
+    color: #334155;
+}
+
+.language-switcher label {
+    font-weight: 600;
+}
+
+.language-switcher select {
+    appearance: none;
+    background: #f8fafc;
+    border: 1px solid #cbd5f5;
+    border-radius: 10px;
+    padding: 6px 12px;
+    color: #0f172a;
+    font-size: 0.95rem;
+    box-shadow: 0 6px 18px rgba(148, 163, 184, 0.2);
 }
 
 .visually-hidden {
@@ -46,7 +92,7 @@ body.in-game #game-container {
     display: flex;
     justify-content: center;
     margin-bottom: 12px;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 50%, #f093fb 100%);
+    background: linear-gradient(135deg, rgba(224,242,254,0.65), rgba(237,233,254,0.6));
     min-height: 100vh;
     align-items: center;
     padding-bottom: var(--selection-footer-h, 140px); /* フッター分の余白を確保 */


### PR DESCRIPTION
## Summary
- add translation helpers to the JS tester and localize tests, benchmark, and block editor strings
- refresh the tester layout with a brighter theme and improved block editor readability
- update top-level styles and locale files so the landing page and tester render clearly in Japanese and English

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7af812b00832ba051de27a2fcce12