### PR TITLE
fix: localize state manager tool

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -15059,7 +15059,35 @@
         },
         "stateManager": {
           "label": "State Manager",
-          "hint": "Export or import all game and tool data in one bundle."
+          "hint": "Export or import all game and tool data in one bundle.",
+          "summary": {
+            "default": "Export/import summary will appear here.",
+            "exportedAt": "Exported at: {value}",
+            "player": "Player: Lv {level} / HP {hp}",
+            "dungeon": "Current floor: {floor}F / Difficulty: {difficulty}",
+            "miniExp": "MiniExp: Selected {selected} / Records {records}",
+            "blockDim": "BlockDim: History {history} / Bookmarks {bookmarks}",
+            "tools": "Tool data: {names}",
+            "noTools": "Tool data: none",
+            "toolSeparator": ", "
+          },
+          "toolNames": {
+            "modMaker": "Mod Maker",
+            "blockDataEditor": "BlockData Editor",
+            "sandbox": "Sandbox",
+            "imageViewer": "Image Viewer"
+          },
+          "status": {
+            "exportPreparing": "Preparing full export…",
+            "exportSuccess": "Saved as {fileName}.",
+            "exportError": "Export failed. Check the console log.",
+            "importReading": "Loading {fileName}…",
+            "importSuccess": "Full import completed.",
+            "importError": "Import failed. Verify the file format."
+          },
+          "messages": {
+            "importComplete": "Imported state data."
+          }
         }
       },
       "sandbox": {

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -15005,7 +15005,35 @@
         },
         "stateManager": {
           "label": "状態管理",
-          "hint": "ゲームとツールの全データをまとめてエクスポート／インポートします。"
+          "hint": "ゲームとツールの全データをまとめてエクスポート／インポートします。",
+          "summary": {
+            "default": "エクスポート／インポートの概要がここに表示されます。",
+            "exportedAt": "エクスポート日時: {value}",
+            "player": "プレイヤー: Lv {level} / HP {hp}",
+            "dungeon": "現在階層: {floor}F / 難易度: {difficulty}",
+            "miniExp": "MiniExp: 選択 {selected} / 記録 {records}件",
+            "blockDim": "BlockDim: 履歴 {history}件 / ブックマーク {bookmarks}件",
+            "tools": "ツールデータ: {names}",
+            "noTools": "ツールデータ: なし",
+            "toolSeparator": "、"
+          },
+          "toolNames": {
+            "modMaker": "Mod作成",
+            "blockDataEditor": "BlockData編集",
+            "sandbox": "サンドボックス",
+            "imageViewer": "画像ビューア"
+          },
+          "status": {
+            "exportPreparing": "全体エクスポートを準備しています…",
+            "exportSuccess": "{fileName} として保存しました。",
+            "exportError": "エクスポートに失敗しました。コンソールログを確認してください。",
+            "importReading": "{fileName} を読み込み中です…",
+            "importSuccess": "全体インポートが完了しました。",
+            "importError": "インポートに失敗しました。ファイル形式を確認してください。"
+          },
+          "messages": {
+            "importComplete": "状態データをインポートしました。"
+          }
         }
       },
       "sandbox": {


### PR DESCRIPTION
## Summary
- localize the tools state manager UI strings and status updates via the global i18n service
- add locale change handling and translation entries for English and Japanese

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68eb33cdf0c4832bbd9fa8db19d74e08