### PR TITLE
Balance block counts for lightweight dungeon addons

### DIFF
--- a/dungeontypes/axis_gallery.js
+++ b/dungeontypes/axis_gallery.js
@@ -106,6 +106,26 @@
         depth: +2,
         chest: 'more',
         type: 'axis-gallery'
+      },
+      {
+        key: 'axis_gallery_c',
+        name: '方位の回廊',
+        nameKey: "dungeon.types.axis_gallery.blocks.axis_gallery_c.name",
+        level: +22,
+        size: +1,
+        depth: +2,
+        chest: 'normal',
+        type: 'axis-gallery'
+      },
+      {
+        key: 'axis_gallery_d',
+        name: '均衡展示室',
+        nameKey: "dungeon.types.axis_gallery.blocks.axis_gallery_d.name",
+        level: +26,
+        size: +2,
+        depth: +3,
+        chest: 'rich',
+        type: 'axis-gallery'
       }
     ],
     blocks2: [
@@ -117,6 +137,36 @@
         size: +1,
         depth: +2,
         chest: 'rich',
+        type: 'axis-gallery'
+      },
+      {
+        key: 'axis_gallery_cross',
+        name: '交差展示廊',
+        nameKey: "dungeon.types.axis_gallery.blocks.axis_gallery_cross.name",
+        level: +30,
+        size: +1,
+        depth: +2,
+        chest: 'more',
+        type: 'axis-gallery'
+      },
+      {
+        key: 'axis_gallery_hub',
+        name: '連結の中心',
+        nameKey: "dungeon.types.axis_gallery.blocks.axis_gallery_hub.name",
+        level: +32,
+        size: +2,
+        depth: +3,
+        chest: 'rich',
+        type: 'axis-gallery'
+      },
+      {
+        key: 'axis_gallery_reflect',
+        name: '鏡写しの回廊',
+        nameKey: "dungeon.types.axis_gallery.blocks.axis_gallery_reflect.name",
+        level: +34,
+        size: +2,
+        depth: +3,
+        chest: 'rare',
         type: 'axis-gallery'
       }
     ],
@@ -131,6 +181,39 @@
         chest: 'rich',
         type: 'axis-gallery',
         bossFloors: [7, 14]
+      },
+      {
+        key: 'axis_gallery_relic',
+        name: '軸心の聖遺',
+        nameKey: "dungeon.types.axis_gallery.blocks.axis_gallery_relic.name",
+        level: +38,
+        size: +2,
+        depth: +3,
+        chest: 'rich',
+        type: 'axis-gallery',
+        bossFloors: [10, 18]
+      },
+      {
+        key: 'axis_gallery_sanctum',
+        name: '静謐の至堂',
+        nameKey: "dungeon.types.axis_gallery.blocks.axis_gallery_sanctum.name",
+        level: +42,
+        size: +3,
+        depth: +4,
+        chest: 'rare',
+        type: 'axis-gallery',
+        bossFloors: [14]
+      },
+      {
+        key: 'axis_gallery_vault',
+        name: '軸封の宝庫',
+        nameKey: "dungeon.types.axis_gallery.blocks.axis_gallery_vault.name",
+        level: +46,
+        size: +3,
+        depth: +4,
+        chest: 'legendary',
+        type: 'axis-gallery',
+        bossFloors: [21]
       }
     ]
   };

--- a/dungeontypes/conveyor_foundry.js
+++ b/dungeontypes/conveyor_foundry.js
@@ -96,6 +96,26 @@
         depth: +2,
         chest: 'less',
         type: 'conveyor-foundry'
+      },
+      {
+        key: 'conveyor_foundry_c',
+        name: '歯車整備室',
+        nameKey: "dungeon.types.conveyor_foundry.blocks.conveyor_foundry_c.name",
+        level: +20,
+        size: +1,
+        depth: +2,
+        chest: 'normal',
+        type: 'conveyor-foundry'
+      },
+      {
+        key: 'conveyor_foundry_d',
+        name: '試験炉通路',
+        nameKey: "dungeon.types.conveyor_foundry.blocks.conveyor_foundry_d.name",
+        level: +24,
+        size: +2,
+        depth: +3,
+        chest: 'more',
+        type: 'conveyor-foundry'
       }
     ],
     blocks2: [
@@ -107,6 +127,36 @@
         size: +1,
         depth: +2,
         chest: 'more',
+        type: 'conveyor-foundry'
+      },
+      {
+        key: 'conveyor_foundry_press',
+        name: '油圧プレス区画',
+        nameKey: "dungeon.types.conveyor_foundry.blocks.conveyor_foundry_press.name",
+        level: +28,
+        size: +1,
+        depth: +2,
+        chest: 'rich',
+        type: 'conveyor-foundry'
+      },
+      {
+        key: 'conveyor_foundry_smelter',
+        name: '連続溶解炉',
+        nameKey: "dungeon.types.conveyor_foundry.blocks.conveyor_foundry_smelter.name",
+        level: +30,
+        size: +2,
+        depth: +3,
+        chest: 'rich',
+        type: 'conveyor-foundry'
+      },
+      {
+        key: 'conveyor_foundry_dispatch',
+        name: '出荷ヤード',
+        nameKey: "dungeon.types.conveyor_foundry.blocks.conveyor_foundry_dispatch.name",
+        level: +32,
+        size: +2,
+        depth: +3,
+        chest: 'rare',
         type: 'conveyor-foundry'
       }
     ],
@@ -121,6 +171,39 @@
         chest: 'rich',
         type: 'conveyor-foundry',
         bossFloors: [6, 12]
+      },
+      {
+        key: 'conveyor_foundry_overseer',
+        name: '監督塔制御盤',
+        nameKey: "dungeon.types.conveyor_foundry.blocks.conveyor_foundry_overseer.name",
+        level: +36,
+        size: +2,
+        depth: +3,
+        chest: 'rich',
+        type: 'conveyor-foundry',
+        bossFloors: [9, 15]
+      },
+      {
+        key: 'conveyor_foundry_vault',
+        name: '資材保管庫',
+        nameKey: "dungeon.types.conveyor_foundry.blocks.conveyor_foundry_vault.name",
+        level: +40,
+        size: +3,
+        depth: +4,
+        chest: 'rare',
+        type: 'conveyor-foundry',
+        bossFloors: [12]
+      },
+      {
+        key: 'conveyor_foundry_reactor',
+        name: '炉心反応層',
+        nameKey: "dungeon.types.conveyor_foundry.blocks.conveyor_foundry_reactor.name",
+        level: +44,
+        size: +3,
+        depth: +4,
+        chest: 'legendary',
+        type: 'conveyor-foundry',
+        bossFloors: [18]
       }
     ]
   };

--- a/dungeontypes/irradiated_plains.js
+++ b/dungeontypes/irradiated_plains.js
@@ -95,6 +95,28 @@
         chest:'less',
         type:'irradiated-plains',
         bossFloors:mkBoss(12)
+      },
+      {
+        key:'irradiated_theme_03',
+        name:'Fallout Plains III',
+        nameKey: "dungeon.types.irradiated_plains.blocks.irradiated_theme_03.name",
+        level:+18,
+        size:+1,
+        depth:+2,
+        chest:'normal',
+        type:'irradiated-plains',
+        bossFloors:mkBoss(14)
+      },
+      {
+        key:'irradiated_theme_04',
+        name:'Fallout Plains IV',
+        nameKey: "dungeon.types.irradiated_plains.blocks.irradiated_theme_04.name",
+        level:+22,
+        size:+2,
+        depth:+3,
+        chest:'more',
+        type:'irradiated-plains',
+        bossFloors:mkBoss(16)
       }
     ],
     blocks2: [
@@ -106,6 +128,36 @@
         size:+1,
         depth:+1,
         chest:'normal',
+        type:'irradiated-plains'
+      },
+      {
+        key:'irradiated_core_02',
+        name:'Toxic Heart',
+        nameKey: "dungeon.types.irradiated_plains.blocks.irradiated_core_02.name",
+        level:+16,
+        size:+1,
+        depth:+2,
+        chest:'more',
+        type:'irradiated-plains'
+      },
+      {
+        key:'irradiated_core_03',
+        name:'Fission Ward',
+        nameKey: "dungeon.types.irradiated_plains.blocks.irradiated_core_03.name",
+        level:+20,
+        size:+2,
+        depth:+2,
+        chest:'rich',
+        type:'irradiated-plains'
+      },
+      {
+        key:'irradiated_core_04',
+        name:'Glow Hub',
+        nameKey: "dungeon.types.irradiated_plains.blocks.irradiated_core_04.name",
+        level:+24,
+        size:+2,
+        depth:+3,
+        chest:'rare',
         type:'irradiated-plains'
       }
     ],
@@ -120,6 +172,39 @@
         chest:'more',
         type:'irradiated-plains',
         bossFloors:[6,12]
+      },
+      {
+        key:'irradiated_relic_02',
+        name:'Core Containment',
+        nameKey: "dungeon.types.irradiated_plains.blocks.irradiated_relic_02.name",
+        level:+24,
+        size:+2,
+        depth:+3,
+        chest:'rich',
+        type:'irradiated-plains',
+        bossFloors:[9,15]
+      },
+      {
+        key:'irradiated_relic_03',
+        name:'Fallout Vault',
+        nameKey: "dungeon.types.irradiated_plains.blocks.irradiated_relic_03.name",
+        level:+28,
+        size:+3,
+        depth:+4,
+        chest:'rare',
+        type:'irradiated-plains',
+        bossFloors:[12,18]
+      },
+      {
+        key:'irradiated_relic_04',
+        name:'Gamma Sanctum',
+        nameKey: "dungeon.types.irradiated_plains.blocks.irradiated_relic_04.name",
+        level:+32,
+        size:+3,
+        depth:+4,
+        chest:'legendary',
+        type:'irradiated-plains',
+        bossFloors:[20]
       }
     ]
   };

--- a/dungeontypes/oneway_labyrinth.js
+++ b/dungeontypes/oneway_labyrinth.js
@@ -120,6 +120,26 @@
         depth: +2,
         chest: 'more',
         type: 'oneway-labyrinth'
+      },
+      {
+        key: 'oneway_labyrinth_c',
+        name: '渦巻きの縁',
+        nameKey: "dungeon.types.oneway_labyrinth.blocks.oneway_labyrinth_c.name",
+        level: +24,
+        size: +1,
+        depth: +2,
+        chest: 'normal',
+        type: 'oneway-labyrinth'
+      },
+      {
+        key: 'oneway_labyrinth_d',
+        name: '順行の要塞',
+        nameKey: "dungeon.types.oneway_labyrinth.blocks.oneway_labyrinth_d.name",
+        level: +28,
+        size: +2,
+        depth: +3,
+        chest: 'rich',
+        type: 'oneway-labyrinth'
       }
     ],
     blocks2: [
@@ -131,6 +151,36 @@
         size: +1,
         depth: +2,
         chest: 'rich',
+        type: 'oneway-labyrinth'
+      },
+      {
+        key: 'oneway_labyrinth_cross',
+        name: '矢路の交点',
+        nameKey: "dungeon.types.oneway_labyrinth.blocks.oneway_labyrinth_cross.name",
+        level: +32,
+        size: +1,
+        depth: +2,
+        chest: 'rich',
+        type: 'oneway-labyrinth'
+      },
+      {
+        key: 'oneway_labyrinth_loop',
+        name: '無限輪路',
+        nameKey: "dungeon.types.oneway_labyrinth.blocks.oneway_labyrinth_loop.name",
+        level: +34,
+        size: +2,
+        depth: +3,
+        chest: 'rare',
+        type: 'oneway-labyrinth'
+      },
+      {
+        key: 'oneway_labyrinth_gate',
+        name: '逆行の門',
+        nameKey: "dungeon.types.oneway_labyrinth.blocks.oneway_labyrinth_gate.name",
+        level: +36,
+        size: +2,
+        depth: +3,
+        chest: 'rare',
         type: 'oneway-labyrinth'
       }
     ],
@@ -145,6 +195,39 @@
         chest: 'rich',
         type: 'oneway-labyrinth',
         bossFloors: [8, 16]
+      },
+      {
+        key: 'oneway_labyrinth_relic',
+        name: '矢導の聖所',
+        nameKey: "dungeon.types.oneway_labyrinth.blocks.oneway_labyrinth_relic.name",
+        level: +40,
+        size: +2,
+        depth: +3,
+        chest: 'rich',
+        type: 'oneway-labyrinth',
+        bossFloors: [10, 18]
+      },
+      {
+        key: 'oneway_labyrinth_sanctum',
+        name: '方向の祭室',
+        nameKey: "dungeon.types.oneway_labyrinth.blocks.oneway_labyrinth_sanctum.name",
+        level: +44,
+        size: +3,
+        depth: +4,
+        chest: 'rare',
+        type: 'oneway-labyrinth',
+        bossFloors: [12, 20]
+      },
+      {
+        key: 'oneway_labyrinth_maestro',
+        name: '迷宮指揮塔',
+        nameKey: "dungeon.types.oneway_labyrinth.blocks.oneway_labyrinth_maestro.name",
+        level: +48,
+        size: +3,
+        depth: +4,
+        chest: 'legendary',
+        type: 'oneway-labyrinth',
+        bossFloors: [24]
       }
     ]
   };

--- a/dungeontypes/sandstorm_desert.js
+++ b/dungeontypes/sandstorm_desert.js
@@ -101,6 +101,28 @@
         chest:'normal',
         type:'sandstorm-dunes',
         bossFloors:mkBoss(10)
+      },
+      {
+        key:'sandstorm_theme_03',
+        name:'Sandstorm Theme III',
+        nameKey: "dungeon.types.sandstorm_dunes.blocks.sandstorm_theme_03.name",
+        level:+16,
+        size:+1,
+        depth:+2,
+        chest:'normal',
+        type:'sandstorm-dunes',
+        bossFloors:mkBoss(12)
+      },
+      {
+        key:'sandstorm_theme_04',
+        name:'Sandstorm Theme IV',
+        nameKey: "dungeon.types.sandstorm_dunes.blocks.sandstorm_theme_04.name",
+        level:+20,
+        size:+2,
+        depth:+3,
+        chest:'more',
+        type:'sandstorm-dunes',
+        bossFloors:mkBoss(14)
       }
     ],
     blocks2: [
@@ -112,6 +134,36 @@
         size:+1,
         depth:0,
         chest:'normal',
+        type:'sandstorm-dunes'
+      },
+      {
+        key:'sandstorm_core_02',
+        name:'Mirage Nexus',
+        nameKey: "dungeon.types.sandstorm_dunes.blocks.sandstorm_core_02.name",
+        level:+8,
+        size:+1,
+        depth:+1,
+        chest:'more',
+        type:'sandstorm-dunes'
+      },
+      {
+        key:'sandstorm_core_03',
+        name:'Shifting Basin',
+        nameKey: "dungeon.types.sandstorm_dunes.blocks.sandstorm_core_03.name",
+        level:+14,
+        size:+2,
+        depth:+2,
+        chest:'rich',
+        type:'sandstorm-dunes'
+      },
+      {
+        key:'sandstorm_core_04',
+        name:'Storm Shelter',
+        nameKey: "dungeon.types.sandstorm_dunes.blocks.sandstorm_core_04.name",
+        level:+18,
+        size:+2,
+        depth:+3,
+        chest:'rare',
         type:'sandstorm-dunes'
       }
     ],
@@ -126,6 +178,39 @@
         chest:'more',
         type:'sandstorm-dunes',
         bossFloors:[9,13]
+      },
+      {
+        key:'sandstorm_relic_02',
+        name:'Dune Oracle',
+        nameKey: "dungeon.types.sandstorm_dunes.blocks.sandstorm_relic_02.name",
+        level:+22,
+        size:+2,
+        depth:+3,
+        chest:'rich',
+        type:'sandstorm-dunes',
+        bossFloors:[11,15]
+      },
+      {
+        key:'sandstorm_relic_03',
+        name:'Oasis Vault',
+        nameKey: "dungeon.types.sandstorm_dunes.blocks.sandstorm_relic_03.name",
+        level:+26,
+        size:+2,
+        depth:+4,
+        chest:'rare',
+        type:'sandstorm-dunes',
+        bossFloors:[13,17]
+      },
+      {
+        key:'sandstorm_relic_04',
+        name:'Golden Tempest',
+        nameKey: "dungeon.types.sandstorm_dunes.blocks.sandstorm_relic_04.name",
+        level:+30,
+        size:+3,
+        depth:+4,
+        chest:'legendary',
+        type:'sandstorm-dunes',
+        bossFloors:[20]
       }
     ]
   };


### PR DESCRIPTION
## Summary
- expand the Axis Gallery Pack block tables so each tier now offers four room variants
- add matching tier depth for Conveyor Foundry, Irradiated Plains, Sandstorm Dunes, and One-Way Labyrinth packs
- align lightweight add-ons with the standard four-block-per-tier structure for better balance

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ea0fd8baf8832b8db6a5bb055ecba2