### PR TITLE
Fix rare chest modal localization keys

### DIFF
--- a/index.html
+++ b/index.html
@@ -1337,14 +1337,14 @@
 
     <div id="rare-chest-modal" class="modal modal--rare-chest" style="display:none;" aria-hidden="true">
         <div class="modal-content rare-chest-modal__content">
-            <h3 data-i18n="game.goldenChest.modal.title">黄金の宝箱</h3>
-            <p id="rare-chest-status" class="rare-chest-status" data-i18n="game.goldenChest.modal.status">タイミングバーを中央で止めよう！（Space/Enter）</p>
+            <h3 data-i18n="game.events.goldenChest.modal.title">黄金の宝箱</h3>
+            <p id="rare-chest-status" class="rare-chest-status" data-i18n="game.events.goldenChest.modal.status">タイミングバーを中央で止めよう！（Space/Enter）</p>
             <div class="rare-chest-bar">
                 <div class="rare-chest-bar__target"></div>
                 <div id="rare-chest-pointer" class="rare-chest-bar__pointer"></div>
             </div>
-            <button id="rare-chest-stop" class="rare-chest-stop-btn" data-i18n="game.goldenChest.modal.stop">ストップ</button>
-            <p class="rare-chest-hint" data-i18n="game.goldenChest.modal.hint">Space / Enter キーでも止められます。</p>
+            <button id="rare-chest-stop" class="rare-chest-stop-btn" data-i18n="game.events.goldenChest.modal.stop">ストップ</button>
+            <p class="rare-chest-hint" data-i18n="game.events.goldenChest.modal.hint">Space / Enter キーでも止められます。</p>
         </div>
     </div>
 

--- a/main.js
+++ b/main.js
@@ -16095,7 +16095,7 @@ function startRareChestMinigame(chest) {
     rareChestState.pendingEnemyTurn = true;
     updateRareChestPointerVisual();
     const statusText = translateOrFallback(
-        'game.goldenChest.modal.status',
+        'game.events.goldenChest.modal.status',
         'タイミングバーを中央で止めよう！（Space/Enter）'
     );
     setRareChestStatus(statusText);


### PR DESCRIPTION
## Summary
- correct the golden chest modal translation keys to live under game.events
- ensure the rare chest status text uses the proper localization path

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ea087bd960832bb2dfea7dff4dfa8c