### PR TITLE
Fix localization fallback handling in trump games

### DIFF
--- a/games/trump_games.js
+++ b/games/trump_games.js
@@ -500,6 +500,38 @@
     const localization = opts?.localization || (typeof window !== 'undefined' && typeof window.createMiniGameLocalization === 'function'
       ? window.createMiniGameLocalization({ id: 'trump_games' })
       : null);
+    const formatTemplateString = (template, params) => {
+      if (template == null) return '';
+      const source = String(template);
+      if (!params || typeof params !== 'object') return source;
+      return source.replace(/\{([^{}]+)\}/g, (match, token) => {
+        const key = token.trim();
+        if (!key) return match;
+        const value = params[key];
+        return value === undefined || value === null ? match : String(value);
+      });
+    };
+    const computeFallbackText = (fallback, params) => {
+      if (typeof fallback === 'function') {
+        try {
+          const result = fallback(params || {});
+          return result == null ? '' : String(result);
+        } catch (error) {
+          console.warn('[Mini Trump] fallback text error', error);
+          return '';
+        }
+      }
+      if (typeof fallback === 'string') {
+        return formatTemplateString(fallback, params);
+      }
+      if (fallback == null) return '';
+      try {
+        return String(fallback);
+      } catch (error) {
+        console.warn('[Mini Trump] failed to stringify fallback text', error);
+        return '';
+      }
+    };
     const getLocale = () => {
       if (localization && typeof localization.getLocale === 'function') {
         try {
@@ -512,15 +544,21 @@
       return 'ja';
     };
     const text = (key, fallback, params) => {
+      const fallbackText = computeFallbackText(fallback, params);
       if (localization && typeof localization.t === 'function') {
-        try { return localization.t(key, fallback, params); } catch (error) {
+        try {
+          const translated = localization.t(key, fallbackText, params);
+          if (typeof translated === 'string' && translated.length) {
+            return translated;
+          }
+          if (translated != null && typeof translated !== 'string') {
+            return String(translated);
+          }
+        } catch (error) {
           console.warn('[Mini Trump] localization error', error);
         }
       }
-      if (typeof fallback === 'function') {
-        try { return fallback(params || {}); } catch { return ''; }
-      }
-      return fallback ?? '';
+      return fallbackText;
     };
     const formatNumber = (value, options) => {
       if (localization && typeof localization.formatNumber === 'function') {


### PR DESCRIPTION
## Summary
- precompute localization fallbacks for trump games so parameterised strings remain available when translations are missing
- return formatted fallback text whenever localization fails to resolve a translation to keep game initialization stable

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68eb2cfa9820832b84a774a5d6983922