### PR TITLE
feat: localize trump sevens and daifugo ui

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -12718,6 +12718,81 @@
             "finished": "Secured place {place}"
           }
         },
+        "sevens": {
+          "players": {
+            "you": "You",
+            "north": "North",
+            "east": "East",
+            "west": "West"
+          },
+          "log": {
+            "startingCard": "{name} placed {card} to start.",
+            "playCard": "{name} placed {card}.",
+            "pass": "{name} passed."
+          },
+          "toast": {
+            "invalidCard": "You can't play that card.",
+            "cardsAvailable": "You still have cards you can play.",
+            "everyonePassed": "Everyone passed. Wait until the situation changes.",
+            "victory": "{name} wins!"
+          },
+          "actions": {
+            "restart": "Rematch (R)",
+            "pass": "Pass"
+          },
+          "player": {
+            "handCount": "Hand {count} cards"
+          },
+          "status": {
+            "turn": "Turn: {name} ・ Pass streak {passes}"
+          },
+          "hud": {
+            "leaderDetail": "{name} ({count} cards)",
+            "noLeader": "-",
+            "score": "Fewest cards: {summary}"
+          }
+        },
+        "daifugo": {
+          "players": {
+            "you": "You",
+            "north": "North",
+            "east": "East",
+            "west": "West"
+          },
+          "pile": {
+            "title": "Current Field",
+            "reset": "Reset",
+            "requirement": "Required value: {value}"
+          },
+          "status": {
+            "lead": "Lead: {name}",
+            "playAny": "Play any card.",
+            "mustBeatOrPass": "Play a stronger card or pass (P).",
+            "roundEnd": "Round complete"
+          },
+          "history": {
+            "playCard": "{name}: {card}",
+            "pass": "{name}: Pass"
+          },
+          "toast": {
+            "invalidCard": "You can't play that card.",
+            "cannotPassLead": "You can't pass on the opening lead."
+          },
+          "actions": {
+            "pass": "Pass (P)",
+            "restart": "Restart (R)",
+            "nextRound": "Next Round (R)"
+          },
+          "playersMeta": {
+            "finished": "Place {place}",
+            "handCount": "{count} cards"
+          },
+          "hud": {
+            "bestPlace": "Place {place}",
+            "noRecord": "---",
+            "scoreSummary": "Total {plays} games / Wins {wins} / Best {best}"
+          }
+        },
         "klondike": {
           "labels": {
             "stock": "Stock",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -12720,6 +12720,81 @@
             "finished": "{place} 位確定"
           }
         },
+        "sevens": {
+          "players": {
+            "you": "あなた",
+            "north": "北",
+            "east": "東",
+            "west": "西"
+          },
+          "log": {
+            "startingCard": "{name} が {card} を開始に配置。",
+            "playCard": "{name} が {card} を配置。",
+            "pass": "{name} はパス。"
+          },
+          "toast": {
+            "invalidCard": "そのカードは並べられません。",
+            "cardsAvailable": "出せるカードがあります。",
+            "everyonePassed": "全員がパスしました。状況が進むまで待ちましょう。",
+            "victory": "{name} の勝利！"
+          },
+          "actions": {
+            "restart": "再戦 (R)",
+            "pass": "パス"
+          },
+          "player": {
+            "handCount": "手札 {count} 枚"
+          },
+          "status": {
+            "turn": "手番: {name} ・ パス連続 {passes}"
+          },
+          "hud": {
+            "leaderDetail": "{name} ({count}枚)",
+            "noLeader": "-",
+            "score": "最少手札: {summary}"
+          }
+        },
+        "daifugo": {
+          "players": {
+            "you": "あなた",
+            "north": "北",
+            "east": "東",
+            "west": "西"
+          },
+          "pile": {
+            "title": "現在の場",
+            "reset": "リセット",
+            "requirement": "要求値: {value}"
+          },
+          "status": {
+            "lead": "リード: {name}",
+            "playAny": "好きなカードを出してください。",
+            "mustBeatOrPass": "場より強いカードを出すかパス (P) してください。",
+            "roundEnd": "ラウンド終了"
+          },
+          "history": {
+            "playCard": "{name}: {card}",
+            "pass": "{name}: パス"
+          },
+          "toast": {
+            "invalidCard": "そのカードは出せません。",
+            "cannotPassLead": "最初のリードではパスできません。"
+          },
+          "actions": {
+            "pass": "パス (P)",
+            "restart": "リスタート (R)",
+            "nextRound": "次のラウンド (R)"
+          },
+          "playersMeta": {
+            "finished": "{place} 位",
+            "handCount": "{count} 枚"
+          },
+          "hud": {
+            "bestPlace": "{place} 位",
+            "noRecord": "---",
+            "scoreSummary": "通算 {plays} 回 / 勝利 {wins} 回 / ベスト {best}"
+          }
+        },
         "klondike": {
           "labels": {
             "stock": "山札",


### PR DESCRIPTION
## Summary
- route all Sevens UI copy through the localization resolver and refresh on locale changes
- translate the new Sevens and Daifugō strings in both English and Japanese locale files

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68eb33462380832ba7b98568dfb0f6bc