### PR TITLE
Fix localization for tosochu mini-game

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -934,7 +934,49 @@
           },
           "tosochu": {
             "name": "Run for Money",
-            "description": "Evade hunters in a TV-style chase, banking massive EXP if you last or surrender safely."
+            "description": "Evade hunters in a TV-style chase, banking massive EXP if you last or surrender safely.",
+            "ui": {
+              "timer": "Time Left {seconds}s",
+              "exp": "Stored EXP {exp}",
+              "missionNotReady": "Mission: Not yet activated",
+              "missionActive": "Mission: {label}{optionalSuffix} — {seconds}s remaining (Coords: {coords})",
+              "missionComplete": "Missions Complete: {success}/{total} succeeded",
+              "missionSuccess": "{label}: Success!",
+              "missionFailed": "{label}: Failed…",
+              "surrender": "Surrender",
+              "surrenderCountdown": "Surrendering...{seconds}s"
+            },
+            "status": {
+              "hunterAdded": "A hunter has joined the chase!",
+              "hunterRetreat": "Mission success! One hunter retreated",
+              "missionActivated": "Mission activated: {label}",
+              "escapeSuccess": "Escaped! +{total} EXP (Breakdown {base}+{bonus})",
+              "surrenderSuccess": "Surrendered. Banked {exp} EXP",
+              "caught": "Caught... no EXP earned",
+              "dungeonUnavailable": "Dungeon API unavailable",
+              "stageGenerationFailed": "Failed to generate the stage",
+              "runStart": "The chase begins!",
+              "runPaused": "Paused",
+              "standby": "Standby",
+              "surrenderZoneHint": "Enter the surrender zone before pressing the button",
+              "surrenderAttempt": "Attempting surrender… endure for {duration}s!",
+              "surrenderCancelled": "Surrender cancelled",
+              "beaconSuccess": "Beacon secured! Signal jamming strengthened",
+              "beaconFail": "Beacon failed... hunters are on alert",
+              "dataSuccess": "Classified intel secured! Rewards increased",
+              "dataFail": "Alarm triggered! A fast hunter has appeared",
+              "boxSuccess": "Disarmed! Hunter boxes are delayed",
+              "boxFail": "Disarm failed... an extra hunter deployed",
+              "vaultSuccess": "Jackpot! But you're now a prime target",
+              "vaultFail": "Vault defended... two hunters released"
+            },
+            "missions": {
+              "optionalSuffix": " (Optional)",
+              "beacon": { "label": "Reach the beacon" },
+              "data": { "label": "Hack the data terminal" },
+              "box": { "label": "Disarm the hunter box" },
+              "vault": { "label": "Crack the high-risk vault" }
+            }
           },
           "ten_ten": {
             "name": "1010 Puzzle",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -934,7 +934,49 @@
           },
           "tosochu": {
             "name": "逃走中",
-            "description": "逃走者 VS ハンターの番組風アクション。逃げ切れば+10000EXP、自首で蓄積EXP"
+            "description": "逃走者 VS ハンターの番組風アクション。逃げ切れば+10000EXP、自首で蓄積EXP",
+            "ui": {
+              "timer": "残り {seconds}s",
+              "exp": "蓄積EXP {exp}",
+              "missionNotReady": "ミッション: まだ発動していません",
+              "missionActive": "ミッション: {label}{optionalSuffix}：残り{seconds}s (地点: {coords})",
+              "missionComplete": "ミッション完了：成功{success}/{total}",
+              "missionSuccess": "{label}：成功！",
+              "missionFailed": "{label}：失敗…",
+              "surrender": "自首する",
+              "surrenderCountdown": "自首中...{seconds}s"
+            },
+            "status": {
+              "hunterAdded": "ハンターが追加投入された！",
+              "hunterRetreat": "ミッション成功！ハンター1体が撤退",
+              "missionActivated": "ミッション発動：{label}",
+              "escapeSuccess": "逃走成功！+{total} EXP (内訳 {base}+{bonus})",
+              "surrenderSuccess": "自首。蓄積{exp}EXPを獲得",
+              "caught": "捕まってしまった…獲得EXPなし",
+              "dungeonUnavailable": "ダンジョンAPI利用不可",
+              "stageGenerationFailed": "ステージ生成に失敗しました",
+              "runStart": "逃走開始！",
+              "runPaused": "一時停止中",
+              "standby": "逃走中スタンバイ",
+              "surrenderZoneHint": "自首ゾーンに入ってからボタンを押してください",
+              "surrenderAttempt": "自首を試みています…{duration}s耐え抜け！",
+              "surrenderCancelled": "自首を中断しました",
+              "beaconSuccess": "ビーコン成功！電波妨害を強化",
+              "beaconFail": "ビーコン失敗…ハンターが警戒強化",
+              "dataSuccess": "極秘情報を確保！報酬が増加",
+              "dataFail": "警報が鳴った！高速ハンターが出現",
+              "boxSuccess": "解除成功！ハンターボックスの発動が遅延",
+              "boxFail": "解除失敗…ハンターが追加投入",
+              "vaultSuccess": "大金獲得！しかし狙われやすくなった",
+              "vaultFail": "金庫防衛が発動…ハンターが二体解放"
+            },
+            "missions": {
+              "optionalSuffix": "（任意）",
+              "beacon": { "label": "ビーコンに接触せよ" },
+              "data": { "label": "情報端末をハック" },
+              "box": { "label": "ハンターボックスを解除" },
+              "vault": { "label": "ハイリスク金庫を解錠" }
+            }
           },
           "ten_ten": {
             "name": "1010パズル",


### PR DESCRIPTION
## Summary
- integrate the tosochu mini-game with the shared i18n helpers so UI strings translate correctly
- add mission/status translations for Japanese and English locales, including surrender prompts and mission details

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e7b24ee068832ba7c17171917136f6