### PR TITLE
Fix Aurora Circuit control prompt localization

### DIFF
--- a/games/topdown_race.js
+++ b/games/topdown_race.js
@@ -260,7 +260,10 @@
     instruction.style.color = '#cbd5f5';
     instruction.style.fontSize = '12px';
     instruction.style.lineHeight = '1.6';
-    instruction.innerHTML = '↑/W:アクセル　↓/S:ブレーキ　←→/A・D:ステア<br>Space:ターボ　R:リスタート';
+    instruction.innerHTML = translateUi(
+      'selection.miniexp.games.topdown_race.instructions.controls',
+      '↑/W: Accelerate  ↓/S: Brake  ←→/A·D: Steer<br>Space: Turbo  R: Restart'
+    );
     container.appendChild(instruction);
 
     root.appendChild(container);

--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -1301,6 +1301,9 @@
               "expSummary": "EXP Earned: Lap {lap} / Best {best} / Boost {boost} / Finish {finish}",
               "restartHint": "Press {key} to restart"
             },
+            "instructions": {
+              "controls": "↑/W: Accelerate  ↓/S: Brake  ←→/A·D: Steer<br>Space: Turbo  R: Restart"
+            },
             "status": {
               "you": "You",
               "dnf": "DNF",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -1301,6 +1301,9 @@
               "expSummary": "獲得EXP: ラップ{lap} / ベスト{best} / ブースト{boost} / フィニッシュ{finish}",
               "restartHint": "Rキーで再スタート"
             },
+            "instructions": {
+              "controls": "↑/W:アクセル　↓/S:ブレーキ　←→/A・D:ステア<br>Space:ターボ　R:リスタート"
+            },
             "status": {
               "you": "自分",
               "dnf": "DNF",


### PR DESCRIPTION
## Summary
- add translation keys for the Aurora Circuit control instructions
- use the i18n helper so the control prompt renders in the active language

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68ea4efdd6e4832baaec52b81484a5a7