### PR TITLE
Fix Mancala localization support

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -11496,6 +11496,59 @@
           "check": "{defender} is in check (+{exp}{expLabel})"
         }
       },
+      "mancala": {
+        "actions": {
+          "restart": "Restart",
+          "hint": "Hint"
+        },
+        "hud": {
+          "score": {
+            "player": "You",
+            "ai": "AI",
+            "separator": ": "
+          }
+        },
+        "board": {
+          "store": {
+            "player": "You",
+            "ai": "AI"
+          },
+          "pitLabel": {
+            "player": "You {index}",
+            "ai": "AI {index}"
+          }
+        },
+        "status": {
+          "start": "Your turn — choose a pit to sow.",
+          "extraTurn": {
+            "player": "Extra turn! Pick another pit.",
+            "ai": "The AI gained another turn…"
+          },
+          "turn": {
+            "player": "Your turn",
+            "aiThinking": "AI is thinking…"
+          },
+          "result": {
+            "draw": "Draw! {player} to {ai}",
+            "win": "Victory! {player} to {ai}",
+            "loss": "Defeat… {player} to {ai}"
+          },
+          "hint": "Hint: Pit {pit} looks promising"
+        },
+        "history": {
+          "who": {
+            "player": "You",
+            "ai": "AI"
+          },
+          "entry": {
+            "pit": "Pit {number}",
+            "store": "Store +{amount}",
+            "capture": "Capture {amount}",
+            "extraTurn": "Extra turn",
+            "separator": " / "
+          }
+        }
+      },
       "system": {
         "header": {
           "title": "System Inspector",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -11496,6 +11496,59 @@
           "check": "{defender}が王手を受けています (+{exp}{expLabel})"
         }
       },
+      "mancala": {
+        "actions": {
+          "restart": "リスタート",
+          "hint": "ヒント"
+        },
+        "hud": {
+          "score": {
+            "player": "あなた",
+            "ai": "AI",
+            "separator": "："
+          }
+        },
+        "board": {
+          "store": {
+            "player": "あなた",
+            "ai": "AI"
+          },
+          "pitLabel": {
+            "player": "自{index}",
+            "ai": "AI{index}"
+          }
+        },
+        "status": {
+          "start": "あなたのターン ― 種をまく穴を選んでください",
+          "extraTurn": {
+            "player": "追加ターン！別の穴を選びましょう。",
+            "ai": "AIがもう一度ターンを獲得しました…"
+          },
+          "turn": {
+            "player": "あなたのターン",
+            "aiThinking": "AIが考えています…"
+          },
+          "result": {
+            "draw": "引き分け！ {player} 対 {ai}",
+            "win": "勝利！ {player} 対 {ai}",
+            "loss": "敗北… {player} 対 {ai}"
+          },
+          "hint": "ヒント: 穴{pit}が有望です"
+        },
+        "history": {
+          "who": {
+            "player": "あなた",
+            "ai": "AI"
+          },
+          "entry": {
+            "pit": "穴{number}",
+            "store": "ストア +{amount}",
+            "capture": "捕獲 {amount}",
+            "extraTurn": "追加ターン",
+            "separator": " ／ "
+          }
+        }
+      },
       "system": {
         "header": {
           "title": "システムユーティリティ",


### PR DESCRIPTION
## Summary
- add mancala-specific strings to the English locale for HUD labels, statuses, and history entries
- add matching mancala strings to the Japanese locale so translations resolve correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ea12b5997c832bb232f134e4bcbf25