### PR TITLE
Fix typing challenge localization

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -1084,7 +1084,69 @@
           },
           "typing": {
             "name": "Typing Challenge",
-            "description": "Type accurately for 60 seconds to push WPM and EXP."
+            "description": "Type accurately for 60 seconds to push WPM and EXP.",
+            "controls": {
+              "difficulty": "Difficulty",
+              "target": "Target WPM",
+              "targetValue": "{targetWpm} WPM",
+              "difficultyOptions": {
+                "easy": "Easy",
+                "normal": "Normal",
+                "hard": "Hard"
+              }
+            },
+            "words": {
+              "nextEmpty": "Next: -",
+              "nextWithValue": "Next: {word}"
+            },
+            "input": {
+              "placeholder": "Type the shown word (Space/Enter to confirm)"
+            },
+            "buttons": {
+              "reset": "Reset",
+              "retry": "Try again"
+            },
+            "stats": {
+              "labels": {
+                "accuracy": "ACC",
+                "wpm": "WPM",
+                "combo": "COMBO",
+                "sessionXp": "SESSION XP"
+              },
+              "targetInfo": {
+                "pending": "Target {targetWpm} WPM / Progress -",
+                "active": "Target {targetWpm} WPM / Progress {progress}%"
+              }
+            },
+            "result": {
+              "title": "RESULT",
+              "labels": {
+                "accuracy": "Accuracy",
+                "wpm": "Average WPM",
+                "words": "Correct chars",
+                "combo": "Max combo"
+              },
+              "wordsValue": "{count} chars"
+            },
+            "xp": {
+              "title": "EXP breakdown",
+              "none": "No EXP earned this run",
+              "wordLabel": "Word {index}",
+              "word": "{label}: +{xp} EXP",
+              "wordWithMilestones": "{label}: +{xp} EXP ({milestones})",
+              "milestoneEntry": "x{combo}+{bonus}",
+              "milestoneSeparator": ", ",
+              "accuracyLabel": "Accuracy bonus ({accuracyPercent}%)",
+              "accuracy": "{label}: +{xp} EXP",
+              "generic": "+{xp} EXP"
+            },
+            "toasts": {
+              "start": "60-second challenge started! Good luck!",
+              "mistype": "Mistype!",
+              "completeBeforeConfirm": "Type the full word before confirming!",
+              "comboMilestone": "Combo x{combo}! +{bonus} EXP",
+              "comboSeparator": " / "
+            }
           },
           "imperial_realm": {
             "name": "Imperial Realm",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -1084,7 +1084,69 @@
           },
           "typing": {
             "name": "タイピングチャレンジ",
-            "description": "60秒タイプで正確さとスピードを競うタイピングチャレンジ"
+            "description": "60秒タイプで正確さとスピードを競うタイピングチャレンジ",
+            "controls": {
+              "difficulty": "難易度",
+              "target": "ターゲットWPM",
+              "targetValue": "{targetWpm} WPM",
+              "difficultyOptions": {
+                "easy": "EASY",
+                "normal": "NORMAL",
+                "hard": "HARD"
+              }
+            },
+            "words": {
+              "nextEmpty": "次: -",
+              "nextWithValue": "次: {word}"
+            },
+            "input": {
+              "placeholder": "表示された単語をタイプ（Space/Enterで確定）"
+            },
+            "buttons": {
+              "reset": "リセット",
+              "retry": "もう一度挑戦"
+            },
+            "stats": {
+              "labels": {
+                "accuracy": "ACC",
+                "wpm": "WPM",
+                "combo": "COMBO",
+                "sessionXp": "SESSION XP"
+              },
+              "targetInfo": {
+                "pending": "ターゲット {targetWpm} WPM / 達成度 -",
+                "active": "ターゲット {targetWpm} WPM / 達成度 {progress}%"
+              }
+            },
+            "result": {
+              "title": "RESULT",
+              "labels": {
+                "accuracy": "精度",
+                "wpm": "平均WPM",
+                "words": "正タイプ数",
+                "combo": "最高コンボ"
+              },
+              "wordsValue": "{count} 文字"
+            },
+            "xp": {
+              "title": "EXP 内訳",
+              "none": "EXPは獲得できませんでした",
+              "wordLabel": "単語 {index}",
+              "word": "{label}: +{xp} EXP",
+              "wordWithMilestones": "{label}: +{xp} EXP ({milestones})",
+              "milestoneEntry": "x{combo}+{bonus}",
+              "milestoneSeparator": "、",
+              "accuracyLabel": "精度ボーナス ({accuracyPercent}%)",
+              "accuracy": "{label}: +{xp} EXP",
+              "generic": "+{xp} EXP"
+            },
+            "toasts": {
+              "start": "60秒チャレンジ開始！がんばって！",
+              "mistype": "ミスタイプ！",
+              "completeBeforeConfirm": "全文字をタイプしてから確定！",
+              "comboMilestone": "Combo x{combo}! +{bonus} EXP",
+              "comboSeparator": " / "
+            }
           },
           "imperial_realm": {
             "name": "インペリアル・レルム",


### PR DESCRIPTION
## Summary
- integrate the typing challenge mini-game UI with the global i18n helpers and react to locale changes
- add English and Japanese locale strings for all typing challenge controls, stats, messages, and XP summaries

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7b5955a38832b8103475db4ea0552