### PR TITLE
Fix run-all selector for localized tests

### DIFF
--- a/games/tester.js
+++ b/games/tester.js
@@ -808,6 +808,7 @@
       TEST_DEFS.forEach(def => {
         const item = document.createElement('div');
         item.className = 'mini-tester-test-item';
+        item.dataset.testId = def.id;
 
         const title = document.createElement('strong');
         if (def.nameKey) {
@@ -860,7 +861,7 @@
       async function runAllTests() {
         for (const def of TEST_DEFS) {
           if (destroyed) return;
-          const entry = [...list.children].find(child => child.querySelector('strong').textContent === def.name);
+          const entry = list.querySelector(`[data-test-id="${def.id}"]`);
           if (!entry) continue;
           const btn = entry.querySelector('button');
           const resultEl = entry.querySelector('.mini-tester-test-result');


### PR DESCRIPTION
## Summary
- tag each tester entry with its test definition id so it can be selected reliably
- update the run-all loop to locate entries by data attribute instead of translated text, restoring functionality in all locales

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ea01711800832b892152cc83acbc36