### PR TITLE
Fix block data editor localization

### DIFF
--- a/index.html
+++ b/index.html
@@ -743,41 +743,50 @@
                                 </div>
                             </div>
                         </section>
-                        <section id="tool-blockdata-editor" class="tool-panel" data-tool-panel="blockdata-editor" aria-label="ブロックデータ編集ツール">
+                        <section id="tool-blockdata-editor" class="tool-panel" data-tool-panel="blockdata-editor" aria-label="ブロックデータ編集ツール" data-i18n-attr="aria-label:tools.blockdataEditor.panelAriaLabel">
                             <header class="tool-panel-header">
-                                <h3>BlockDataビジュアルエディタ</h3>
-                                <p>blockdata.json を読み込み、BlockDimブロックの一覧・編集・書き出しを行います。</p>
+                                <h3 data-i18n="tools.blockdataEditor.header.title">BlockDataビジュアルエディタ</h3>
+                                <p data-i18n="tools.blockdataEditor.header.description">blockdata.json を読み込み、BlockDimブロックの一覧・編集・書き出しを行います。</p>
                             </header>
                             <div class="blockdata-editor">
-                                <aside class="blockdata-sidebar" aria-label="ブロック一覧">
+                                <aside class="blockdata-sidebar" aria-label="ブロック一覧" data-i18n-attr="aria-label:tools.blockdataEditor.sidebar.ariaLabel">
                                     <div class="blockdata-group">
-                                        <span class="blockdata-group-label">対象セット</span>
-                                        <div class="blockdata-group-buttons" role="tablist" aria-label="BlockDataセット">
-                                            <button type="button" class="blockdata-group-button active" data-block-group="blocks1" aria-pressed="true">1stブロック <span class="count" aria-hidden="true">0</span></button>
-                                            <button type="button" class="blockdata-group-button" data-block-group="blocks2" aria-pressed="false">2ndブロック <span class="count" aria-hidden="true">0</span></button>
-                                            <button type="button" class="blockdata-group-button" data-block-group="blocks3" aria-pressed="false">3rdブロック <span class="count" aria-hidden="true">0</span></button>
+                                        <span class="blockdata-group-label" data-i18n="tools.blockdataEditor.sidebar.groupLabel">対象セット</span>
+                                        <div class="blockdata-group-buttons" role="tablist" aria-label="BlockDataセット" data-i18n-attr="aria-label:tools.blockdataEditor.sidebar.groupAriaLabel">
+                                            <button type="button" class="blockdata-group-button active" data-block-group="blocks1" aria-pressed="true">
+                                                <span class="label" data-i18n="tools.blockdataEditor.sidebar.groups.blocks1">1stブロック</span>
+                                                <span class="count" aria-hidden="true">0</span>
+                                            </button>
+                                            <button type="button" class="blockdata-group-button" data-block-group="blocks2" aria-pressed="false">
+                                                <span class="label" data-i18n="tools.blockdataEditor.sidebar.groups.blocks2">2ndブロック</span>
+                                                <span class="count" aria-hidden="true">0</span>
+                                            </button>
+                                            <button type="button" class="blockdata-group-button" data-block-group="blocks3" aria-pressed="false">
+                                                <span class="label" data-i18n="tools.blockdataEditor.sidebar.groups.blocks3">3rdブロック</span>
+                                                <span class="count" aria-hidden="true">0</span>
+                                            </button>
                                         </div>
                                     </div>
                                     <label class="blockdata-search" for="blockdata-search-input">
-                                        <span>検索</span>
-                                        <input id="blockdata-search-input" type="search" placeholder="名前 / キーで絞り込み">
+                                        <span data-i18n="tools.blockdataEditor.sidebar.searchLabel">検索</span>
+                                        <input id="blockdata-search-input" type="search" placeholder="名前 / キーで絞り込み" data-i18n-attr="placeholder:tools.blockdataEditor.sidebar.searchPlaceholder">
                                     </label>
                                     <div class="blockdata-sidebar-actions">
-                                        <button type="button" id="blockdata-create" class="blockdata-primary">+ 新規ブロック</button>
+                                        <button type="button" id="blockdata-create" class="blockdata-primary" data-i18n="tools.blockdataEditor.sidebar.create">+ 新規ブロック</button>
                                     </div>
-                                    <div id="blockdata-list" class="blockdata-list" role="listbox" aria-label="ブロック候補"></div>
+                                    <div id="blockdata-list" class="blockdata-list" role="listbox" aria-label="ブロック候補" data-i18n-attr="aria-label:tools.blockdataEditor.sidebar.listAriaLabel"></div>
                                 </aside>
                                 <div class="blockdata-main">
                                     <div class="blockdata-filebar">
                                         <label class="blockdata-version">
-                                            <span>バージョン</span>
+                                            <span data-i18n="tools.blockdataEditor.main.versionLabel">バージョン</span>
                                             <input id="blockdata-version" type="number" min="1" step="1" value="1">
                                         </label>
                                         <div class="blockdata-file-actions">
-                                            <button type="button" id="blockdata-reload">再読込</button>
-                                            <button type="button" id="blockdata-import">インポート</button>
-                                            <button type="button" id="blockdata-copy">コピー</button>
-                                            <button type="button" id="blockdata-download">ダウンロード</button>
+                                            <button type="button" id="blockdata-reload" data-i18n="tools.blockdataEditor.main.actions.reload">再読込</button>
+                                            <button type="button" id="blockdata-import" data-i18n="tools.blockdataEditor.main.actions.import">インポート</button>
+                                            <button type="button" id="blockdata-copy" data-i18n="tools.blockdataEditor.main.actions.copy">コピー</button>
+                                            <button type="button" id="blockdata-download" data-i18n="tools.blockdataEditor.main.actions.download">ダウンロード</button>
                                         </div>
                                         <input type="file" id="blockdata-import-file" accept="application/json" hidden>
                                     </div>
@@ -785,30 +794,30 @@
                                     <p id="blockdata-status" class="blockdata-status" role="status"></p>
                                     <form id="blockdata-form">
                                         <fieldset data-blockdata-fieldset disabled>
-                                            <legend id="blockdata-form-legend">ブロック詳細</legend>
+                                            <legend id="blockdata-form-legend" data-i18n="tools.blockdataEditor.main.formLegend">ブロック詳細</legend>
                                             <div class="blockdata-form-grid">
                                                 <label>
-                                                    <span>キー</span>
-                                                    <input id="blockdata-field-key" type="text" required placeholder="例: b3999">
+                                                    <span data-i18n="tools.blockdataEditor.main.fields.key.label">キー</span>
+                                                    <input id="blockdata-field-key" type="text" required placeholder="例: b3999" data-i18n-attr="placeholder:tools.blockdataEditor.main.fields.key.placeholder">
                                                 </label>
                                                 <label>
-                                                    <span>名前</span>
-                                                    <input id="blockdata-field-name" type="text" required placeholder="ブロック名">
+                                                    <span data-i18n="tools.blockdataEditor.main.fields.name.label">名前</span>
+                                                    <input id="blockdata-field-name" type="text" required placeholder="ブロック名" data-i18n-attr="placeholder:tools.blockdataEditor.main.fields.name.placeholder">
                                                 </label>
                                                 <label>
-                                                    <span>推奨Lv</span>
+                                                    <span data-i18n="tools.blockdataEditor.main.fields.level.label">推奨Lv</span>
                                                     <input id="blockdata-field-level" type="number" step="1" value="0">
                                                 </label>
                                                 <label>
-                                                    <span>サイズ</span>
+                                                    <span data-i18n="tools.blockdataEditor.main.fields.size.label">サイズ</span>
                                                     <input id="blockdata-field-size" type="number" step="1" value="0">
                                                 </label>
                                                 <label>
-                                                    <span>深さ</span>
+                                                    <span data-i18n="tools.blockdataEditor.main.fields.depth.label">深さ</span>
                                                     <input id="blockdata-field-depth" type="number" step="1" value="0">
                                                 </label>
                                                 <label>
-                                                    <span>宝箱</span>
+                                                    <span data-i18n="tools.blockdataEditor.main.fields.chest.label">宝箱</span>
                                                     <select id="blockdata-field-chest">
                                                         <option value="normal">normal</option>
                                                         <option value="more">more</option>
@@ -816,27 +825,27 @@
                                                     </select>
                                                 </label>
                                                 <label>
-                                                    <span>タイプ</span>
-                                                    <input id="blockdata-field-type" type="text" list="blockdata-type-options" placeholder="例: maze">
+                                                    <span data-i18n="tools.blockdataEditor.main.fields.type.label">タイプ</span>
+                                                    <input id="blockdata-field-type" type="text" list="blockdata-type-options" placeholder="例: maze" data-i18n-attr="placeholder:tools.blockdataEditor.main.fields.type.placeholder">
                                                 </label>
                                                 <label class="full">
-                                                    <span>ボス階層</span>
-                                                    <input id="blockdata-field-bossfloors" type="text" placeholder="カンマ区切り (例: 5,10)">
+                                                    <span data-i18n="tools.blockdataEditor.main.fields.bossFloors.label">ボス階層</span>
+                                                    <input id="blockdata-field-bossfloors" type="text" placeholder="カンマ区切り (例: 5,10)" data-i18n-attr="placeholder:tools.blockdataEditor.main.fields.bossFloors.placeholder">
                                                 </label>
                                                 <label class="full">
-                                                    <span>追加プロパティ(JSON)</span>
+                                                    <span data-i18n="tools.blockdataEditor.main.fields.extras.label">追加プロパティ(JSON)</span>
                                                     <textarea id="blockdata-field-extras" rows="4" placeholder="{}"></textarea>
                                                 </label>
                                             </div>
                                         </fieldset>
                                         <div class="blockdata-form-actions">
-                                            <button type="button" id="blockdata-save" class="blockdata-primary" disabled>選択を保存</button>
-                                            <button type="button" id="blockdata-delete" class="blockdata-danger" disabled>削除</button>
+                                            <button type="button" id="blockdata-save" class="blockdata-primary" disabled data-i18n="tools.blockdataEditor.main.formActions.save">選択を保存</button>
+                                            <button type="button" id="blockdata-delete" class="blockdata-danger" disabled data-i18n="tools.blockdataEditor.main.formActions.delete">削除</button>
                                         </div>
                                     </form>
-                                    <section class="blockdata-preview-section" aria-label="JSONプレビュー">
+                                    <section class="blockdata-preview-section" aria-label="JSONプレビュー" data-i18n-attr="aria-label:tools.blockdataEditor.main.preview.ariaLabel">
                                         <header>
-                                            <h4>blockdata.jsonプレビュー</h4>
+                                            <h4 data-i18n="tools.blockdataEditor.main.preview.title">blockdata.jsonプレビュー</h4>
                                             <span id="blockdata-preview-size" class="blockdata-preview-size"></span>
                                         </header>
                                         <textarea id="blockdata-json-preview" readonly></textarea>
@@ -857,6 +866,7 @@
                                 <option value="wide-maze"></option>
                                 <option value="snake"></option>
                             </datalist>
+                        </section>
                         <section id="tool-image-viewer" class="tool-panel" data-tool-panel="image-viewer" aria-label="画像ビューア">
                             <header class="tool-panel-header">
                                 <h3>画像ビューア</h3>

--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -15069,6 +15069,102 @@
           }
         }
       },
+      "blockdataEditor": {
+        "panelAriaLabel": "Block Data Editor",
+        "header": {
+          "title": "BlockData Visual Editor",
+          "description": "Load blockdata.json to review, edit, and export BlockDim block definitions."
+        },
+        "sidebar": {
+          "ariaLabel": "Block list",
+          "groupLabel": "Target set",
+          "groupAriaLabel": "BlockData sets",
+          "groups": {
+            "blocks1": "1st Blocks",
+            "blocks2": "2nd Blocks",
+            "blocks3": "3rd Blocks"
+          },
+          "searchLabel": "Search",
+          "searchPlaceholder": "Filter by name or key",
+          "create": "+ New block",
+          "listAriaLabel": "Block candidates",
+          "empty": {
+            "noData": "No data loaded.",
+            "noMatches": "No blocks match the filter.",
+            "noBlocks": "No blocks available."
+          },
+          "untitled": "(Untitled)"
+        },
+        "main": {
+          "versionLabel": "Version",
+          "actions": {
+            "reload": "Reload",
+            "import": "Import",
+            "copy": "Copy",
+            "download": "Download"
+          },
+          "formLegend": "Block details",
+          "fields": {
+            "key": { "label": "Key", "placeholder": "e.g. b3999" },
+            "name": { "label": "Name", "placeholder": "Block name" },
+            "level": { "label": "Recommended Lv" },
+            "size": { "label": "Size" },
+            "depth": { "label": "Depth" },
+            "chest": { "label": "Chest" },
+            "type": { "label": "Type", "placeholder": "e.g. maze" },
+            "bossFloors": { "label": "Boss floors", "placeholder": "Comma separated (e.g. 5,10)" },
+            "extras": { "label": "Extra properties (JSON)" }
+          },
+          "formActions": {
+            "save": "Save selection",
+            "delete": "Delete"
+          },
+          "preview": {
+            "ariaLabel": "JSON preview",
+            "title": "blockdata.json preview",
+            "size": "{lines} lines / {bytes} bytes"
+          },
+          "dirty": {
+            "dirty": "Unsaved changes detected. Remember to export or copy your data.",
+            "clean": "All changes saved."
+          },
+          "status": {
+            "loading": "Loading blockdata.json…",
+            "loadSuccess": "Loaded blockdata.json.",
+            "loadError": "Failed to load blockdata.json. Please import data manually.",
+            "noData": "No data loaded.",
+            "creating": "Creating a new block. Fill in the required fields.",
+            "importSuccess": "Loaded {name}.",
+            "importParseError": "Failed to parse JSON. Please verify the format.",
+            "importReadError": "Could not read the file.",
+            "saved": "Block saved.",
+            "deleteNoSelection": "No block is selected for deletion.",
+            "deleted": "Block deleted.",
+            "copyEmpty": "Nothing to copy.",
+            "copied": "Copied to clipboard.",
+            "copyFailed": "Copy failed.",
+            "downloadEmpty": "Nothing to download.",
+            "downloaded": "JSON file downloaded."
+          },
+          "confirm": {
+            "reload": "Unsaved changes will be lost. Reload anyway?",
+            "delete": "Delete the selected block?",
+            "discard": "Discard the in-progress edits?"
+          },
+          "list": {
+            "levelValue": "Lv {level}",
+            "levelUnknown": "Lv -",
+            "meta": "{key} · {level}"
+          }
+        },
+        "errors": {
+          "extrasObject": "Extra properties must be a JSON object.",
+          "missingKey": "Enter a key.",
+          "missingName": "Enter a name.",
+          "duplicateKey": "A block with the same key already exists.",
+          "invalidBossFloor": "Boss floors contain a non-numeric value: {value}"
+        }
+      },
       "modMaker": {
         "panelAriaLabel": "Dungeon Type Mod Maker",
         "header": {

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -15015,6 +15015,102 @@
           }
         }
       },
+      "blockdataEditor": {
+        "panelAriaLabel": "ブロックデータ編集ツール",
+        "header": {
+          "title": "BlockDataビジュアルエディタ",
+          "description": "blockdata.json を読み込み、BlockDimブロックの一覧・編集・書き出しを行います。"
+        },
+        "sidebar": {
+          "ariaLabel": "ブロック一覧",
+          "groupLabel": "対象セット",
+          "groupAriaLabel": "BlockDataセット",
+          "groups": {
+            "blocks1": "1stブロック",
+            "blocks2": "2ndブロック",
+            "blocks3": "3rdブロック"
+          },
+          "searchLabel": "検索",
+          "searchPlaceholder": "名前 / キーで絞り込み",
+          "create": "+ 新規ブロック",
+          "listAriaLabel": "ブロック候補",
+          "empty": {
+            "noData": "データが読み込まれていません。",
+            "noMatches": "該当するブロックがありません。",
+            "noBlocks": "ブロックがありません。"
+          },
+          "untitled": "(無題)"
+        },
+        "main": {
+          "versionLabel": "バージョン",
+          "actions": {
+            "reload": "再読込",
+            "import": "インポート",
+            "copy": "コピー",
+            "download": "ダウンロード"
+          },
+          "formLegend": "ブロック詳細",
+          "fields": {
+            "key": { "label": "キー", "placeholder": "例: b3999" },
+            "name": { "label": "名前", "placeholder": "ブロック名" },
+            "level": { "label": "推奨Lv" },
+            "size": { "label": "サイズ" },
+            "depth": { "label": "深さ" },
+            "chest": { "label": "宝箱" },
+            "type": { "label": "タイプ", "placeholder": "例: maze" },
+            "bossFloors": { "label": "ボス階層", "placeholder": "カンマ区切り (例: 5,10)" },
+            "extras": { "label": "追加プロパティ(JSON)" }
+          },
+          "formActions": {
+            "save": "選択を保存",
+            "delete": "削除"
+          },
+          "preview": {
+            "ariaLabel": "JSONプレビュー",
+            "title": "blockdata.jsonプレビュー",
+            "size": "{lines} 行 / {bytes} bytes"
+          },
+          "dirty": {
+            "dirty": "未保存の変更があります。エクスポートまたはコピーを忘れずに。",
+            "clean": "最新の状態です。"
+          },
+          "status": {
+            "loading": "blockdata.json を読み込んでいます…",
+            "loadSuccess": "blockdata.json を読み込みました。",
+            "loadError": "blockdata.json の読み込みに失敗しました。インポートから読み込んでください。",
+            "noData": "データが読み込まれていません。",
+            "creating": "新規ブロックを作成中です。必要な項目を入力してください。",
+            "importSuccess": "{name} を読み込みました。",
+            "importParseError": "JSONの読み込みに失敗しました。形式を確認してください。",
+            "importReadError": "ファイルを読み込めませんでした。",
+            "saved": "ブロックを保存しました。",
+            "deleteNoSelection": "削除対象のブロックが選択されていません。",
+            "deleted": "ブロックを削除しました。",
+            "copyEmpty": "コピーする内容がありません。",
+            "copied": "クリップボードにコピーしました。",
+            "copyFailed": "コピーできませんでした。",
+            "downloadEmpty": "ダウンロードする内容がありません。",
+            "downloaded": "JSONファイルをダウンロードしました。"
+          },
+          "confirm": {
+            "reload": "未エクスポートの変更が失われます。再読込しますか？",
+            "delete": "選択したブロックを削除しますか？",
+            "discard": "編集中の内容が破棄されます。続行しますか？"
+          },
+          "list": {
+            "levelValue": "Lv {level}",
+            "levelUnknown": "Lv -",
+            "meta": "{key} · {level}"
+          }
+        },
+        "errors": {
+          "extrasObject": "追加プロパティはJSONオブジェクトで入力してください。",
+          "missingKey": "キーを入力してください。",
+          "missingName": "名前を入力してください。",
+          "duplicateKey": "同じキーのブロックが既に存在します。",
+          "invalidBossFloor": "ボス階層に数値ではない値があります: {value}"
+        }
+      },
       "modMaker": {
         "panelAriaLabel": "ダンジョンタイプMod作成ツール",
         "header": {

--- a/js/tools/blockdata-editor.js
+++ b/js/tools/blockdata-editor.js
@@ -1,6 +1,8 @@
 (function (global) {
     'use strict';
 
+    const i18n = global.I18n || null;
+
     const GROUPS = ['blocks1', 'blocks2', 'blocks3'];
     const STANDARD_KEYS = new Set(['key', 'name', 'level', 'size', 'depth', 'chest', 'type', 'bossFloors']);
     const CHEST_OPTIONS = ['normal', 'more', 'less'];
@@ -15,11 +17,46 @@
         form: null,
         formDirty: false,
         dirty: false,
-        loading: false
+        loading: false,
+        localeUnsubscribe: null
     };
 
     const refs = {};
     let pendingSerializedState = null;
+    let lastStatusPayload = { key: null, params: null, fallback: '', isError: false, variant: null };
+
+    function translate(key, params, fallback) {
+        if (key && i18n && typeof i18n.t === 'function') {
+            const value = i18n.t(key, params);
+            if (value !== undefined && value !== null && value !== key) {
+                return value;
+            }
+        }
+        if (typeof fallback === 'function') {
+            return fallback();
+        }
+        if (fallback !== undefined && fallback !== null) {
+            return fallback;
+        }
+        if (typeof key === 'string') {
+            return key;
+        }
+        return '';
+    }
+
+    function applyStatusFromPayload() {
+        if (!refs.status) return;
+        const { key, params, fallback, isError, variant } = lastStatusPayload || {};
+        const text = key ? translate(key, params, fallback) : (typeof fallback === 'string' ? fallback : (typeof fallback === 'function' ? fallback() : ''));
+        refs.status.textContent = text || '';
+        refs.status.classList.remove('error', 'success');
+        if (!text) return;
+        if (variant === 'success') {
+            refs.status.classList.add('success');
+        } else if (variant === 'error' || isError) {
+            refs.status.classList.add('error');
+        }
+    }
 
     function createEmptyData() {
         return {
@@ -129,6 +166,16 @@
         refs.previewSize = panel.querySelector('#blockdata-preview-size');
     }
 
+    function refreshLocaleDependentUI() {
+        if (state.panel && i18n && typeof i18n.applyTranslations === 'function') {
+            i18n.applyTranslations(state.panel);
+        }
+        updateDirtyIndicator();
+        renderList();
+        renderPreview();
+        applyStatusFromPayload();
+    }
+
     function bindEvents() {
         refs.groupButtons.forEach(btn => {
             btn.addEventListener('click', () => {
@@ -209,6 +256,12 @@
         cacheElements(context.panel);
         bindEvents();
         resetUI();
+        if (!state.localeUnsubscribe && i18n && typeof i18n.onLocaleChanged === 'function') {
+            state.localeUnsubscribe = i18n.onLocaleChanged(() => {
+                refreshLocaleDependentUI();
+            });
+        }
+        refreshLocaleDependentUI();
         loadInitialData();
     }
 
@@ -232,7 +285,10 @@
     }
 
     function loadInitialData() {
-        setStatus('blockdata.json を読み込んでいます…');
+        setStatus({
+            key: 'tools.blockdataEditor.main.status.loading',
+            fallback: 'blockdata.json を読み込んでいます…'
+        });
         state.loading = true;
         fetch('blockdata.json', { cache: 'no-store' })
             .then(res => {
@@ -243,12 +299,20 @@
             })
             .then(data => {
                 applyData(data);
-                setStatus('blockdata.json を読み込みました。', false, 'success');
+                setStatus({
+                    key: 'tools.blockdataEditor.main.status.loadSuccess',
+                    fallback: 'blockdata.json を読み込みました。',
+                    variant: 'success'
+                });
             })
             .catch(err => {
                 console.warn('[BlockDataEditor] Failed to load blockdata.json:', err);
                 applyData(createEmptyData());
-                setStatus('blockdata.json の読み込みに失敗しました。インポートから読み込んでください。', true);
+                setStatus({
+                    key: 'tools.blockdataEditor.main.status.loadError',
+                    fallback: 'blockdata.json の読み込みに失敗しました。インポートから読み込んでください。',
+                    isError: true
+                });
             })
             .finally(() => {
                 state.loading = false;
@@ -313,7 +377,11 @@
         if (!state.data) {
             const empty = document.createElement('p');
             empty.className = 'blockdata-empty';
-            empty.textContent = 'データが読み込まれていません。';
+            empty.textContent = translate(
+                'tools.blockdataEditor.sidebar.empty.noData',
+                null,
+                'データが読み込まれていません。'
+            );
             refs.list.appendChild(empty);
             return;
         }
@@ -330,7 +398,9 @@
         if (!filtered.length) {
             const empty = document.createElement('p');
             empty.className = 'blockdata-empty';
-            empty.textContent = term ? '該当するブロックがありません。' : 'ブロックがありません。';
+            empty.textContent = term
+                ? translate('tools.blockdataEditor.sidebar.empty.noMatches', null, '該当するブロックがありません。')
+                : translate('tools.blockdataEditor.sidebar.empty.noBlocks', null, 'ブロックがありません。');
             refs.list.appendChild(empty);
             return;
         }
@@ -346,11 +416,19 @@
             btn.dataset.index = String(index);
 
             const title = document.createElement('strong');
-            title.textContent = block.name || '(無題)';
+            const displayName = block.name || translate('tools.blockdataEditor.sidebar.untitled', null, '(無題)');
+            title.textContent = displayName;
             const meta = document.createElement('span');
             meta.className = 'meta';
-            const levelText = Number.isFinite(block.level) ? `Lv ${block.level}` : 'Lv -';
-            meta.textContent = `${block.key || '-'} · ${levelText}`;
+            const levelText = Number.isFinite(block.level)
+                ? translate('tools.blockdataEditor.main.list.levelValue', { level: block.level }, `Lv ${block.level}`)
+                : translate('tools.blockdataEditor.main.list.levelUnknown', null, 'Lv -');
+            const metaText = translate(
+                'tools.blockdataEditor.main.list.meta',
+                { key: block.key || '-', level: levelText },
+                `${block.key || '-'} · ${levelText}`
+            );
+            meta.textContent = metaText;
             btn.appendChild(title);
             btn.appendChild(meta);
 
@@ -452,35 +530,62 @@
     }
 
     function setStatus(message, isError = false, variant = null) {
-        if (!refs.status) return;
-        refs.status.textContent = message || '';
-        refs.status.classList.remove('error', 'success');
-        if (!message) return;
-        if (variant === 'success') {
-            refs.status.classList.add('success');
-        } else if (variant === 'error' || isError) {
-            refs.status.classList.add('error');
+        if (message && typeof message === 'object') {
+            const payload = message;
+            const payloadIsError = typeof payload.isError === 'boolean' ? payload.isError : isError;
+            const payloadVariant = payload.variant !== undefined ? payload.variant : variant;
+            const fallback = payload.fallback !== undefined ? payload.fallback : (payload.text !== undefined ? payload.text : '');
+            lastStatusPayload = {
+                key: payload.key || null,
+                params: payload.params || null,
+                fallback,
+                isError: payloadIsError,
+                variant: payloadVariant
+            };
+            applyStatusFromPayload();
+            return;
         }
+        lastStatusPayload = {
+            key: null,
+            params: null,
+            fallback: message || '',
+            isError,
+            variant
+        };
+        applyStatusFromPayload();
     }
 
     function clearStatus() {
-        setStatus('');
+        lastStatusPayload = { key: null, params: null, fallback: '', isError: false, variant: null };
+        applyStatusFromPayload();
     }
 
     function updateDirtyIndicator() {
         if (!refs.dirtyIndicator) return;
         if (state.dirty) {
-            refs.dirtyIndicator.textContent = '未保存の変更があります。エクスポートまたはコピーを忘れずに。';
+            refs.dirtyIndicator.textContent = translate(
+                'tools.blockdataEditor.main.dirty.dirty',
+                null,
+                '未保存の変更があります。エクスポートまたはコピーを忘れずに。'
+            );
             refs.dirtyIndicator.classList.add('is-dirty');
         } else {
-            refs.dirtyIndicator.textContent = '最新の状態です。';
+            refs.dirtyIndicator.textContent = translate(
+                'tools.blockdataEditor.main.dirty.clean',
+                null,
+                '最新の状態です。'
+            );
             refs.dirtyIndicator.classList.remove('is-dirty');
         }
     }
 
     function handleCreateNew() {
         if (!state.data) {
-            setStatus('データが読み込まれていません。', true);
+            setStatus({
+                key: 'tools.blockdataEditor.main.status.noData',
+                fallback: 'データが読み込まれていません。',
+                isError: true
+            });
             return;
         }
         if (!maybeDiscardForm()) return;
@@ -490,7 +595,10 @@
         state.formDirty = true;
         fillForm();
         updateFormButtons();
-        setStatus('新規ブロックを作成中です。必要な項目を入力してください。');
+        setStatus({
+            key: 'tools.blockdataEditor.main.status.creating',
+            fallback: '新規ブロックを作成中です。必要な項目を入力してください。'
+        });
         if (refs.fieldKey) refs.fieldKey.focus();
     }
 
@@ -507,7 +615,11 @@
 
     function handleReload() {
         if (state.loading) return;
-        if ((state.dirty || state.formDirty) && !confirm('未エクスポートの変更が失われます。再読込しますか？')) {
+        if ((state.dirty || state.formDirty) && !confirm(translate(
+            'tools.blockdataEditor.main.confirm.reload',
+            null,
+            '未エクスポートの変更が失われます。再読込しますか？'
+        ))) {
             return;
         }
         loadInitialData();
@@ -521,14 +633,27 @@
             try {
                 const parsed = JSON.parse(e.target.result);
                 applyData(parsed);
-                setStatus(`${file.name} を読み込みました。`, false, 'success');
+                setStatus({
+                    key: 'tools.blockdataEditor.main.status.importSuccess',
+                    params: { name: file.name },
+                    fallback: `${file.name} を読み込みました。`,
+                    variant: 'success'
+                });
             } catch (err) {
                 console.error('[BlockDataEditor] Failed to import file:', err);
-                setStatus('JSONの読み込みに失敗しました。形式を確認してください。', true);
+                setStatus({
+                    key: 'tools.blockdataEditor.main.status.importParseError',
+                    fallback: 'JSONの読み込みに失敗しました。形式を確認してください。',
+                    isError: true
+                });
             }
         };
         reader.onerror = () => {
-            setStatus('ファイルを読み込めませんでした。', true);
+            setStatus({
+                key: 'tools.blockdataEditor.main.status.importReadError',
+                fallback: 'ファイルを読み込めませんでした。',
+                isError: true
+            });
         };
         reader.readAsText(file, 'utf-8');
     }
@@ -556,7 +681,7 @@
             }
             return parsed;
         } catch (err) {
-            throw new Error('追加プロパティはJSONオブジェクトで入力してください。');
+            throw new Error(translate('tools.blockdataEditor.errors.extrasObject', null, '追加プロパティはJSONオブジェクトで入力してください。'));
         }
     }
 
@@ -568,23 +693,27 @@
         const list = state.data[group] || [];
         const key = state.form.key.trim();
         if (!key) {
-            errors.push('キーを入力してください。');
+            errors.push(translate('tools.blockdataEditor.errors.missingKey', null, 'キーを入力してください。'));
         }
         const name = state.form.name.trim();
         if (!name) {
-            errors.push('名前を入力してください。');
+            errors.push(translate('tools.blockdataEditor.errors.missingName', null, '名前を入力してください。'));
         }
         if (key) {
             const duplicateIndex = list.findIndex((item, idx) => item.key === key && idx !== state.selectedIndex);
             if (duplicateIndex >= 0) {
-                errors.push('同じキーのブロックが既に存在します。');
+                errors.push(translate('tools.blockdataEditor.errors.duplicateKey', null, '同じキーのブロックが既に存在します。'));
             }
         }
         let bossFloorsResult = { values: [] };
         if (state.form.bossFloorsText) {
             bossFloorsResult = parseBossFloors(state.form.bossFloorsText);
             if (bossFloorsResult.error) {
-                errors.push(`ボス階層に数値ではない値があります: ${bossFloorsResult.error}`);
+                errors.push(translate(
+                    'tools.blockdataEditor.errors.invalidBossFloor',
+                    { value: bossFloorsResult.error },
+                    `ボス階層に数値ではない値があります: ${bossFloorsResult.error}`
+                ));
             }
         }
         let extras = {};
@@ -630,17 +759,25 @@
         updateGroupCounts();
         renderList();
         renderPreview();
-        setStatus('ブロックを保存しました。', false, 'success');
+        setStatus({
+            key: 'tools.blockdataEditor.main.status.saved',
+            fallback: 'ブロックを保存しました。',
+            variant: 'success'
+        });
         global.AchievementSystem?.recordEvent('tools_blockdata_save');
     }
 
     function handleDelete() {
         if (!state.data) return;
         if (state.selectedIndex < 0 || !GROUPS.includes(state.selectedGroup)) {
-            setStatus('削除対象のブロックが選択されていません。', true);
+            setStatus({
+                key: 'tools.blockdataEditor.main.status.deleteNoSelection',
+                fallback: '削除対象のブロックが選択されていません。',
+                isError: true
+            });
             return;
         }
-        if (!confirm('選択したブロックを削除しますか？')) {
+        if (!confirm(translate('tools.blockdataEditor.main.confirm.delete', null, '選択したブロックを削除しますか？'))) {
             return;
         }
         const list = state.data[state.selectedGroup];
@@ -655,7 +792,11 @@
         renderList();
         renderPreview();
         markDirty();
-        setStatus('ブロックを削除しました。', false, 'success');
+        setStatus({
+            key: 'tools.blockdataEditor.main.status.deleted',
+            fallback: 'ブロックを削除しました。',
+            variant: 'success'
+        });
     }
 
     function markDirty() {
@@ -678,7 +819,12 @@
             if (typeof TextEncoder !== 'undefined') {
                 bytes = new TextEncoder().encode(jsonString).length;
             }
-            refs.previewSize.textContent = `${lines.toLocaleString()} 行 / ${bytes.toLocaleString()} bytes`;
+            const sizeText = translate(
+                'tools.blockdataEditor.main.preview.size',
+                { lines: lines.toLocaleString(), bytes: bytes.toLocaleString() },
+                `${lines.toLocaleString()} 行 / ${bytes.toLocaleString()} bytes`
+            );
+            refs.previewSize.textContent = sizeText;
         }
     }
 
@@ -686,12 +832,20 @@
         if (!refs.preview) return;
         const text = refs.preview.value;
         if (!text) {
-            setStatus('コピーする内容がありません。', true);
+            setStatus({
+                key: 'tools.blockdataEditor.main.status.copyEmpty',
+                fallback: 'コピーする内容がありません。',
+                isError: true
+            });
             return;
         }
         if (navigator.clipboard?.writeText) {
             navigator.clipboard.writeText(text)
-                .then(() => setStatus('クリップボードにコピーしました。', false, 'success'))
+                .then(() => setStatus({
+                    key: 'tools.blockdataEditor.main.status.copied',
+                    fallback: 'クリップボードにコピーしました。',
+                    variant: 'success'
+                }))
                 .catch(err => {
                     console.warn('[BlockDataEditor] Clipboard write failed:', err);
                     fallbackCopy(text);
@@ -714,10 +868,18 @@
         textarea.select();
         try {
             document.execCommand('copy');
-            setStatus('クリップボードにコピーしました。', false, 'success');
+            setStatus({
+                key: 'tools.blockdataEditor.main.status.copied',
+                fallback: 'クリップボードにコピーしました。',
+                variant: 'success'
+            });
         } catch (err) {
             console.error('[BlockDataEditor] execCommand copy failed:', err);
-            setStatus('コピーできませんでした。', true);
+            setStatus({
+                key: 'tools.blockdataEditor.main.status.copyFailed',
+                fallback: 'コピーできませんでした。',
+                isError: true
+            });
         }
         document.body.removeChild(textarea);
     }
@@ -726,7 +888,11 @@
         if (!refs.preview) return;
         const text = refs.preview.value;
         if (!text) {
-            setStatus('ダウンロードする内容がありません。', true);
+            setStatus({
+                key: 'tools.blockdataEditor.main.status.downloadEmpty',
+                fallback: 'ダウンロードする内容がありません。',
+                isError: true
+            });
             return;
         }
         const blob = new Blob([text], { type: 'application/json' });
@@ -738,13 +904,17 @@
         a.click();
         document.body.removeChild(a);
         setTimeout(() => URL.revokeObjectURL(url), 500);
-        setStatus('JSONファイルをダウンロードしました。', false, 'success');
+        setStatus({
+            key: 'tools.blockdataEditor.main.status.downloaded',
+            fallback: 'JSONファイルをダウンロードしました。',
+            variant: 'success'
+        });
         global.AchievementSystem?.recordEvent('tools_blockdata_download');
     }
 
     function maybeDiscardForm() {
         if (!state.formDirty) return true;
-        const ok = confirm('編集中の内容が破棄されます。続行しますか？');
+        const ok = confirm(translate('tools.blockdataEditor.main.confirm.discard', null, '編集中の内容が破棄されます。続行しますか？'));
         if (ok) {
             state.formDirty = false;
         }


### PR DESCRIPTION
## Summary
- add localization hooks to the BlockData editor markup and wire it to the global i18n system
- translate BlockData editor UI strings and status messages in the Japanese and English locale bundles
- update the BlockData editor script to surface localized strings, remember status keys, and refresh when the language changes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68eb2bc2b720832ba7256b8e18cc0b9b