### PR TITLE
Fix 2048 setup localization

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -702,7 +702,12 @@
           },
           "game2048": {
             "name": "2048",
-            "description": "Merge tiles toward 2048, earning EXP based on log2 sums."
+            "description": "Merge tiles toward 2048, earning EXP based on log2 sums.",
+            "setup": {
+              "sizeLabel": "Board size: ",
+              "startButton": "Start",
+              "boardSizeOption": "{size}×{size}"
+            }
           },
           "todo_list": {
             "name": "To-Do List",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -702,7 +702,12 @@
           },
           "game2048": {
             "name": "2048",
-            "description": "合成log2 / 2048で+777"
+            "description": "合成log2 / 2048で+777",
+            "setup": {
+              "sizeLabel": "盤面サイズ: ",
+              "startButton": "開始",
+              "boardSizeOption": "{size}×{size}"
+            }
           },
           "todo_list": {
             "name": "ToDoリスト",


### PR DESCRIPTION
## Summary
- add localized board size label, button text, and option formatting for the 2048 mini-game setup in English and Japanese

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ea178c455c832bbf9ce3283f590aa4