### PR TITLE
Add localization entries for Highway Chaser minigame

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -11588,6 +11588,44 @@
           "modest": "Modest"
         }
       },
+      "pseudo3d_race": {
+        "scenery": {
+          "billboard": "BOOST"
+        },
+        "hud": {
+          "speed": "SPEED {speed} {unit}",
+          "distance": "DIST {distance} {unit}",
+          "time": "TIME {time}{unit}",
+          "crash": "CRASH {crashes}/{limit}",
+          "paused": "PAUSED",
+          "nitro": "NITRO",
+          "progress": "COURSE PROGRESS",
+          "upcomingTurn": {
+            "right": "Right turn",
+            "left": "Left turn"
+          }
+        },
+        "help": {
+          "controls": "Controls: Steer with ←/→ or A/D • Accelerate with ↑/W • Brake with ↓/S • Press Space for Nitro",
+          "objective": "Objective: Cover distance before time runs out and overtake traffic safely.",
+          "shortcuts": "H to toggle help / P to pause"
+        },
+        "end": {
+          "title": "GAME OVER",
+          "restart": "Press R to restart",
+          "pause": "Press P to pause/resume"
+        },
+        "countdown": {
+          "go": "GO!"
+        },
+        "popup": {
+          "nitro": "NITRO!"
+        },
+        "controls": {
+          "nitro": "NITRO",
+          "pause": "PAUSE"
+        }
+      },
       "othello": {
         "hud": {
           "status": {

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -11592,6 +11592,44 @@
           "modest": "まあまあ"
         }
       },
+      "pseudo3d_race": {
+        "scenery": {
+          "billboard": "ブースト"
+        },
+        "hud": {
+          "speed": "速度 {speed}{unit}",
+          "distance": "距離 {distance}{unit}",
+          "time": "残り {time}{unit}",
+          "crash": "クラッシュ {crashes}/{limit}",
+          "paused": "一時停止",
+          "nitro": "ニトロ",
+          "progress": "コース進捗",
+          "upcomingTurn": {
+            "right": "右カーブ",
+            "left": "左カーブ"
+          }
+        },
+        "help": {
+          "controls": "操作: ←/→ または A/D でステアリング ・ ↑/W でアクセル ・ ↓/S でブレーキ ・ スペースでニトロ",
+          "objective": "目的: 制限時間内に距離を稼ぎ、交通を安全に追い越そう",
+          "shortcuts": "H でヘルプ切替 / P で一時停止"
+        },
+        "end": {
+          "title": "ゲームオーバー",
+          "restart": "Rでリスタート",
+          "pause": "Pで一時停止/再開"
+        },
+        "countdown": {
+          "go": "スタート!"
+        },
+        "popup": {
+          "nitro": "ニトロ!"
+        },
+        "controls": {
+          "nitro": "ニトロ",
+          "pause": "一時停止"
+        }
+      },
       "othello": {
         "hud": {
           "status": {


### PR DESCRIPTION
## Summary
- add English localization strings covering Highway Chaser HUD, help, and controls
- add matching Japanese translations so the minigame can switch languages correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7b004e218832b8094b36dca3a4f8e