### PR TITLE
Fix Math Lab startup regression

### DIFF
--- a/games/math_lab.js
+++ b/games/math_lab.js
@@ -160,6 +160,10 @@
     let totalGraphs = 0;
     const shortcuts = opts?.shortcuts;
     let shortcutsLocked = false;
+    const localeBindings = [];
+    const localeCleanup = [];
+    let lastStatusDescriptor = null;
+    let lastStatusTimestamp = null;
 
     const container = document.createElement('div');
     container.className = 'math-lab-root';
@@ -333,11 +337,6 @@
     let approxForceEllipsis = false;
     let latestHistoryEntry = null;
     let lastSymbolicRaw = null;
-
-    const localeBindings = [];
-    const localeCleanup = [];
-    let lastStatusDescriptor = null;
-    let lastStatusTimestamp = null;
 
     function runLocaleBindings(){
       localeBindings.forEach(fn => {


### PR DESCRIPTION
## Summary
- initialize the Math Lab locale tracking state before any locale bindings are registered so the game can mount without a ReferenceError
- keep the locale sync logic intact while allowing the loading overlay text to register correctly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ea61d14814832b8d18152d7c6ded02