### PR TITLE
feat: localize trump selection gameplay UI

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -12558,6 +12558,7 @@
             "hint": "Hint (H)",
             "restart": "Restart (R)",
             "returnToList": "Game List (B)",
+            "newGame": "New Game (R)",
             "rematch": "Play Again"
           },
           "hud": {
@@ -12575,6 +12576,83 @@
           },
           "player": {
             "finished": "Secured place {place}"
+          }
+        },
+        "klondike": {
+          "labels": {
+            "stock": "Stock",
+            "waste": "Waste",
+            "foundation": "{symbol} Foundation"
+          },
+          "info": {
+            "initial": "Draw from the stock or move tableau cards.",
+            "selectDestination": "Choose a destination. Only kings may fill empty columns.",
+            "recyclePrompt": "Click the waste pile to recycle the stock.",
+            "finished": "Congratulations! Try a new deal to test your skills."
+          },
+          "actions": {
+            "drawStock": "Draw Stock (D)",
+            "autoFoundation": "Auto to Foundation (A)",
+            "newGame": "New Deal (R)"
+          },
+          "status": {
+            "summary": "Moves {moves} ・ Recycles {recycles} ・ Stock {stock} ・ Waste {waste} ・ Foundation {foundation}"
+          },
+          "hud": {
+            "bestMoves": "{moves} moves",
+            "scoreSummary": "Total {plays} games / Wins {wins} / Best {best}"
+          },
+          "placeholders": {
+            "recycle": "Redeal",
+            "empty": "Empty"
+          },
+          "toast": {
+            "newLayout": "Starting a new deal.",
+            "emptyStock": "Both the stock and waste are empty.",
+            "recycledWaste": "Returned the waste to the stock.",
+            "noFoundationSpace": "No space available on the foundation.",
+            "invalidTableauMove": "You can't move to that column.",
+            "lockedCard": "You can't flip this card yet.",
+            "cleared": "Klondike cleared!"
+          }
+        },
+        "memory": {
+          "actions": {
+            "retry": "Play Again (R)"
+          },
+          "toast": {
+            "resolveOpenCards": "Close the open cards before flipping another.",
+            "manualReset": "Mismatch. Tap the cards to turn them face down.",
+            "cleared": "Cleared! Time {time} / Misses {misses}"
+          },
+          "flip": {
+            "auto": "Auto",
+            "manual": "Manual"
+          },
+          "status": {
+            "summary": "Pairs {matches}/{pairs} ・ Misses {misses} ・ Time {time} ・ Flip {mode}"
+          },
+          "hud": {
+            "bestSeconds": "{seconds}s",
+            "scoreSummary": "Total {plays} games / Best {best}"
+          }
+        },
+        "hearts": {
+          "actions": {
+            "newDeal": "New Deal (R)",
+            "nextDeal": "Next Deal (R)"
+          },
+          "status": {
+            "summary": "Tricks {trick}/13 ・ Hearts broken {status}",
+            "heartsBroken": {
+              "yes": "Broken",
+              "no": "Not yet"
+            }
+          }
+        },
+        "spider": {
+          "actions": {
+            "dealStock": "Deal Stock (D)"
           }
         },
         "baba": {

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -12560,6 +12560,7 @@
             "hint": "ヒント (H)",
             "restart": "リスタート (R)",
             "returnToList": "ゲーム一覧 (B)",
+            "newGame": "新しいゲーム (R)",
             "rematch": "再戦する"
           },
           "hud": {
@@ -12577,6 +12578,83 @@
           },
           "player": {
             "finished": "{place} 位確定"
+          }
+        },
+        "klondike": {
+          "labels": {
+            "stock": "山札",
+            "waste": "捨て札",
+            "foundation": "{symbol} 台札"
+          },
+          "info": {
+            "initial": "山札をめくるか、場札を選択して移動しましょう。",
+            "selectDestination": "移動先をクリックしてください。空列にはキングのみ置けます。",
+            "recyclePrompt": "捨て札をクリックして山札に戻しましょう。",
+            "finished": "おめでとうございます！新しいゲームで腕試ししましょう。"
+          },
+          "actions": {
+            "drawStock": "山札をめくる (D)",
+            "autoFoundation": "自動で台札へ (A)",
+            "newGame": "新しいゲーム (R)"
+          },
+          "status": {
+            "summary": "移動 {moves} 手 ・ 再構築 {recycles} 回 ・ 山札 {stock} ・ 捨て札 {waste} ・ 台札 {foundation}"
+          },
+          "hud": {
+            "bestMoves": "{moves} 手",
+            "scoreSummary": "通算 {plays} 回 / 勝利 {wins} 回 / ベスト {best}"
+          },
+          "placeholders": {
+            "recycle": "返す",
+            "empty": "空"
+          },
+          "toast": {
+            "newLayout": "新しい配置でゲームを開始しました。",
+            "emptyStock": "山札も捨て札も空です。",
+            "recycledWaste": "捨て札を山札に戻しました。",
+            "noFoundationSpace": "台札に置ける場所がありません。",
+            "invalidTableauMove": "その列には移動できません。",
+            "lockedCard": "このカードはまだ表にできません。",
+            "cleared": "クロンダイクをクリアしました！"
+          }
+        },
+        "memory": {
+          "actions": {
+            "retry": "もう一度 (R)"
+          },
+          "toast": {
+            "resolveOpenCards": "開いたカードを戻してから次をめくってください。",
+            "manualReset": "不一致です。カードをタップして裏返してください。",
+            "cleared": "クリア！タイム {time} / ミス {misses}"
+          },
+          "flip": {
+            "auto": "自動",
+            "manual": "手動"
+          },
+          "status": {
+            "summary": "ペア {matches}/{pairs} ・ ミス {misses} ・ 経過 {time} ・ 裏返し {mode}"
+          },
+          "hud": {
+            "bestSeconds": "{seconds} 秒",
+            "scoreSummary": "通算 {plays} 回 / ベスト {best}"
+          }
+        },
+        "hearts": {
+          "actions": {
+            "newDeal": "新しいディール (R)",
+            "nextDeal": "次のディール (R)"
+          },
+          "status": {
+            "summary": "トリック {trick}/13 ・ ハート解禁 {status}",
+            "heartsBroken": {
+              "yes": "済",
+              "no": "未"
+            }
+          }
+        },
+        "spider": {
+          "actions": {
+            "dealStock": "山札を配る (D)"
           }
         },
         "baba": {


### PR DESCRIPTION
## Summary
- add localized labels, status text, and action metadata for the Klondike solitaire interface
- translate Memory game HUD elements, toasts, and restart actions while wiring locale change updates
- extend the English and Japanese locale tables with the new trump game strings and hook Hearts UI into localization

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68eb2724f94c832b82e02f5815f49eec