### PR TITLE
Fix Diagram Maker locale definitions

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -15079,71 +15079,6 @@
           "timerComplete": "Timer finished!"
         }
       },
-      "diagramMaker": {
-        "errors": {
-          "containerMissing": "MiniExp Diagram Maker requires a container",
-          "pngSignature": "Unable to recognize PNG signature",
-          "pngDataMissing": "No draw.io data found inside the PNG",
-          "inflateUnsupported": "This environment does not support inflating compressed data",
-          "parseXml": "Failed to parse XML",
-          "diagramMissing": "No diagram element found",
-          "mxGraphMissing": "No mxGraphModel element found",
-          "diagramDecodeFailed": "Failed to decode diagram data",
-          "mxGraphRootMissing": "mxGraphModel root element is missing",
-          "loadFailed": "Failed to load: {error}",
-          "saveFailed": "Failed to save: {error}",
-          "exportFailed": "Failed to export: {error}"
-        },
-        "defaults": {
-          "fileName": "Untitled Diagram.drawio",
-          "layerName": "Layer {index}",
-          "pageName": "Page {index}",
-          "textPlaceholder": "Text",
-          "nodePlaceholder": "New Node"
-        },
-        "tools": {
-          "select": "Select",
-          "rectangle": "Rectangle",
-          "ellipse": "Ellipse",
-          "text": "Text",
-          "connector": "Connector",
-          "delete": "Delete"
-        },
-        "actions": {
-          "new": "New",
-          "open": "Open",
-          "save": "Save",
-          "export": "Export",
-          "exportFormat": "Export as {formatLabel}",
-          "undo": "Undo",
-          "redo": "Redo"
-        },
-        "sections": {
-          "properties": "Properties"
-        },
-        "fields": {
-          "x": "X",
-          "y": "Y",
-          "width": "Width",
-          "height": "Height",
-          "fill": "Fill",
-          "stroke": "Stroke",
-          "strokeWidth": "Stroke Width",
-          "textColor": "Text Color",
-          "fontSize": "Font Size",
-          "text": "Text"
-        },
-        "toggles": {
-          "grid": "Grid",
-          "snap": "Snap"
-        },
-        "labels": {
-          "exp": "EXP: {value}"
-        },
-        "confirm": {
-          "newDocument": "You have unsaved changes. Create a new diagram?"
-        }
-      },
       "clockHub": {
         "errors": {
           "noContainer": "Clock Hub requires a container"
@@ -16068,8 +16003,73 @@
         }
       },
     },
-    "games": {
-      "sugorokuLife": {
+      "games": {
+        "diagramMaker": {
+          "errors": {
+            "containerMissing": "MiniExp Diagram Maker requires a container",
+            "pngSignature": "Unable to recognize PNG signature",
+            "pngDataMissing": "No draw.io data found inside the PNG",
+            "inflateUnsupported": "This environment does not support inflating compressed data",
+            "parseXml": "Failed to parse XML",
+            "diagramMissing": "No diagram element found",
+            "mxGraphMissing": "No mxGraphModel element found",
+            "diagramDecodeFailed": "Failed to decode diagram data",
+            "mxGraphRootMissing": "mxGraphModel root element is missing",
+            "loadFailed": "Failed to load: {error}",
+            "saveFailed": "Failed to save: {error}",
+            "exportFailed": "Failed to export: {error}"
+          },
+          "defaults": {
+            "fileName": "Untitled Diagram.drawio",
+            "layerName": "Layer {index}",
+            "pageName": "Page {index}",
+            "textPlaceholder": "Text",
+            "nodePlaceholder": "New Node"
+          },
+          "tools": {
+            "select": "Select",
+            "rectangle": "Rectangle",
+            "ellipse": "Ellipse",
+            "text": "Text",
+            "connector": "Connector",
+            "delete": "Delete"
+          },
+          "actions": {
+            "new": "New",
+            "open": "Open",
+            "save": "Save",
+            "export": "Export",
+            "exportFormat": "Export as {formatLabel}",
+            "undo": "Undo",
+            "redo": "Redo"
+          },
+          "sections": {
+            "properties": "Properties"
+          },
+          "fields": {
+            "x": "X",
+            "y": "Y",
+            "width": "Width",
+            "height": "Height",
+            "fill": "Fill",
+            "stroke": "Stroke",
+            "strokeWidth": "Stroke Width",
+            "textColor": "Text Color",
+            "fontSize": "Font Size",
+            "text": "Text"
+          },
+          "toggles": {
+            "grid": "Grid",
+            "snap": "Snap"
+          },
+          "labels": {
+            "exp": "EXP: {value}"
+          },
+          "confirm": {
+            "newDocument": "You have unsaved changes. Create a new diagram?"
+          }
+        },
+        "sugorokuLife": {
         "ui": {
           "currencySuffix": "G",
           "expUnit": "EXP",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -15083,71 +15083,6 @@
           "timerComplete": "タイマー完了！"
         }
       },
-      "diagramMaker": {
-        "errors": {
-          "containerMissing": "MiniExp Diagram Maker を表示するコンテナが必要です",
-          "pngSignature": "PNG署名を認識できませんでした",
-          "pngDataMissing": "PNG内にdraw.ioデータが見つかりませんでした",
-          "inflateUnsupported": "圧縮データの展開に対応していない環境です",
-          "parseXml": "XMLを解析できませんでした",
-          "diagramMissing": "diagram 要素が見つかりません",
-          "mxGraphMissing": "mxGraphModel が見つかりません",
-          "diagramDecodeFailed": "diagram データを展開できませんでした",
-          "mxGraphRootMissing": "mxGraphModel root が見つかりません",
-          "loadFailed": "読み込みに失敗しました: {error}",
-          "saveFailed": "保存に失敗しました: {error}",
-          "exportFailed": "書き出しに失敗しました: {error}"
-        },
-        "defaults": {
-          "fileName": "未保存の図.drawio",
-          "layerName": "レイヤー {index}",
-          "pageName": "ページ {index}",
-          "textPlaceholder": "テキスト",
-          "nodePlaceholder": "新しいノード"
-        },
-        "tools": {
-          "select": "選択",
-          "rectangle": "四角",
-          "ellipse": "楕円",
-          "text": "テキスト",
-          "connector": "コネクタ",
-          "delete": "削除"
-        },
-        "actions": {
-          "new": "新規",
-          "open": "開く",
-          "save": "保存",
-          "export": "書き出し",
-          "exportFormat": "{formatLabel} で書き出し",
-          "undo": "元に戻す",
-          "redo": "やり直す"
-        },
-        "sections": {
-          "properties": "プロパティ"
-        },
-        "fields": {
-          "x": "X",
-          "y": "Y",
-          "width": "幅",
-          "height": "高さ",
-          "fill": "塗り",
-          "stroke": "線",
-          "strokeWidth": "線幅",
-          "textColor": "文字色",
-          "fontSize": "文字サイズ",
-          "text": "テキスト"
-        },
-        "toggles": {
-          "grid": "グリッド",
-          "snap": "スナップ"
-        },
-        "labels": {
-          "exp": "EXP: {value}"
-        },
-        "confirm": {
-          "newDocument": "保存されていない変更があります。新規作成しますか？"
-        }
-      },
       "clockHub": {
         "errors": {
           "noContainer": "Clock Hubにはコンテナが必要です"
@@ -16072,8 +16007,73 @@
         }
       },
     },
-    "games": {
-      "sugorokuLife": {
+      "games": {
+        "diagramMaker": {
+          "errors": {
+            "containerMissing": "MiniExp Diagram Maker を表示するコンテナが必要です",
+            "pngSignature": "PNG署名を認識できませんでした",
+            "pngDataMissing": "PNG内にdraw.ioデータが見つかりませんでした",
+            "inflateUnsupported": "圧縮データの展開に対応していない環境です",
+            "parseXml": "XMLを解析できませんでした",
+            "diagramMissing": "diagram 要素が見つかりません",
+            "mxGraphMissing": "mxGraphModel が見つかりません",
+            "diagramDecodeFailed": "diagram データを展開できませんでした",
+            "mxGraphRootMissing": "mxGraphModel root が見つかりません",
+            "loadFailed": "読み込みに失敗しました: {error}",
+            "saveFailed": "保存に失敗しました: {error}",
+            "exportFailed": "書き出しに失敗しました: {error}"
+          },
+          "defaults": {
+            "fileName": "未保存の図.drawio",
+            "layerName": "レイヤー {index}",
+            "pageName": "ページ {index}",
+            "textPlaceholder": "テキスト",
+            "nodePlaceholder": "新しいノード"
+          },
+          "tools": {
+            "select": "選択",
+            "rectangle": "四角",
+            "ellipse": "楕円",
+            "text": "テキスト",
+            "connector": "コネクタ",
+            "delete": "削除"
+          },
+          "actions": {
+            "new": "新規",
+            "open": "開く",
+            "save": "保存",
+            "export": "書き出し",
+            "exportFormat": "{formatLabel} で書き出し",
+            "undo": "元に戻す",
+            "redo": "やり直す"
+          },
+          "sections": {
+            "properties": "プロパティ"
+          },
+          "fields": {
+            "x": "X",
+            "y": "Y",
+            "width": "幅",
+            "height": "高さ",
+            "fill": "塗り",
+            "stroke": "線",
+            "strokeWidth": "線幅",
+            "textColor": "文字色",
+            "fontSize": "文字サイズ",
+            "text": "テキスト"
+          },
+          "toggles": {
+            "grid": "グリッド",
+            "snap": "スナップ"
+          },
+          "labels": {
+            "exp": "EXP: {value}"
+          },
+          "confirm": {
+            "newDocument": "保存されていない変更があります。新規作成しますか？"
+          }
+        },
+        "sugorokuLife": {
         "ui": {
           "currencySuffix": "G",
           "expUnit": "EXP",


### PR DESCRIPTION
## Summary
- relocate the Diagram Maker translation blocks in both English and Japanese locale bundles into the active games section
- remove the duplicate earlier definitions that were being overwritten so lookups resolve correctly

## Testing
- node -e "global.__i18nLocales={}; require('./js/i18n/locales/en.json.js'); console.log(global.__i18nLocales.en.games.diagramMaker.actions.save);"
- node -e "global.__i18nLocales={}; require('./js/i18n/locales/ja.json.js'); console.log(global.__i18nLocales.ja.games.diagramMaker.actions.save);"

------
https://chatgpt.com/codex/tasks/task_e_68ea42d29c0c832b8b50120ea7c7be95