### PR TITLE
Fix SameGame popup localization

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -12927,6 +12927,21 @@
           "hard": "Hard"
         }
       },
+      "same": {
+        "hud": {
+          "title": "SameGame",
+          "removed": "Removed",
+          "status": "{title} | {difficulty} | {removedLabel}: {removed}"
+        },
+        "difficulty": {
+          "easy": "Easy",
+          "normal": "Normal",
+          "hard": "Hard"
+        },
+        "hint": {
+          "popup": "Group of {size} / +{expFormatted} EXP"
+        }
+      },
       "piano_tiles": {
         "tips": "Tap lanes or press D/F/J/K keys, and hold for long notes.",
         "hud": {

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -12927,6 +12927,21 @@
           "hard": "むずかしい"
         }
       },
+      "same": {
+        "hud": {
+          "title": "セイムゲーム",
+          "removed": "消去数",
+          "status": "{title} | {difficulty} | {removedLabel}: {removed}"
+        },
+        "difficulty": {
+          "easy": "かんたん",
+          "normal": "ふつう",
+          "hard": "むずかしい"
+        },
+        "hint": {
+          "popup": "{size}個 / 予想+{expFormatted}EXP"
+        }
+      },
       "piano_tiles": {
         "tips": "タップ or D/F/J/Kキーでレーンを叩き、長いノーツは離さずにホールド。",
         "hud": {


### PR DESCRIPTION
## Summary
- add SameGame HUD and hint translation entries to the English locale bundle
- add matching SameGame translations to the Japanese locale bundle so the popup localizes correctly

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ea1317ebf4832baef445b86760c2c2