### PR TITLE
Fix Onigokko localization strings

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -1068,7 +1068,22 @@
           },
           "onigokko": {
             "name": "Tag Escape",
-            "description": "Run around a mixed dungeon to dodge the chaser and survive for EXP."
+            "description": "Run around a mixed dungeon to dodge the chaser and survive for EXP.",
+            "timer": {
+              "remaining": "Time left: {seconds}s"
+            },
+            "status": {
+              "start": "Chase start! Move with Arrow keys / WASD.",
+              "paused": "Paused",
+              "loading": "Loading stage…",
+              "ready": "Ready! Press Start to begin the chase.",
+              "stage_generation_failed": "Stage generation failed",
+              "api_unavailable": "Dungeon API unavailable",
+              "caught": "Caught!",
+              "caught_no_reward": "Caught! No EXP earned.",
+              "escaped": "Escaped! Great job!",
+              "escape_success": "Escape successful!"
+            }
           },
           "darumasan": {
             "name": "Darumasan ga Koronda",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -1068,7 +1068,22 @@
           },
           "onigokko": {
             "name": "鬼ごっこ",
-            "description": "混合型ダンジョンを舞台に鬼から逃げるトイアクション"
+            "description": "混合型ダンジョンを舞台に鬼から逃げるトイアクション",
+            "timer": {
+              "remaining": "残り {seconds}s"
+            },
+            "status": {
+              "start": "鬼ごっこ開始！矢印キー/WASDで移動",
+              "paused": "一時停止中",
+              "loading": "ステージ読み込み中…",
+              "ready": "準備完了！開始で鬼ごっこスタート",
+              "stage_generation_failed": "ステージ生成に失敗しました",
+              "api_unavailable": "ダンジョンAPIが利用できません",
+              "caught": "捕まった！",
+              "caught_no_reward": "捕まってしまった！獲得EXPなし",
+              "escaped": "見事逃げ切った！",
+              "escape_success": "逃げ切り成功！"
+            }
           },
           "darumasan": {
             "name": "だるまさんがころんだ",


### PR DESCRIPTION
## Summary
- add localized timer and status strings for the Onigokko mini-game in Japanese and English

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e7b4e31204832b93c973e9a45681cc