### PR TITLE
Fix steady wire localization support

### DIFF
--- a/games/steady_wire.js
+++ b/games/steady_wire.js
@@ -1,4 +1,5 @@
 (function(){
+  const GLOBAL = typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : null);
   const CANVAS_CFG = { width: 640, height: 420, margin: 40 };
   const DIFFICULTY_CFG = {
     EASY:   { corridor: 88, checkpointXp: 4, finishXp: 24, jitter: 60, keyboardSpeed: 180 },
@@ -82,8 +83,8 @@
   }
 
   function create(root, awardXp, opts){
-    const localization = opts?.localization || (typeof window !== 'undefined' && typeof window.createMiniGameLocalization === 'function'
-      ? window.createMiniGameLocalization({ id: 'steady_wire' })
+    const localization = opts?.localization || (GLOBAL && typeof GLOBAL.createMiniGameLocalization === 'function'
+      ? GLOBAL.createMiniGameLocalization({ id: 'steady_wire' })
       : null);
     const text = (key, fallback, params) => {
       if (localization && typeof localization.t === 'function'){

--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -1368,7 +1368,42 @@
           },
           "steady_wire": {
             "name": "Steady Wire",
-            "description": "Trace randomized mazes without touching the edge to collect EXP."
+            "description": "Trace randomized mazes without touching the edge to collect EXP.",
+            "status": {
+              "selectControl": "Choose a control method",
+              "hitObstacle": "You bumped the wire…",
+              "clearedWithTime": "Cleared! Great job ({time}s)",
+              "cleared": "Cleared! Great job!",
+              "leftCourse": "You left the course…",
+              "pointerLeft": "Pointer left the corridor…",
+              "mouseInstructions": "Mouse: Click the start circle to begin moving",
+              "keyboardInstructions": "Keyboard: Move with Arrow keys or WASD",
+              "mouseDrag": "Drag the dot carefully—stay inside the corridor"
+            },
+            "overlay": {
+              "modePrompt": "Pick a control method to begin!",
+              "retryPrompt": "You hit the edge! Try again?",
+              "clearedWithTime": "Cleared! Finished {difficulty} in {time} seconds!",
+              "cleared": "Cleared! You conquered {difficulty}!",
+              "selectControlFirst": "Choose a control method first",
+              "welcome": "Welcome to Steady Wire!\nPick mouse or keyboard controls to get started.\nStay in the corridor and reach the goal on the right."
+            },
+            "buttons": {
+              "startMouse": "Start with mouse",
+              "startKeyboard": "Start with keyboard",
+              "retrySameMode": "Retry with same controls"
+            },
+            "difficulty": {
+              "label": {
+                "easy": "Easy",
+                "normal": "Normal",
+                "hard": "Hard"
+              }
+            },
+            "canvas": {
+              "startLabel": "START",
+              "goalLabel": "GOAL"
+            }
           },
           "flappy_bird": {
             "name": "Flappy Bird Clone",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -1368,7 +1368,42 @@
           },
           "steady_wire": {
             "name": "イライラ棒",
-            "description": "毎回生成されるコースを外れず進むワイヤーループ。操作方法を選んで挑戦"
+            "description": "毎回生成されるコースを外れず進むワイヤーループ。操作方法を選んで挑戦",
+            "status": {
+              "selectControl": "操作方法を選択してください",
+              "hitObstacle": "ぶつかってしまった…",
+              "clearedWithTime": "クリア！おめでとう ({time}s)",
+              "cleared": "クリア！おめでとう！",
+              "leftCourse": "コースから外れてしまった…",
+              "pointerLeft": "コースから出てしまった…",
+              "mouseInstructions": "マウスで操作: スタート円をクリックして進もう",
+              "keyboardInstructions": "キーボードで操作: 矢印 / WASD で移動",
+              "mouseDrag": "マウスで●をコースから外さないように進もう"
+            },
+            "overlay": {
+              "modePrompt": "操作方法を選んでスタート！",
+              "retryPrompt": "ぶつかってしまった！再挑戦しますか？",
+              "clearedWithTime": "クリア！難易度 {difficulty} を {time} 秒で突破しました！",
+              "cleared": "クリア！難易度 {difficulty} を突破しました！",
+              "selectControlFirst": "まず操作方法を選んでください",
+              "welcome": "イライラ棒ミニゲームへようこそ！\nマウスまたはキーボード操作を選んでください。\nコースから外れずに右端のゴールまで進みましょう。"
+            },
+            "buttons": {
+              "startMouse": "マウスモードで開始",
+              "startKeyboard": "キーボードモードで開始",
+              "retrySameMode": "同じモードで再挑戦"
+            },
+            "difficulty": {
+              "label": {
+                "easy": "かんたん",
+                "normal": "ふつう",
+                "hard": "むずかしい"
+              }
+            },
+            "canvas": {
+              "startLabel": "スタート",
+              "goalLabel": "ゴール"
+            }
           },
           "flappy_bird": {
             "name": "フラッピーバード風",


### PR DESCRIPTION
## Summary
- ensure the Steady Wire minigame falls back to the global localization helper when provided by the host
- add Japanese and English locale strings for Steady Wire UI text and difficulty labels

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ea519a7834832b8990147ae53a3440