### PR TITLE
Fix timer localization lookups

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -16097,6 +16097,56 @@
       },
     },
       "games": {
+        "timer": {
+          "header": {
+            "title": "Timer", 
+            "subtitle": "Stay on task with a focused countdown or track sessions with the stopwatch."
+          },
+          "xpBadge": "Session EXP {formattedXp}",
+          "modes": {
+            "countdown": "Countdown",
+            "stopwatch": "Stopwatch"
+          },
+          "inputs": {
+            "hours": "Hours",
+            "minutes": "Minutes",
+            "seconds": "Seconds"
+          },
+          "quickButtons": {
+            "addMinutes": "+{minutes} min",
+            "subtractMinutes": "-{minutes} min",
+            "pomodoro": "Pomodoro {minutes} min"
+          },
+          "controls": {
+            "start": "Start",
+            "pause": "Pause",
+            "resume": "Resume",
+            "reset": "Reset"
+          },
+          "status": {
+            "ready": "Ready",
+            "countdownReady": "Countdown ready",
+            "stopwatchReady": "Stopwatch ready",
+            "countdownRunning": "Counting down…",
+            "resumed": "Resumed",
+            "paused": "Paused",
+            "stopwatchRunning": "Stopwatch running…",
+            "stopwatchMinuteAwarded": "{minutes} min elapsed!",
+            "stopwatchMinute": "{minutes} min elapsed",
+            "completed": "Complete! Great work"
+          },
+          "history": {
+            "title": "Recent Log",
+            "labels": {
+              "complete": "Complete",
+              "start": "Start",
+              "stopwatchMinute": "Minute",
+              "generic": "Milestone"
+            },
+            "xpAward": "{label}: +{formattedXp} EXP",
+            "timerComplete": "Timer finished!"
+          }
+        },
         "diagramMaker": {
           "errors": {
             "containerMissing": "MiniExp Diagram Maker requires a container",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -16101,6 +16101,56 @@
       },
     },
       "games": {
+        "timer": {
+          "header": {
+            "title": "タイマー",
+            "subtitle": "カウントダウンやストップウォッチで集中時間や休憩をスマートに管理"
+          },
+          "xpBadge": "今回獲得 {formattedXp} EXP",
+          "modes": {
+            "countdown": "カウントダウン",
+            "stopwatch": "ストップウォッチ"
+          },
+          "inputs": {
+            "hours": "時間",
+            "minutes": "分",
+            "seconds": "秒"
+          },
+          "quickButtons": {
+            "addMinutes": "+{minutes}分",
+            "subtractMinutes": "-{minutes}分",
+            "pomodoro": "{minutes}分ポモドーロ"
+          },
+          "controls": {
+            "start": "開始",
+            "pause": "一時停止",
+            "resume": "再開",
+            "reset": "リセット"
+          },
+          "status": {
+            "ready": "準備完了",
+            "countdownReady": "カウントダウンの準備完了",
+            "stopwatchReady": "ストップウォッチの準備完了",
+            "countdownRunning": "カウント中…",
+            "resumed": "再開しました",
+            "paused": "一時停止中",
+            "stopwatchRunning": "計測中…",
+            "stopwatchMinuteAwarded": "{minutes}分経過！",
+            "stopwatchMinute": "{minutes}分経過",
+            "completed": "完了！お疲れさまでした"
+          },
+          "history": {
+            "title": "最近のログ",
+            "labels": {
+              "complete": "完了",
+              "start": "開始",
+              "stopwatchMinute": "経過",
+              "generic": "達成"
+            },
+            "xpAward": "{label}: +{formattedXp} EXP",
+            "timerComplete": "タイマー完了！"
+          }
+        },
         "diagramMaker": {
           "errors": {
             "containerMissing": "MiniExp Diagram Maker を表示するコンテナが必要です",


### PR DESCRIPTION
## Summary
- add the timer mini-game strings to the `games.timer` namespace in the English and Japanese locale bundles so timer.js can resolve translations

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ea4748eaa4832b97954a44862eca61