### PR TITLE
Fix typing locale keys

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -1084,69 +1084,7 @@
           },
           "typing": {
             "name": "Typing Challenge",
-            "description": "Type accurately for 60 seconds to push WPM and EXP.",
-            "controls": {
-              "difficulty": "Difficulty",
-              "target": "Target WPM",
-              "targetValue": "{targetWpm} WPM",
-              "difficultyOptions": {
-                "easy": "Easy",
-                "normal": "Normal",
-                "hard": "Hard"
-              }
-            },
-            "words": {
-              "nextEmpty": "Next: -",
-              "nextWithValue": "Next: {word}"
-            },
-            "input": {
-              "placeholder": "Type the shown word (Space/Enter to confirm)"
-            },
-            "buttons": {
-              "reset": "Reset",
-              "retry": "Try again"
-            },
-            "stats": {
-              "labels": {
-                "accuracy": "ACC",
-                "wpm": "WPM",
-                "combo": "COMBO",
-                "sessionXp": "SESSION XP"
-              },
-              "targetInfo": {
-                "pending": "Target {targetWpm} WPM / Progress -",
-                "active": "Target {targetWpm} WPM / Progress {progress}%"
-              }
-            },
-            "result": {
-              "title": "RESULT",
-              "labels": {
-                "accuracy": "Accuracy",
-                "wpm": "Average WPM",
-                "words": "Correct chars",
-                "combo": "Max combo"
-              },
-              "wordsValue": "{count} chars"
-            },
-            "xp": {
-              "title": "EXP breakdown",
-              "none": "No EXP earned this run",
-              "wordLabel": "Word {index}",
-              "word": "{label}: +{xp} EXP",
-              "wordWithMilestones": "{label}: +{xp} EXP ({milestones})",
-              "milestoneEntry": "x{combo}+{bonus}",
-              "milestoneSeparator": ", ",
-              "accuracyLabel": "Accuracy bonus ({accuracyPercent}%)",
-              "accuracy": "{label}: +{xp} EXP",
-              "generic": "+{xp} EXP"
-            },
-            "toasts": {
-              "start": "60-second challenge started! Good luck!",
-              "mistype": "Mistype!",
-              "completeBeforeConfirm": "Type the full word before confirming!",
-              "comboMilestone": "Combo x{combo}! +{bonus} EXP",
-              "comboSeparator": " / "
-            }
+            "description": "Type accurately for 60 seconds to push WPM and EXP."
           },
           "imperial_realm": {
             "name": "Imperial Realm",
@@ -13263,6 +13201,72 @@
         "sandboxDisabled": "Returned to exploration mode.",
         "sampleInserted": "Sample code inserted.",
         "cleared": "Input cleared."
+      }
+    },
+    "miniGames": {
+      "typing": {
+        "controls": {
+          "difficulty": "Difficulty",
+          "target": "Target WPM",
+          "targetValue": "{targetWpm} WPM",
+          "difficultyOptions": {
+            "easy": "Easy",
+            "normal": "Normal",
+            "hard": "Hard"
+          }
+        },
+        "words": {
+          "nextEmpty": "Next: -",
+          "nextWithValue": "Next: {word}"
+        },
+        "input": {
+          "placeholder": "Type the shown word (Space/Enter to confirm)"
+        },
+        "buttons": {
+          "reset": "Reset",
+          "retry": "Try again"
+        },
+        "stats": {
+          "labels": {
+            "accuracy": "ACC",
+            "wpm": "WPM",
+            "combo": "COMBO",
+            "sessionXp": "SESSION XP"
+          },
+          "targetInfo": {
+            "pending": "Target {targetWpm} WPM / Progress -",
+            "active": "Target {targetWpm} WPM / Progress {progress}%"
+          }
+        },
+        "result": {
+          "title": "RESULT",
+          "labels": {
+            "accuracy": "Accuracy",
+            "wpm": "Average WPM",
+            "words": "Correct chars",
+            "combo": "Max combo"
+          },
+          "wordsValue": "{count} chars"
+        },
+        "xp": {
+          "title": "EXP breakdown",
+          "none": "No EXP earned this run",
+          "wordLabel": "Word {index}",
+          "word": "{label}: +{xp} EXP",
+          "wordWithMilestones": "{label}: +{xp} EXP ({milestones})",
+          "milestoneEntry": "x{combo}+{bonus}",
+          "milestoneSeparator": ", ",
+          "accuracyLabel": "Accuracy bonus ({accuracyPercent}%)",
+          "accuracy": "{label}: +{xp} EXP",
+          "generic": "+{xp} EXP"
+        },
+        "toasts": {
+          "start": "60-second challenge started! Good luck!",
+          "mistype": "Mistype!",
+          "completeBeforeConfirm": "Type the full word before confirming!",
+          "comboMilestone": "Combo x{combo}! +{bonus} EXP",
+          "comboSeparator": " / "
+        }
       }
     },
     "games": {

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -1084,69 +1084,7 @@
           },
           "typing": {
             "name": "タイピングチャレンジ",
-            "description": "60秒タイプで正確さとスピードを競うタイピングチャレンジ",
-            "controls": {
-              "difficulty": "難易度",
-              "target": "ターゲットWPM",
-              "targetValue": "{targetWpm} WPM",
-              "difficultyOptions": {
-                "easy": "EASY",
-                "normal": "NORMAL",
-                "hard": "HARD"
-              }
-            },
-            "words": {
-              "nextEmpty": "次: -",
-              "nextWithValue": "次: {word}"
-            },
-            "input": {
-              "placeholder": "表示された単語をタイプ（Space/Enterで確定）"
-            },
-            "buttons": {
-              "reset": "リセット",
-              "retry": "もう一度挑戦"
-            },
-            "stats": {
-              "labels": {
-                "accuracy": "ACC",
-                "wpm": "WPM",
-                "combo": "COMBO",
-                "sessionXp": "SESSION XP"
-              },
-              "targetInfo": {
-                "pending": "ターゲット {targetWpm} WPM / 達成度 -",
-                "active": "ターゲット {targetWpm} WPM / 達成度 {progress}%"
-              }
-            },
-            "result": {
-              "title": "RESULT",
-              "labels": {
-                "accuracy": "精度",
-                "wpm": "平均WPM",
-                "words": "正タイプ数",
-                "combo": "最高コンボ"
-              },
-              "wordsValue": "{count} 文字"
-            },
-            "xp": {
-              "title": "EXP 内訳",
-              "none": "EXPは獲得できませんでした",
-              "wordLabel": "単語 {index}",
-              "word": "{label}: +{xp} EXP",
-              "wordWithMilestones": "{label}: +{xp} EXP ({milestones})",
-              "milestoneEntry": "x{combo}+{bonus}",
-              "milestoneSeparator": "、",
-              "accuracyLabel": "精度ボーナス ({accuracyPercent}%)",
-              "accuracy": "{label}: +{xp} EXP",
-              "generic": "+{xp} EXP"
-            },
-            "toasts": {
-              "start": "60秒チャレンジ開始！がんばって！",
-              "mistype": "ミスタイプ！",
-              "completeBeforeConfirm": "全文字をタイプしてから確定！",
-              "comboMilestone": "Combo x{combo}! +{bonus} EXP",
-              "comboSeparator": " / "
-            }
+            "description": "60秒タイプで正確さとスピードを競うタイピングチャレンジ"
           },
           "imperial_realm": {
             "name": "インペリアル・レルム",
@@ -13267,6 +13205,72 @@
         "sandboxDisabled": "探索モードに戻りました。",
         "sampleInserted": "サンプルコードを挿入しました。",
         "cleared": "入力をクリアしました。"
+      }
+    },
+    "miniGames": {
+      "typing": {
+        "controls": {
+          "difficulty": "難易度",
+          "target": "ターゲットWPM",
+          "targetValue": "{targetWpm} WPM",
+          "difficultyOptions": {
+            "easy": "EASY",
+            "normal": "NORMAL",
+            "hard": "HARD"
+          }
+        },
+        "words": {
+          "nextEmpty": "次: -",
+          "nextWithValue": "次: {word}"
+        },
+        "input": {
+          "placeholder": "表示された単語をタイプ（Space/Enterで確定）"
+        },
+        "buttons": {
+          "reset": "リセット",
+          "retry": "もう一度挑戦"
+        },
+        "stats": {
+          "labels": {
+            "accuracy": "ACC",
+            "wpm": "WPM",
+            "combo": "COMBO",
+            "sessionXp": "SESSION XP"
+          },
+          "targetInfo": {
+            "pending": "ターゲット {targetWpm} WPM / 達成度 -",
+            "active": "ターゲット {targetWpm} WPM / 達成度 {progress}%"
+          }
+        },
+        "result": {
+          "title": "RESULT",
+          "labels": {
+            "accuracy": "精度",
+            "wpm": "平均WPM",
+            "words": "正タイプ数",
+            "combo": "最高コンボ"
+          },
+          "wordsValue": "{count} 文字"
+        },
+        "xp": {
+          "title": "EXP 内訳",
+          "none": "EXPは獲得できませんでした",
+          "wordLabel": "単語 {index}",
+          "word": "{label}: +{xp} EXP",
+          "wordWithMilestones": "{label}: +{xp} EXP ({milestones})",
+          "milestoneEntry": "x{combo}+{bonus}",
+          "milestoneSeparator": "、",
+          "accuracyLabel": "精度ボーナス ({accuracyPercent}%)",
+          "accuracy": "{label}: +{xp} EXP",
+          "generic": "+{xp} EXP"
+        },
+        "toasts": {
+          "start": "60秒チャレンジ開始！がんばって！",
+          "mistype": "ミスタイプ！",
+          "completeBeforeConfirm": "全文字をタイプしてから確定！",
+          "comboMilestone": "Combo x{combo}! +{bonus} EXP",
+          "comboSeparator": " / "
+        }
       }
     },
     "games": {


### PR DESCRIPTION
## Summary
- move typing challenge locale entries from the selection menu tree into the miniGames namespace used at runtime
- keep the selection menu metadata while exposing typing challenge UI strings for English and Japanese locales

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ea015d9b44832b93d9ff60351bb871