### PR TITLE
Add notepad localization strings to active locale dictionaries

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -16312,6 +16312,87 @@
           "paused": "Paused",
           "found": "Treasure found! Building the next round…"
         }
+      },
+      "notepad": {
+        "defaultFileName": "Untitled.txt",
+        "confirm": {
+          "discardChanges": "Discard changes and close?",
+          "newWithoutSaving": "Start a new file without saving changes?"
+        },
+        "menu": {
+          "file": "File",
+          "edit": "Edit",
+          "view": {
+            "label": "View",
+            "enableWordWrap": "Enable Word Wrap",
+            "disableWordWrap": "Disable Word Wrap",
+            "showStatusBar": "Show Status Bar",
+            "hideStatusBar": "Hide Status Bar"
+          },
+          "fileNew": "New",
+          "fileOpen": "Open...",
+          "fileSave": "Save",
+          "fileSaveAs": "Save As...",
+          "filePrint": "Print...",
+          "editUndo": "Undo",
+          "editRedo": "Redo",
+          "editCut": "Cut",
+          "editCopy": "Copy",
+          "editPaste": "Paste",
+          "editDelete": "Delete",
+          "editFind": "Find...",
+          "editReplace": "Replace...",
+          "editSelectAll": "Select All",
+          "viewZoomIn": "Zoom In",
+          "viewZoomOut": "Zoom Out",
+          "viewZoomReset": "Reset Zoom"
+        },
+        "commands": {
+          "heading": "Toggle heading level",
+          "bullet": "Toggle bullet list",
+          "bold": "Bold (Markdown)",
+          "italic": "Italic (Markdown)",
+          "underline": "Underline tag",
+          "wordWrap": "Toggle word wrap",
+          "zoomReset": "Reset zoom",
+          "settings": "Settings"
+        },
+        "settings": {
+          "title": "Settings",
+          "wordWrap": "Word wrap",
+          "statusBar": "Status bar",
+          "zoom": "Zoom",
+          "zoomReset": "Reset",
+          "insertTimestamp": "Insert timestamp"
+        },
+        "prompts": {
+          "search": "Enter text to find",
+          "saveFileName": "Enter a file name to save",
+          "replaceTarget": "Enter text to replace",
+          "replaceWith": "Enter replacement text"
+        },
+        "alerts": {
+          "searchNotFound": "No matches found.",
+          "replaceNotFound": "No occurrences found to replace.",
+          "fileReadFailed": "Failed to read the file.",
+          "printPopupBlocked": "Could not open the print window. Please allow pop-ups."
+        },
+        "print": {
+          "label": "Print",
+          "windowTitleFallback": "Notepad"
+        },
+        "status": {
+          "position": "Ln {line}, Col {column}",
+          "length": "{count} characters",
+          "typeText": "Text",
+          "lineEnding": {
+            "lf": "Unix (LF)",
+            "crlf": "Windows (CRLF)"
+          }
+        },
+        "timestamp": {
+          "pattern": "{month}/{day}/{year} {hour}:{minute}:{second}"
+        }
       }
     }
   };

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -16316,6 +16316,87 @@
           "paused": "一時停止中",
           "found": "宝を発見！次のラウンドを生成中…"
         }
+      },
+      "notepad": {
+        "defaultFileName": "タイトルなし.txt",
+        "confirm": {
+          "discardChanges": "変更を破棄して閉じますか？",
+          "newWithoutSaving": "変更を保存せずに新しいファイルを開きますか？"
+        },
+        "menu": {
+          "file": "ファイル",
+          "edit": "編集",
+          "view": {
+            "label": "表示",
+            "enableWordWrap": "折り返しを有効化",
+            "disableWordWrap": "折り返しを無効化",
+            "showStatusBar": "ステータスバーを表示",
+            "hideStatusBar": "ステータスバーを非表示"
+          },
+          "fileNew": "新規",
+          "fileOpen": "開く...",
+          "fileSave": "上書き保存",
+          "fileSaveAs": "名前を付けて保存...",
+          "filePrint": "印刷...",
+          "editUndo": "元に戻す",
+          "editRedo": "やり直し",
+          "editCut": "切り取り",
+          "editCopy": "コピー",
+          "editPaste": "貼り付け",
+          "editDelete": "削除",
+          "editFind": "検索...",
+          "editReplace": "置換...",
+          "editSelectAll": "すべて選択",
+          "viewZoomIn": "ズームイン",
+          "viewZoomOut": "ズームアウト",
+          "viewZoomReset": "ズームを既定に戻す"
+        },
+        "commands": {
+          "heading": "見出しを切り替え",
+          "bullet": "箇条書きを切り替え",
+          "bold": "太字 (Markdown)",
+          "italic": "斜体 (Markdown)",
+          "underline": "下線タグ",
+          "wordWrap": "折り返しを切り替え",
+          "zoomReset": "ズームを既定に戻す",
+          "settings": "設定"
+        },
+        "settings": {
+          "title": "設定",
+          "wordWrap": "折り返し",
+          "statusBar": "ステータスバー",
+          "zoom": "ズーム",
+          "zoomReset": "リセット",
+          "insertTimestamp": "日時を挿入"
+        },
+        "prompts": {
+          "search": "検索する文字列を入力してください",
+          "saveFileName": "保存するファイル名を入力してください",
+          "replaceTarget": "置換する文字列を入力してください",
+          "replaceWith": "置換後の文字列を入力してください"
+        },
+        "alerts": {
+          "searchNotFound": "見つかりませんでした。",
+          "replaceNotFound": "対象の文字列が見つかりませんでした。",
+          "fileReadFailed": "ファイルの読み込みに失敗しました。",
+          "printPopupBlocked": "印刷ウィンドウを開けませんでした。ポップアップを許可してください。"
+        },
+        "print": {
+          "label": "印刷",
+          "windowTitleFallback": "メモ帳"
+        },
+        "status": {
+          "position": "行 {line}, 列 {column}",
+          "length": "{count} 文字",
+          "typeText": "テキスト",
+          "lineEnding": {
+            "lf": "Unix (LF)",
+            "crlf": "Windows (CRLF)"
+          }
+        },
+        "timestamp": {
+          "pattern": "{year}-{month}-{day} {hour}:{minute}:{second}"
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- add the notepad locale entries to the Japanese dictionary so runtime lookups resolve translations
- mirror the notepad translations in the English locale so the mini-game text localizes in both languages

## Testing
- node - <<'NODE'
const fs=require('fs');const vm=require('vm');
const context={};context.global=context;context.window=context;
vm.runInNewContext(fs.readFileSync('js/i18n/locales/ja.json.js','utf8'),context);
vm.runInNewContext(fs.readFileSync('js/i18n/locales/en.json.js','utf8'),context);
const locales=context.__i18nLocales;
const text=fs.readFileSync('games/notepad.js','utf8');
const regex=/['\"](games\.notepad[^'\"\s]*)['\"]/g;
const keys=new Set();
let match;
while((match=regex.exec(text))){keys.add(match[1]);}
keys.add('selection.miniexp.games.notepad.name');
for(const [locale,data] of Object.entries(locales)){
  if(locale!=='ja'&&locale!=='en') continue;
  const missing=[];
  keys.forEach((key)=>{
    const value=key.split('.').reduce((acc,seg)=>acc && acc[seg],data);
    if(value===undefined) missing.push(key);
  });
  console.log(locale, missing.length?`missing: ${missing.join(', ')}`:'all present');
}
NODE

------
https://chatgpt.com/codex/tasks/task_e_68ea1808e734832babb47d1b88b0de85