### PR TITLE
Fix localization namespace for graphics tester mod

### DIFF
--- a/games/graphics_tester.js
+++ b/games/graphics_tester.js
@@ -53,7 +53,7 @@
     @media (max-width:860px){ .gfx3d-main { grid-template-columns:1fr; } }
   `;
 
-  const I18N_NAMESPACE = 'games.graphicsTester';
+  const I18N_NAMESPACE = 'miniexp.games.graphicsTester';
   const i18n = typeof window !== 'undefined' ? window.I18n : null;
   let activeLocalizationInstance = null;
 


### PR DESCRIPTION
## Summary
- update the graphics tester mod to use the miniexp localization namespace so English strings resolve correctly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ea63c28660832bbd5cd2d2e8d74643