### PR TITLE
Fix undefined text reference in system minigame registration

### DIFF
--- a/games/system.js
+++ b/games/system.js
@@ -1434,11 +1434,12 @@
 
   window.registerMiniGame({
     id: 'system',
-    name: text('selection.miniexp.games.system.name', 'システム'), nameKey: 'selection.miniexp.games.system.name',
-    description: text('selection.miniexp.games.system.description', 'PCやOS、ブラウザ、IP情報を一括確認できるシステムモニターユーティリティ'), descriptionKey: 'selection.miniexp.games.system.description', categoryIds: ['utility'],
-    category: text('selection.miniexp.category.utility', 'ユーティリティ'),
+    name: 'システム', nameKey: 'selection.miniexp.games.system.name',
+    description: 'PCやOS、ブラウザ、IP情報を一括確認できるシステムモニターユーティリティ', descriptionKey: 'selection.miniexp.games.system.description', categoryIds: ['utility'],
+    category: 'ユーティリティ',
     version: '0.1.0',
     author: 'mod',
+    localizationKey: 'minigame.system',
     create
   });
 })();


### PR DESCRIPTION
## Summary
- replace usage of the unavailable `text` helper when registering the system minigame
- provide static fallback strings and expose the localization key to preserve translation support

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ea4c1383c4832b97c4801d9fdc582a