### PR TITLE
Fix stopwatch localization fallback

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -16863,6 +16863,36 @@
     store['en'].games = {};
   }
   var enGames = store['en'].games;
+  if (!enGames.stopwatch) {
+    enGames.stopwatch = {
+      "header": {
+        "title": "Stopwatch Pro"
+      },
+      "statusBadge": {
+        "running": "Running",
+        "stopped": "Stopped"
+      },
+      "info": {
+        "lapCount": "Lap: {count}",
+        "lastLap": "Last lap: {time}",
+        "lastLapNone": "Last lap: -",
+        "sessionXp": "Session EXP: {xp}"
+      },
+      "buttons": {
+        "start": "Start",
+        "pause": "Pause",
+        "resume": "Resume",
+        "lap": "Lap",
+        "reset": "Reset"
+      },
+      "laps": {
+        "title": "Lap history",
+        "subtitle": "Most recent first",
+        "empty": "Your laps will appear here once recorded.",
+        "label": "Lap {index}"
+      }
+    };
+  }
   if (!enGames.wording) {
     enGames.wording = {
         "name": "Wording",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -16868,6 +16868,36 @@
     store['ja'].games = {};
   }
   var jaGames = store['ja'].games;
+  if (!jaGames.stopwatch) {
+    jaGames.stopwatch = {
+      "header": {
+        "title": "ストップウォッチ Pro"
+      },
+      "statusBadge": {
+        "running": "計測中",
+        "stopped": "停止中"
+      },
+      "info": {
+        "lapCount": "ラップ: {count}",
+        "lastLap": "前ラップ: {time}",
+        "lastLapNone": "前ラップ: -",
+        "sessionXp": "セッションEXP: {xp}"
+      },
+      "buttons": {
+        "start": "スタート",
+        "pause": "一時停止",
+        "resume": "再開",
+        "lap": "ラップ",
+        "reset": "リセット"
+      },
+      "laps": {
+        "title": "ラップ記録",
+        "subtitle": "最新順に表示",
+        "empty": "ラップを記録するとここに表示されます",
+        "label": "ラップ {index}"
+      }
+    };
+  }
   if (!jaGames.wording) {
     jaGames.wording = {
         "name": "Wording",


### PR DESCRIPTION
## Summary
- add explicit stopwatch translations to the shared English and Japanese locale dictionaries
- ensure stopwatch UI strings use localized text instead of English fallbacks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ea550642e8832bb47b705ad73c42f9