### PR TITLE
Fix Bowling Duel localization helper usage

### DIFF
--- a/games/bowling.js
+++ b/games/bowling.js
@@ -16,14 +16,60 @@
       { cpuSkill: 0.48, variance: 0.28, cpuVariance: 0.22, victoryXp: 30 } :
       { cpuSkill: 0.62, variance: 0.24, cpuVariance: 0.19, victoryXp: 40 };
 
-    const i18n = window.I18n;
     const I18N_PREFIX = 'games.bowlingDuel';
+    const globalI18n = (typeof window !== 'undefined' && window.I18n) ? window.I18n : null;
+    const localization = opts?.localization
+      || (typeof window !== 'undefined' && typeof window.createMiniGameLocalization === 'function'
+        ? window.createMiniGameLocalization({ id: 'bowling_duel', localizationKey: I18N_PREFIX, textKeyPrefix: I18N_PREFIX })
+        : null);
+    const ownsLocalization = !opts?.localization && localization && typeof localization.destroy === 'function';
+
+    function computeFallbackValue(key, params, fallback){
+      if(typeof fallback === 'function'){
+        try {
+          const value = fallback(params || {});
+          return value == null ? '' : String(value);
+        } catch (error) {
+          console.warn('[bowling] Failed to evaluate fallback for', key, error);
+          return '';
+        }
+      }
+      if(fallback == null) return '';
+      try {
+        return String(fallback);
+      } catch {
+        return '';
+      }
+    }
 
     function localize(key, params, fallback){
+      const fallbackResolver = (()=>{
+        let evaluated = false;
+        let cached = '';
+        return ()=>{
+          if(!evaluated){
+            evaluated = true;
+            cached = computeFallbackValue(key, params, fallback);
+          }
+          return cached;
+        };
+      })();
+
+      if(localization && typeof localization.t === 'function'){
+        try {
+          const result = localization.t(key, fallbackResolver, params);
+          if(result !== undefined && result !== null && result !== key){
+            return result;
+          }
+        } catch (error) {
+          console.warn('[bowling] Failed to translate via helper for', key, error);
+        }
+      }
+
       const fullKey = `${I18N_PREFIX}.${key}`;
       try {
-        if(typeof i18n?.t === 'function'){
-          const translated = i18n.t(fullKey, params);
+        if(typeof globalI18n?.t === 'function'){
+          const translated = globalI18n.t(fullKey, params);
           if(typeof translated === 'string' && translated !== fullKey){
             return translated;
           }
@@ -31,9 +77,8 @@
       } catch (error) {
         console.warn('[bowling] Failed to resolve translation for', fullKey, error);
       }
-      if(typeof fallback === 'function'){ return fallback(params || {}); }
-      if(fallback !== undefined){ return fallback; }
-      return '';
+
+      return fallbackResolver();
     }
 
     const statusFallbacks = {
@@ -657,7 +702,17 @@
     }
     function destroy(){
       stop();
-      detachLocale?.();
+      try {
+        detachLocale?.();
+      } catch (error) {
+        console.warn('[bowling] Failed to detach locale listener:', error);
+      }
+      detachLocale = null;
+      if(ownsLocalization && localization && typeof localization.destroy === 'function'){
+        try { localization.destroy(); } catch (error) {
+          console.warn('[bowling] Failed to dispose localization helper:', error);
+        }
+      }
       container.remove();
     }
     function getScore(){ const totals = updateTotals(); return totals.player; }
@@ -741,8 +796,24 @@
 
     applyLocale();
 
-    if(typeof i18n?.onLocaleChanged === 'function'){
-      detachLocale = i18n.onLocaleChanged(()=>{ applyLocale(); });
+    let localeListenerAttached = false;
+    if(localization && typeof localization.onChange === 'function'){
+      try {
+        const unsubscribe = localization.onChange(() => { applyLocale(); });
+        localeListenerAttached = true;
+        detachLocale = typeof unsubscribe === 'function' ? unsubscribe : null;
+      } catch (error) {
+        console.warn('[bowling] Failed to attach localization listener via helper:', error);
+      }
+    }
+    if(!localeListenerAttached && typeof globalI18n?.onLocaleChanged === 'function'){
+      try {
+        const unsubscribe = globalI18n.onLocaleChanged(() => { applyLocale(); });
+        detachLocale = typeof unsubscribe === 'function' ? unsubscribe : null;
+        localeListenerAttached = true;
+      } catch (error) {
+        console.warn('[bowling] Failed to attach localization listener:', error);
+      }
     }
 
     resetState();


### PR DESCRIPTION
## Summary
- use the MiniExp localization helper when available and fall back to the global I18n instance
- centralize fallback evaluation so localized fallbacks receive parameters correctly
- subscribe to locale changes through the helper or global API for live updates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ea4c68cdbc832b957fdaa7c0a4bb98