### PR TITLE
fix: update trump selection locale strings

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -12068,8 +12068,8 @@
             "bestScore": "Best {score}"
           },
           "unimplemented": {
-            "phase": "Planned for Phase {phase}.",
-            "status": "In preparation."
+            "phase": "Scheduled for Phase {phase}.",
+            "status": "Preparing content."
           }
         },
         "errors": {
@@ -12092,7 +12092,7 @@
           },
           "forest": {
             "label": "Forest",
-            "description": "Deep green gradient with gold"
+            "description": "Deep green gradient with gold accents"
           }
         },
         "games": {

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -12050,7 +12050,7 @@
         "placeholder": {
           "primary": "左のリストからゲームを選んでください。",
           "separator": " / ",
-          "phaseInfo": "Phase {phase}: {games}"
+          "phaseInfo": "フェーズ {phase}: {games}"
         },
         "status": {
           "selectGame": "ゲームを選択してください。",
@@ -12058,8 +12058,8 @@
           "devPlaceholder": "現在は開発中です。"
         },
         "actions": {
-          "returnToHub": "ゲームを終了",
-          "default": "Action",
+          "returnToHub": "セレクションに戻る",
+          "default": "操作",
           "backToList": "一覧に戻る"
         },
         "list": {
@@ -12068,7 +12068,7 @@
             "bestScore": "ベスト {score}"
           },
           "unimplemented": {
-            "phase": "Phase {phase} で実装予定です。",
+            "phase": "フェーズ {phase} で実装予定です。",
             "status": "実装準備中です。"
           }
         },


### PR DESCRIPTION
## Summary
- adjust the English Trump Selection strings to clarify phase messaging and card back descriptions
- localize the Japanese Trump Selection UI strings for phase info and hub actions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ea5289e038832baa554808cb956653