### PR TITLE
Fix Xiangqi mini-game localization strings

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -440,7 +440,49 @@
           },
           "xiangqi": {
             "name": "Xiangqi",
-            "description": "Command Chinese chess pieces, scoring EXP for captures, checks, and mates."
+            "description": "Command Chinese chess pieces, scoring EXP for captures, checks, and mates.",
+            "header": {
+              "title": "Xiangqi",
+              "subtitle": "{color} moves first"
+            },
+            "controls": {
+              "reset": "Reset position"
+            },
+            "board": {
+              "riverLabel": "Chu River  Han Border"
+            },
+            "color": {
+              "red": "Red",
+              "black": "Black",
+              "redPlayer": "Red (Bottom)",
+              "blackPlayer": "Black (Top)"
+            },
+            "pieces": {
+              "general": "General",
+              "advisor": "Advisor",
+              "elephant": "Elephant",
+              "horse": "Horse",
+              "chariot": "Chariot",
+              "cannon": "Cannon",
+              "soldier": "Soldier"
+            },
+            "expLabel": "EXP",
+            "piece": {
+              "description": "{color} {piece}"
+            },
+            "status": {
+              "turnLine": "Turn: {turn}",
+              "turn": {
+                "red": "It is {color}'s move.",
+                "black": "It is {color}'s move."
+              },
+              "scoreLine": "Total score: {score}",
+              "capture": "{actor} captured {target} (+{exp}{expLabel})",
+              "move": "{piece} moved.",
+              "win": "{loser} is checkmated. {winner} wins!",
+              "stalemate": "Stalemate (no legal moves).",
+              "check": "{defender} is in check (+{exp}{expLabel})"
+            }
           },
           "shogi": {
             "name": "Shogi",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -440,7 +440,49 @@
           },
           "xiangqi": {
             "name": "シャンチー",
-            "description": "中国の将棋・象棋。駒取り・王手・詰みでEXPを稼ごう"
+            "description": "中国の将棋・象棋。駒取り・王手・詰みでEXPを稼ごう",
+            "header": {
+              "title": "シャンチー",
+              "subtitle": "{color}が先手"
+            },
+            "controls": {
+              "reset": "初期配置に戻す"
+            },
+            "board": {
+              "riverLabel": "楚河　漢界"
+            },
+            "color": {
+              "red": "赤",
+              "black": "黒",
+              "redPlayer": "赤（下）",
+              "blackPlayer": "黒（上）"
+            },
+            "pieces": {
+              "general": "将",
+              "advisor": "士",
+              "elephant": "象",
+              "horse": "馬",
+              "chariot": "車",
+              "cannon": "砲",
+              "soldier": "卒"
+            },
+            "expLabel": "EXP",
+            "piece": {
+              "description": "{color}の{piece}"
+            },
+            "status": {
+              "turnLine": "手番: {turn}",
+              "turn": {
+                "red": "{color}の番です",
+                "black": "{color}の番です"
+              },
+              "scoreLine": "合計スコア: {score}",
+              "capture": "{actor}が{target}を取りました (+{exp}{expLabel})",
+              "move": "{piece}が移動しました",
+              "win": "{loser}が詰みました。{winner}の勝利！",
+              "stalemate": "持将軍（合法手がありません）",
+              "check": "{defender}が王手を受けています (+{exp}{expLabel})"
+            }
           },
           "shogi": {
             "name": "将棋",


### PR DESCRIPTION
## Summary
- add localized labels for the Xiangqi mini-game UI in Japanese and English
- cover piece names, status messages, and static headers with translatable strings

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ea0e373988832ba42ebe52361057de