### PR TITLE
Fix janken state initialization order

### DIFF
--- a/games/janken.js
+++ b/games/janken.js
@@ -157,6 +157,14 @@
     const historyRecords = [];
     let statusState = { key: 'status.prompt', fallback: '手を選ぶと掛け声が始まるよ', params: null };
     let detachLocale = null;
+    let wins = 0;
+    let losses = 0;
+    let ties = 0;
+    let streak = 0;
+    let bestStreak = 0;
+    let roundCount = 0;
+    let isResolving = false;
+    let lastPlayerChoice = null;
 
     function choiceLabel(index){
       const def = CHOICES[index] || {};
@@ -256,15 +264,6 @@
     const BEATS = [1,2,0];
     const BEATEN_BY = [2,0,1];
     const CHANT_INTERVAL = 260;
-
-    let wins = 0;
-    let losses = 0;
-    let ties = 0;
-    let streak = 0;
-    let bestStreak = 0;
-    let roundCount = 0;
-    let isResolving = false;
-    let lastPlayerChoice = null;
 
     function setGameTimeout(fn, delay){
       const id = setTimeout(() => {


### PR DESCRIPTION
## Summary
- initialize the janken game state counters and flags before any functions that may execute immediately
- prevent ReferenceError crashes when starting the janken mini game

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7bb99ed50832bbd50f4721b858782