### PR TITLE
Fix localization keys for Ultimate Tic-Tac-Toe

### DIFF
--- a/games/ultimate_ttt.js
+++ b/games/ultimate_ttt.js
@@ -69,14 +69,14 @@
   }
 
   const TEXT = {
-    statusPlayer: message('miniExp.ultimateTtt.status.player', 'あなたの番'),
-    statusAi: message('miniExp.ultimateTtt.status.ai', 'AIの番'),
-    statusEnded: message('miniExp.ultimateTtt.status.ended', 'ゲーム終了'),
-    activeBoard: message('miniExp.ultimateTtt.activeBoard', '指定盤: ({x}, {y})'),
-    restartHint: message('miniExp.ultimateTtt.overlay.restartHint', 'Rキーで再開できます'),
-    resultPlayerWin: message('miniExp.ultimateTtt.result.playerWin', 'あなたの勝ち！'),
-    resultAiWin: message('miniExp.ultimateTtt.result.aiWin', 'AIの勝ち…'),
-    resultDraw: message('miniExp.ultimateTtt.result.draw', '引き分け'),
+    statusPlayer: message('game.miniExp.ultimateTtt.status.player', 'あなたの番'),
+    statusAi: message('game.miniExp.ultimateTtt.status.ai', 'AIの番'),
+    statusEnded: message('game.miniExp.ultimateTtt.status.ended', 'ゲーム終了'),
+    activeBoard: message('game.miniExp.ultimateTtt.activeBoard', '指定盤: ({x}, {y})'),
+    restartHint: message('game.miniExp.ultimateTtt.overlay.restartHint', 'Rキーで再開できます'),
+    resultPlayerWin: message('game.miniExp.ultimateTtt.result.playerWin', 'あなたの勝ち！'),
+    resultAiWin: message('game.miniExp.ultimateTtt.result.aiWin', 'AIの勝ち…'),
+    resultDraw: message('game.miniExp.ultimateTtt.result.draw', '引き分け'),
   };
 
   function lineThreat(values, color){


### PR DESCRIPTION
## Summary
- update the Ultimate Tic-Tac-Toe mini game to use the correct game.miniExp translation namespace so localized strings resolve

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ea1394e334832ba2d02e7792684a25