### PR TITLE
Fix Virus Buster localization namespace

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -874,27 +874,7 @@
           },
           "virus_buster": {
             "name": "Virus Buster",
-            "description": "Stack capsules to match colors and wipe viruses for EXP.",
-            "title": "Virus Buster",
-            "hud": {
-              "level": "Level {level}",
-              "viruses": "Viruses {count}",
-              "cleared": "Cleared {count}",
-              "chainLabel": "{chain} Chain!",
-              "chainNice": "Nice!",
-              "chainVirus": "Virus x{count}",
-              "stageClear": "Stage Clear!",
-              "controls": "Controls: ←→ Move / ↓ Soft Drop / ↑ or X Rotate / Space Hard Drop / R Reset"
-            },
-            "floating": {
-              "drop": "DROP!",
-              "virus": "Virus x{count}",
-              "stageClear": "STAGE CLEAR!"
-            },
-            "status": {
-              "gameOver": "Game Over",
-              "restartHint": "Press R to restart"
-            }
+            "description": "Stack capsules to match colors and wipe viruses for EXP."
           },
           "sichuan": {
             "name": "Sichuan Puzzle",
@@ -11292,6 +11272,28 @@
           "mistake": "Correct answer: {answer}",
           "emptyAnswer": "Enter an answer before submitting",
           "invalidAnswer": "Please enter a number"
+        }
+      },
+      "virus_buster": {
+        "title": "Virus Buster",
+        "hud": {
+          "level": "Level {level}",
+          "viruses": "Viruses {count}",
+          "cleared": "Cleared {count}",
+          "chainLabel": "{chain} Chain!",
+          "chainNice": "Nice!",
+          "chainVirus": "Virus x{count}",
+          "stageClear": "Stage Clear!",
+          "controls": "Controls: ←→ Move / ↓ Soft Drop / ↑ or X Rotate / Space Hard Drop / R Reset"
+        },
+        "floating": {
+          "drop": "DROP!",
+          "virus": "Virus x{count}",
+          "stageClear": "STAGE CLEAR!"
+        },
+        "status": {
+          "gameOver": "Game Over",
+          "restartHint": "Press R to restart"
         }
       },
       "acchimuitehoi": {

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -874,27 +874,7 @@
           },
           "virus_buster": {
             "name": "ドクターマリオ風",
-            "description": "カプセルで4つ揃え！ウイルス退治でEXP獲得",
-            "title": "ドクターマリオ風",
-            "hud": {
-              "level": "レベル {level}",
-              "viruses": "ウイルス {count}",
-              "cleared": "除去数 {count}",
-              "chainLabel": "{chain}連鎖！",
-              "chainNice": "ナイス！",
-              "chainVirus": "ウイルス x{count}",
-              "stageClear": "ステージクリア！",
-              "controls": "操作: ←→移動 / ↓ソフトドロップ / ↑またはX回転 / Spaceハードドロップ / Rリセット"
-            },
-            "floating": {
-              "drop": "ドロップ！",
-              "virus": "ウイルス x{count}",
-              "stageClear": "ステージクリア！"
-            },
-            "status": {
-              "gameOver": "ゲームオーバー",
-              "restartHint": "Rでリスタート"
-            }
+            "description": "カプセルで4つ揃え！ウイルス退治でEXP獲得"
           },
           "sichuan": {
             "name": "四川省パズル",
@@ -11292,6 +11272,28 @@
           "mistake": "正解は {answer}",
           "emptyAnswer": "入力してから回答してください",
           "invalidAnswer": "数値で入力してください"
+        }
+      },
+      "virus_buster": {
+        "title": "ドクターマリオ風",
+        "hud": {
+          "level": "レベル {level}",
+          "viruses": "ウイルス {count}",
+          "cleared": "除去数 {count}",
+          "chainLabel": "{chain}連鎖！",
+          "chainNice": "ナイス！",
+          "chainVirus": "ウイルス x{count}",
+          "stageClear": "ステージクリア！",
+          "controls": "操作: ←→移動 / ↓ソフトドロップ / ↑またはX回転 / Spaceハードドロップ / Rリセット"
+        },
+        "floating": {
+          "drop": "ドロップ！",
+          "virus": "ウイルス x{count}",
+          "stageClear": "ステージクリア！"
+        },
+        "status": {
+          "gameOver": "ゲームオーバー",
+          "restartHint": "Rでリスタート"
         }
       },
       "acchimuitehoi": {


### PR DESCRIPTION
## Summary
- move the Virus Buster UI strings from the miniexp catalog namespace to minigame.virus_buster
- ensure both English and Japanese locale files expose the in-game HUD, floating text, and status labels under the keys resolved by the mini-game runtime

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ea01678100832b8e178d9c12c78362