### PR TITLE
Fix Virus Buster localization strings

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -874,7 +874,27 @@
           },
           "virus_buster": {
             "name": "Virus Buster",
-            "description": "Stack capsules to match colors and wipe viruses for EXP."
+            "description": "Stack capsules to match colors and wipe viruses for EXP.",
+            "title": "Virus Buster",
+            "hud": {
+              "level": "Level {level}",
+              "viruses": "Viruses {count}",
+              "cleared": "Cleared {count}",
+              "chainLabel": "{chain} Chain!",
+              "chainNice": "Nice!",
+              "chainVirus": "Virus x{count}",
+              "stageClear": "Stage Clear!",
+              "controls": "Controls: ←→ Move / ↓ Soft Drop / ↑ or X Rotate / Space Hard Drop / R Reset"
+            },
+            "floating": {
+              "drop": "DROP!",
+              "virus": "Virus x{count}",
+              "stageClear": "STAGE CLEAR!"
+            },
+            "status": {
+              "gameOver": "Game Over",
+              "restartHint": "Press R to restart"
+            }
           },
           "sichuan": {
             "name": "Sichuan Puzzle",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -874,7 +874,27 @@
           },
           "virus_buster": {
             "name": "ドクターマリオ風",
-            "description": "カプセルで4つ揃え！ウイルス退治でEXP獲得"
+            "description": "カプセルで4つ揃え！ウイルス退治でEXP獲得",
+            "title": "ドクターマリオ風",
+            "hud": {
+              "level": "レベル {level}",
+              "viruses": "ウイルス {count}",
+              "cleared": "除去数 {count}",
+              "chainLabel": "{chain}連鎖！",
+              "chainNice": "ナイス！",
+              "chainVirus": "ウイルス x{count}",
+              "stageClear": "ステージクリア！",
+              "controls": "操作: ←→移動 / ↓ソフトドロップ / ↑またはX回転 / Spaceハードドロップ / Rリセット"
+            },
+            "floating": {
+              "drop": "ドロップ！",
+              "virus": "ウイルス x{count}",
+              "stageClear": "ステージクリア！"
+            },
+            "status": {
+              "gameOver": "ゲームオーバー",
+              "restartHint": "Rでリスタート"
+            }
           },
           "sichuan": {
             "name": "四川省パズル",


### PR DESCRIPTION
## Summary
- wire the Virus Buster mini-game into the shared localization helper and refresh when the locale changes
- externalize in-game UI text to translation keys and add matching English/Japanese strings

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e7b084fab4832bb698fcb54c8df7bf