### PR TITLE
Improve Trump selection localization

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -12179,6 +12179,103 @@
             "title": "Page One",
             "description": "Classic shedding game that inspired UNO."
           }
+        },
+        "common": {
+          "actions": {
+            "hint": "Hint (H)",
+            "restart": "Restart (R)",
+            "returnToList": "Game List (B)",
+            "rematch": "Play Again"
+          },
+          "hud": {
+            "scoreSummary": "Total {plays} games / Best {best} / Hand {hand} cards",
+            "noRecord": "---",
+            "bestPlace": "Place {place}"
+          },
+          "status": {
+            "turn": "{name}'s turn"
+          },
+          "youSuffix": " (You)",
+          "hand": {
+            "empty": "No cards",
+            "cleared": "Finished (Place {place})"
+          },
+          "player": {
+            "finished": "Secured place {place}"
+          }
+        },
+        "baba": {
+          "status": {
+            "humanTurn": "Your turn: Click the card of the player on your right. (Hand {cards} cards)"
+          },
+          "toast": {
+            "hint": "Click the player on your right to draw a card.",
+            "start": "Game start! Draw a card from the player on your right.",
+            "finish": "Finished! Place {place}",
+            "loser": "{name} is holding the joker. Game over!"
+          }
+        },
+        "jiji": {
+          "table": {
+            "label": "Table card",
+            "rank": "Rank: {rank}",
+            "none": "No table card"
+          },
+          "controls": {
+            "swap": {
+              "enable": "Swap mode",
+              "disable": "Exit swap mode"
+            }
+          },
+          "status": {
+            "humanTurn": "Your turn: Swap with the table if needed, then draw from the player on your right.",
+            "selectSwap": "Choose a card from your hand to swap.",
+            "humanDraw": "Swap with the table or draw from your right-hand player."
+          },
+          "toast": {
+            "noTable": "No table card available to swap.",
+            "hint": "Match the table rank to shed cards from your hand.",
+            "swapped": "Swapped with the table card.",
+            "exitSwap": "Exit swap mode first.",
+            "loser": "{name} is stuck with the Jiji. Game over!",
+            "tableMissing": "No table card available.",
+            "cannotPlaceJiji": "You can't place the Jiji on the table card.",
+            "finish": "Finished! Place {place}"
+          }
+        },
+        "blackjack": {
+          "labels": {
+            "dealer": "Dealer",
+            "player": "Player"
+          },
+          "actions": {
+            "hit": "Hit (H)",
+            "stand": "Stand (S)",
+            "restart": "Restart (R)",
+            "nextHand": "Next Hand (N)"
+          },
+          "messages": {
+            "chooseAction": "Select HIT or STAND.",
+            "chooseActionAlt": "Choose HIT or STAND.",
+            "blackjackPlayer": "Blackjack!",
+            "blackjackDealer": "Dealer has blackjack...",
+            "blackjackPush": "Both have blackjack. Push!",
+            "bust": "Bust ({value})",
+            "totalPrompt": "Total {value} / HIT or STAND",
+            "dealerBust": "Dealer busts ({value})",
+            "dealerVsPlayer": "Dealer {dealer} vs {player}",
+            "playerWin": "You win! {player} vs {dealer}",
+            "push": "Push ({value})"
+          },
+          "status": {
+            "tally": "Wins {wins} / Losses {losses} / Pushes {pushes}"
+          },
+          "hud": {
+            "score": "Total plays {plays} / Wins {wins}"
+          },
+          "toast": {
+            "consolation": "Tough luck! You'll get them next time."
+          }
         }
       },
       "gamble_hall": {

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -12179,6 +12179,103 @@
             "title": "ページワン",
             "description": "UNOの祖先とされる定番ゲーム。"
           }
+        },
+        "common": {
+          "actions": {
+            "hint": "ヒント (H)",
+            "restart": "リスタート (R)",
+            "returnToList": "ゲーム一覧 (B)",
+            "rematch": "再戦する"
+          },
+          "hud": {
+            "scoreSummary": "通算 {plays} 回 / ベスト {best} / 手札 {hand} 枚",
+            "noRecord": "---",
+            "bestPlace": "{place} 位"
+          },
+          "status": {
+            "turn": "{name} の番"
+          },
+          "youSuffix": " (You)",
+          "hand": {
+            "empty": "手札なし",
+            "cleared": "上がり ({place}位)"
+          },
+          "player": {
+            "finished": "{place} 位確定"
+          }
+        },
+        "baba": {
+          "status": {
+            "humanTurn": "あなたの番：右隣のカードをクリックしてください。（手札 {cards} 枚）"
+          },
+          "toast": {
+            "hint": "右隣のプレイヤーのカードをクリックして引きましょう。",
+            "start": "ゲーム開始！右隣のプレイヤーからカードを引きましょう。",
+            "finish": "上がり！順位 {place}",
+            "loser": "{name} がジョーカーを持っています。ゲーム終了！"
+          }
+        },
+        "jiji": {
+          "table": {
+            "label": "台札",
+            "rank": "ランク: {rank}",
+            "none": "台札なし"
+          },
+          "controls": {
+            "swap": {
+              "enable": "交換モード",
+              "disable": "交換モード解除"
+            }
+          },
+          "status": {
+            "humanTurn": "あなたの番：必要なら台札と交換し、右隣からカードを引きましょう。",
+            "selectSwap": "交換するカードを自分の手札から選んでください。",
+            "humanDraw": "台札と交換するか、右隣からカードを引いてください。"
+          },
+          "toast": {
+            "noTable": "交換できる台札がありません。",
+            "hint": "台札と同じランクを揃えると手札を減らせます。",
+            "swapped": "台札と交換しました。",
+            "exitSwap": "交換モードを終了してください。",
+            "loser": "{name} がジジを持っています。ゲーム終了！",
+            "tableMissing": "台札がありません。",
+            "cannotPlaceJiji": "ジジは台札に置けません。",
+            "finish": "上がり！順位 {place}"
+          }
+        },
+        "blackjack": {
+          "labels": {
+            "dealer": "ディーラー",
+            "player": "プレイヤー"
+          },
+          "actions": {
+            "hit": "ヒット (H)",
+            "stand": "スタンド (S)",
+            "restart": "リスタート (R)",
+            "nextHand": "次のハンド (N)"
+          },
+          "messages": {
+            "chooseAction": "HIT / STAND を選択してください。",
+            "chooseActionAlt": "HIT または STAND を選択してください。",
+            "blackjackPlayer": "ブラックジャック！",
+            "blackjackDealer": "ディーラーがブラックジャック…",
+            "blackjackPush": "両者ブラックジャック。プッシュ！",
+            "bust": "バースト ({value})",
+            "totalPrompt": "合計 {value} / HIT or STAND",
+            "dealerBust": "ディーラーがバースト ({value})",
+            "dealerVsPlayer": "ディーラー {dealer} 対 {player}",
+            "playerWin": "勝利！{player} 対 {dealer}",
+            "push": "プッシュ ({value})"
+          },
+          "status": {
+            "tally": "勝利 {wins} / 敗北 {losses} / プッシュ {pushes}"
+          },
+          "hud": {
+            "score": "通算プレイ {plays} ・ 勝利 {wins}"
+          },
+          "toast": {
+            "consolation": "残念！次は勝てるはず。"
+          }
         }
       },
       "gamble_hall": {


### PR DESCRIPTION
## Summary
- add localized action labels, HUD strings, and status prompts for the Trump selection Old Maid and Jiji games
- translate Blackjack labels, HUD values, status updates, and toast messaging with locale-aware metadata
- extend Japanese and English locale bundles with Trump selection common, Old Maid, Jiji, and Blackjack entries

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ea5afc7694832bbbfbcbd5076b4240