### PR TITLE
Fix Run for Money UI localization and add regression test

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -14022,6 +14022,54 @@
         }
       }
     },
+    "miniexp": {
+      "games": {
+        "tosochu": {
+          "ui": {
+            "timer": "Time Left {seconds}s",
+            "exp": "Stored EXP {exp}",
+            "missionNotReady": "Mission: Not yet activated",
+            "missionActive": "Mission: {label}{optionalSuffix} — {seconds}s remaining (Coords: {coords})",
+            "missionComplete": "Missions Complete: {success}/{total} succeeded",
+            "missionSuccess": "{label}: Success!",
+            "missionFailed": "{label}: Failed…",
+            "surrender": "Surrender",
+            "surrenderCountdown": "Surrendering...{seconds}s"
+          },
+          "status": {
+            "hunterAdded": "A hunter has joined the chase!",
+            "hunterRetreat": "Mission success! One hunter retreated",
+            "missionActivated": "Mission activated: {label}",
+            "escapeSuccess": "Escaped! +{total} EXP (Breakdown {base}+{bonus})",
+            "surrenderSuccess": "Surrendered. Banked {exp} EXP",
+            "caught": "Caught... no EXP earned",
+            "dungeonUnavailable": "Dungeon API unavailable",
+            "stageGenerationFailed": "Failed to generate the stage",
+            "runStart": "The chase begins!",
+            "runPaused": "Paused",
+            "standby": "Standby",
+            "surrenderZoneHint": "Enter the surrender zone before pressing the button",
+            "surrenderAttempt": "Attempting surrender… endure for {duration}s!",
+            "surrenderCancelled": "Surrender cancelled",
+            "beaconSuccess": "Beacon secured! Signal jamming strengthened",
+            "beaconFail": "Beacon failed... hunters are on alert",
+            "dataSuccess": "Classified intel secured! Rewards increased",
+            "dataFail": "Alarm triggered! A fast hunter has appeared",
+            "boxSuccess": "Disarmed! Hunter boxes are delayed",
+            "boxFail": "Disarm failed... an extra hunter deployed",
+            "vaultSuccess": "Jackpot! But you're now a prime target",
+            "vaultFail": "Vault defended... two hunters released"
+          },
+          "missions": {
+            "optionalSuffix": " (Optional)",
+            "beacon": { "label": "Reach the beacon" },
+            "data": { "label": "Hack the data terminal" },
+            "box": { "label": "Disarm the hunter box" },
+            "vault": { "label": "Crack the high-risk vault" }
+          }
+        }
+      }
+    },
     "tools": {
       "sidebar": {
         "ariaLabel": "Tools list",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -14026,6 +14026,54 @@
         }
       }
     },
+    "miniexp": {
+      "games": {
+        "tosochu": {
+          "ui": {
+            "timer": "残り {seconds}s",
+            "exp": "蓄積EXP {exp}",
+            "missionNotReady": "ミッション: まだ発動していません",
+            "missionActive": "ミッション: {label}{optionalSuffix}：残り{seconds}s (地点: {coords})",
+            "missionComplete": "ミッション完了：成功{success}/{total}",
+            "missionSuccess": "{label}：成功！",
+            "missionFailed": "{label}：失敗…",
+            "surrender": "自首する",
+            "surrenderCountdown": "自首中...{seconds}s"
+          },
+          "status": {
+            "hunterAdded": "ハンターが追加投入された！",
+            "hunterRetreat": "ミッション成功！ハンター1体が撤退",
+            "missionActivated": "ミッション発動：{label}",
+            "escapeSuccess": "逃走成功！+{total} EXP (内訳 {base}+{bonus})",
+            "surrenderSuccess": "自首。蓄積{exp}EXPを獲得",
+            "caught": "捕まってしまった…獲得EXPなし",
+            "dungeonUnavailable": "ダンジョンAPI利用不可",
+            "stageGenerationFailed": "ステージ生成に失敗しました",
+            "runStart": "逃走開始！",
+            "runPaused": "一時停止中",
+            "standby": "逃走中スタンバイ",
+            "surrenderZoneHint": "自首ゾーンに入ってからボタンを押してください",
+            "surrenderAttempt": "自首を試みています…{duration}s耐え抜け！",
+            "surrenderCancelled": "自首を中断しました",
+            "beaconSuccess": "ビーコン成功！電波妨害を強化",
+            "beaconFail": "ビーコン失敗…ハンターが警戒強化",
+            "dataSuccess": "極秘情報を確保！報酬が増加",
+            "dataFail": "警報が鳴った！高速ハンターが出現",
+            "boxSuccess": "解除成功！ハンターボックスの発動が遅延",
+            "boxFail": "解除失敗…ハンターが追加投入",
+            "vaultSuccess": "大金獲得！しかし狙われやすくなった",
+            "vaultFail": "金庫防衛が発動…ハンターが二体解放"
+          },
+          "missions": {
+            "optionalSuffix": "（任意）",
+            "beacon": { "label": "ビーコンに接触せよ" },
+            "data": { "label": "情報端末をハック" },
+            "box": { "label": "ハンターボックスを解除" },
+            "vault": { "label": "ハイリスク金庫を解錠" }
+          }
+        }
+      }
+    },
     "tools": {
       "sidebar": {
         "ariaLabel": "ツール一覧",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "main.js",
   "scripts": {
-    "test": "node tests/bowling-localization.test.js"
+    "test": "node tests/bowling-localization.test.js && node tests/tosochu-localization.test.js"
   },
   "keywords": [],
   "author": "",

--- a/tests/tosochu-localization.test.js
+++ b/tests/tosochu-localization.test.js
@@ -1,0 +1,275 @@
+const assert = require('node:assert/strict');
+const { JSDOM } = require('jsdom');
+
+async function setupLocalization(window) {
+  window.document.dispatchEvent = () => true;
+  window.localStorage = {
+    getItem() { return null; },
+    setItem() {},
+    removeItem() {}
+  };
+
+  window.globalThis = window;
+  global.window = window;
+  global.document = window.document;
+
+  require('../js/i18n/locales/ja.json.js');
+  require('../js/i18n/locales/en.json.js');
+  require('../js/i18n/index.js');
+
+  const I18n = window.I18n;
+  await I18n.init('en');
+
+  window.createMiniGameLocalization = function(def = {}) {
+    const prefixes = [];
+    const addPrefix = (value) => {
+      if (!value) return;
+      const normalized = String(value);
+      if (!normalized) return;
+      if (!prefixes.includes(normalized)) prefixes.push(normalized);
+    };
+    addPrefix(def.localizationKey);
+    addPrefix(def.textKeyPrefix);
+    if (def.id) {
+      addPrefix(`minigame.${def.id}`);
+      addPrefix(`miniexp.games.${def.id}`);
+      addPrefix(`selection.miniexp.games.${def.id}`);
+    }
+    if (!prefixes.length) addPrefix('minigame');
+
+    const buildCandidates = (key) => {
+      if (!key) return prefixes.slice();
+      const result = [];
+      prefixes.forEach(prefix => {
+        if (key.startsWith(prefix)) {
+          result.push(key);
+        } else if (key.startsWith('.')) {
+          result.push(`${prefix}${key}`);
+        } else {
+          result.push(`${prefix}.${key}`);
+        }
+      });
+      if (!result.includes(key)) result.push(key);
+      return result;
+    };
+
+    const listeners = new Set();
+    const detach = I18n.onLocaleChanged(locale => {
+      listeners.forEach(listener => {
+        try {
+          listener(locale);
+        } catch (error) {
+          console.warn('[test] helper listener error', error);
+        }
+      });
+    });
+
+    return {
+      t(key, fallback, params) {
+        const candidates = buildCandidates(key);
+        for (const candidate of candidates) {
+          const translated = I18n.t(candidate, params);
+          if (typeof translated === 'string' && translated !== candidate) {
+            return translated;
+          }
+        }
+        if (typeof fallback === 'function') return fallback();
+        return fallback ?? '';
+      },
+      onChange(handler) {
+        if (typeof handler !== 'function') return () => {};
+        listeners.add(handler);
+        return () => listeners.delete(handler);
+      },
+      formatNumber(value) {
+        try {
+          return I18n.formatNumber(value, { maximumFractionDigits: 1, minimumFractionDigits: 1 });
+        } catch (error) {
+          return typeof value === 'number' ? value.toLocaleString('en-US', { maximumFractionDigits: 1, minimumFractionDigits: 1 }) : String(value ?? '');
+        }
+      },
+      getLocale() { return I18n.getLocale(); },
+      destroy() {
+        detach();
+        listeners.clear();
+      }
+    };
+  };
+
+  return I18n;
+}
+
+function createStubStage(window, tileSize = 32) {
+  const width = 12;
+  const height = 9;
+  const tiles = Array.from({ length: height }, () => Array(width).fill(0));
+
+  const toIndex = (x, y) => `${x},${y}`;
+
+  const pickFloor = (excludeSet = new Set()) => {
+    for (let y = 1; y < height - 1; y++) {
+      for (let x = 1; x < width - 1; x++) {
+        const id = toIndex(x, y);
+        if (!excludeSet.has(id)) {
+          excludeSet.add(id);
+          return { x, y };
+        }
+      }
+    }
+    return { x: 2, y: 2 };
+  };
+
+  return {
+    width,
+    height,
+    tileSize,
+    tiles,
+    pickFloorPositions(count, { exclude } = {}) {
+      const excludeSet = new Set((exclude || []).map(pos => toIndex(pos.x, pos.y)));
+      const result = [];
+      for (let i = 0; i < count; i++) {
+        result.push(pickFloor(excludeSet));
+      }
+      return result;
+    },
+    pickFloorPosition({ exclude } = {}) {
+      const excludeSet = new Set((exclude || []).map(pos => toIndex(pos.x, pos.y)));
+      return pickFloor(excludeSet);
+    },
+    tileCenter(x, y) {
+      return { x: x * tileSize + tileSize / 2, y: y * tileSize + tileSize / 2 };
+    },
+    clampPosition(x, y) {
+      const minX = tileSize;
+      const minY = tileSize;
+      const maxX = (width - 1) * tileSize;
+      const maxY = (height - 1) * tileSize;
+      return {
+        x: Math.min(Math.max(x, minX), maxX),
+        y: Math.min(Math.max(y, minY), maxY)
+      };
+    },
+    collidesCircle() { return false; },
+    createCamera({ viewTilesX, viewTilesY }) {
+      const cameraWidth = viewTilesX * tileSize;
+      const cameraHeight = viewTilesY * tileSize;
+      let centerX = cameraWidth / 2;
+      let centerY = cameraHeight / 2;
+
+      return {
+        width: cameraWidth,
+        height: cameraHeight,
+        setCenter(x, y) {
+          centerX = x;
+          centerY = y;
+        },
+        getBounds() {
+          return {
+            x: centerX - cameraWidth / 2,
+            y: centerY - cameraHeight / 2,
+            width: cameraWidth,
+            height: cameraHeight
+          };
+        },
+        contains() { return true; },
+        project(x, y) {
+          const bounds = this.getBounds();
+          return { x: x - bounds.x, y: y - bounds.y };
+        }
+      };
+    }
+  };
+}
+
+function setupCanvas(window) {
+  window.HTMLCanvasElement.prototype.getContext = function() {
+    return {
+      clearRect() {},
+      drawImage() {},
+      fillRect() {},
+      strokeRect() {},
+      beginPath() {},
+      arc() {},
+      fill() {},
+      stroke() {},
+      set fillStyle(value) { this._fillStyle = value; },
+      get fillStyle() { return this._fillStyle; },
+      set strokeStyle(value) { this._strokeStyle = value; },
+      get strokeStyle() { return this._strokeStyle; },
+      set lineWidth(value) { this._lineWidth = value; },
+      get lineWidth() { return this._lineWidth; }
+    };
+  };
+}
+
+async function main() {
+  const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', { url: 'http://localhost' });
+  const { window } = dom;
+  global.window = window;
+  global.document = window.document;
+  global.HTMLElement = window.HTMLElement;
+  global.Node = window.Node;
+  global.navigator = window.navigator;
+  setupCanvas(window);
+
+  window.requestAnimationFrame = (cb) => setTimeout(() => cb(Date.now()), 16);
+  window.cancelAnimationFrame = (id) => clearTimeout(id);
+  global.requestAnimationFrame = window.requestAnimationFrame;
+  global.cancelAnimationFrame = window.cancelAnimationFrame;
+
+  const I18n = await setupLocalization(window);
+
+  let registeredGame = null;
+  window.registerMiniGame = function(def) {
+    registeredGame = def;
+  };
+
+  require('../games/tosochu.js');
+  assert(registeredGame, 'tosochu should register itself');
+
+  const root = document.getElementById('root');
+  const stage = createStubStage(window);
+  const backgroundCanvas = document.createElement('canvas');
+  backgroundCanvas.width = stage.width * stage.tileSize;
+  backgroundCanvas.height = stage.height * stage.tileSize;
+
+  const dungeonApi = {
+    async generateStage() {
+      return stage;
+    },
+    renderStage() {
+      return { canvas: backgroundCanvas };
+    }
+  };
+
+  const api = registeredGame.create(root, () => {}, { dungeon: dungeonApi, locale: 'en' });
+  assert(api, 'create should return control API');
+
+  await new Promise(resolve => setTimeout(resolve, 50));
+
+  const spans = root.querySelectorAll('.mini-tosochu div span');
+  assert.equal(spans.length >= 3, true, 'should render timer, exp, and status labels');
+  const [timerLabel, expLabel, statusLabel] = spans;
+  assert.equal(timerLabel.textContent, 'Time Left 180.0s');
+  assert.equal(expLabel.textContent, 'Stored EXP 0.0');
+  assert.equal(statusLabel.textContent, 'Standby');
+
+  const missionPanel = root.querySelector('.mini-tosochu > div:nth-child(2)');
+  assert(missionPanel, 'mission panel should exist');
+  assert.equal(missionPanel.textContent, 'Mission: Not yet activated');
+
+  const surrenderButton = root.querySelector('.mini-tosochu button');
+  assert(surrenderButton, 'surrender button should exist');
+  assert.equal(surrenderButton.textContent, 'Surrender');
+
+  api.destroy();
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  I18n.setLocale('ja');
+  await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add English and Japanese `miniexp.games.tosochu` dictionaries so the in-game HUD uses localized strings
- add a jsdom-based regression test that instantiates the Run for Money mini-game and asserts the English UI text
- update the test script to run the new localization regression alongside the existing bowling test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ea56165c74832ba96e1a583633eb61