### PR TITLE
Fix missing Bowling Duel localization entries

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -16361,6 +16361,77 @@
       },
     },
       "games": {
+        "bowlingDuel": {
+          "title": "Bowling Duel MOD",
+          "legend": "Press the button to stop the Aim → Curve → Power gauges in order and roll the ball!",
+          "history": {
+            "title": "Log",
+            "placeholder": "---"
+          },
+          "buttons": {
+            "throw": "🎳 Throw Ball",
+            "reset": "🔄 Reset",
+            "throwing": "🎳 Rolling…"
+          },
+          "scoreboard": {
+            "you": "You",
+            "cpu": "CPU",
+            "total": "Total"
+          },
+          "sliders": {
+            "aim": {
+              "label": "Aim Position",
+              "center": "Center",
+              "right": "Right {value}",
+              "left": "Left {value}"
+            },
+            "curve": {
+              "label": "Curve Amount",
+              "none": "None",
+              "right": "Hooks Right {value}",
+              "left": "Hooks Left {value}"
+            },
+            "power": {
+              "label": "Throw Power",
+              "format": "{value}%"
+            }
+          },
+          "status": {
+            "introHint": "Stop each moving gauge at the right moment to chase strikes!",
+            "framePlayer": "Frame {frame}: Your turn.",
+            "frameCpu": "Frame {frame}: CPU turn…",
+            "remainingPins": "Pins left: {count}. Take another shot!",
+            "playerStrike": "Strike!",
+            "cpuStrike": "CPU rolled a strike!",
+            "victory": "Victory! Score {player} - {cpu}",
+            "draw": "Draw… Score {player} - {cpu}",
+            "defeat": "Defeat… Score {player} - {cpu}"
+          },
+          "stage": {
+            "aim": {
+              "prompt": "Aim gauge oscillating—press to lock it in!",
+              "button": "🛑 Stop Aim",
+              "confirm": "Aim set to {value}!"
+            },
+            "curve": {
+              "prompt": "Curve gauge moving—stop it with the button!",
+              "button": "🛑 Stop Curve",
+              "confirm": "Curve locked at {value}!"
+            },
+            "power": {
+              "prompt": "Watch the power gauge—press to roll!",
+              "button": "🛑 Stop Power",
+              "confirm": "Rolling with {value}!"
+            }
+          },
+          "logs": {
+            "playerShot": "You: aim {aim}, curve {curve}, power {power}% → <strong>{pins}</strong>",
+            "cpuShot": "CPU: aim {aim}, curve {curve}, power {power}% → <strong>{pins}</strong>",
+            "victory": "<strong>Victory!</strong> +{exp}EXP",
+            "draw": "<strong>Draw</strong> +{exp}EXP",
+            "defeat": "<strong>Defeat</strong> +{exp}EXP"
+          }
+        },
         "timer": {
           "header": {
             "title": "Timer", 

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -16365,6 +16365,77 @@
       },
     },
       "games": {
+        "bowlingDuel": {
+          "title": "ボウリング対決 MOD",
+          "legend": "ボタンを押して狙い→カーブ→パワーの順にゲージを止め、投球しよう！",
+          "history": {
+            "title": "ログ",
+            "placeholder": "---"
+          },
+          "buttons": {
+            "throw": "🎳 ボールを投げる",
+            "reset": "🔄 リセット",
+            "throwing": "🎳 投球中…"
+          },
+          "scoreboard": {
+            "you": "あなた",
+            "cpu": "CPU",
+            "total": "合計"
+          },
+          "sliders": {
+            "aim": {
+              "label": "狙い位置",
+              "center": "中央",
+              "right": "右 {value}",
+              "left": "左 {value}"
+            },
+            "curve": {
+              "label": "カーブ量",
+              "none": "なし",
+              "right": "右曲がり {value}",
+              "left": "左曲がり {value}"
+            },
+            "power": {
+              "label": "投球パワー",
+              "format": "{value}%"
+            }
+          },
+          "status": {
+            "introHint": "ゲージをタイミング良く止めてストライクを狙おう！",
+            "framePlayer": "第{frame}フレーム あなたの番です。",
+            "frameCpu": "第{frame}フレーム CPUの番です…",
+            "remainingPins": "残りピン: {count} 本。もう一投！",
+            "playerStrike": "ストライク！",
+            "cpuStrike": "CPUがストライク！",
+            "victory": "勝利！ スコア {player} - {cpu}",
+            "draw": "引き分け… スコア {player} - {cpu}",
+            "defeat": "敗北… スコア {player} - {cpu}"
+          },
+          "stage": {
+            "aim": {
+              "prompt": "狙いゲージが往復中…止めるタイミングでボタン！",
+              "button": "🛑 狙いを止める",
+              "confirm": "狙い位置を {value} にセット！"
+            },
+            "curve": {
+              "prompt": "カーブゲージ調整中…ボタンでストップ！",
+              "button": "🛑 カーブを止める",
+              "confirm": "カーブ量は {value} に決定！"
+            },
+            "power": {
+              "prompt": "パワーゲージを注視…ボタンで投球！",
+              "button": "🛑 パワーを止める",
+              "confirm": "パワー {value} で投球！"
+            }
+          },
+          "logs": {
+            "playerShot": "あなた: aim {aim}, curve {curve}, power {power}% → <strong>{pins}</strong>",
+            "cpuShot": "CPU: aim {aim}, curve {curve}, power {power}% → <strong>{pins}</strong>",
+            "victory": "<strong>勝利！</strong> +{exp}EXP",
+            "draw": "<strong>引き分け</strong> +{exp}EXP",
+            "defeat": "<strong>敗北</strong> +{exp}EXP"
+          }
+        },
         "timer": {
           "header": {
             "title": "タイマー",


### PR DESCRIPTION
## Summary
- register the Bowling Duel MOD translations in the exported English and Japanese locale dictionaries so the UI resolves localized strings

## Testing
- npm test -- bowling-localization

------
https://chatgpt.com/codex/tasks/task_e_68ea59c5d9c0832b8e2c7e9ef053e029