### PR TITLE
Fix Flappy Bird localization strings

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -906,7 +906,14 @@
           },
           "flappy_bird": {
             "name": "Flappy Bird Clone",
-            "description": "Slip through pipe gaps for EXP and multiply it with streaks."
+            "description": "Slip through pipe gaps for EXP and multiply it with streaks.",
+            "ui": {
+              "combo": "COMBO {combo}",
+              "start": "Press Space / Click to start",
+              "gameOver": "GAME OVER",
+              "restart": "Press Space / R to restart",
+              "finalScore": "Score {formattedScore}"
+            }
           },
           "dino_runner": {
             "name": "Dino Runner",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -906,7 +906,14 @@
           },
           "flappy_bird": {
             "name": "フラッピーバード風",
-            "description": "パイプ通過でEXP。連続成功でボーナス"
+            "description": "パイプ通過でEXP。連続成功でボーナス",
+            "ui": {
+              "combo": "コンボ {combo}",
+              "start": "スペース / クリックで開始",
+              "gameOver": "ゲームオーバー",
+              "restart": "スペース / R でリスタート",
+              "finalScore": "スコア {formattedScore}"
+            }
           },
           "dino_runner": {
             "name": "ダイノランナー",


### PR DESCRIPTION
## Summary
- add dedicated UI translations for the Flappy Bird mini-game in English and Japanese so locale switching works

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e7b1568984832b80ad87d8e7170464