### PR TITLE
Fix image viewer localization support

### DIFF
--- a/index.html
+++ b/index.html
@@ -867,40 +867,40 @@
                                 <option value="snake"></option>
                             </datalist>
                         </section>
-                        <section id="tool-image-viewer" class="tool-panel" data-tool-panel="image-viewer" aria-label="画像ビューア">
+                        <section id="tool-image-viewer" class="tool-panel" data-tool-panel="image-viewer" aria-label="画像ビューア" data-i18n-attr="aria-label:tools.imageViewer.panelAriaLabel">
                             <header class="tool-panel-header">
-                                <h3>画像ビューア</h3>
-                                <p>ユーティリティカテゴリ向けのプレビュー。画像を読み込み、パン・ズーム・回転・伸縮・遠近変換を組み合わせて確認できます（変換はプレビューのみ）。</p>
+                                <h3 data-i18n="tools.imageViewer.header.title">画像ビューア</h3>
+                                <p data-i18n="tools.imageViewer.header.description">ユーティリティカテゴリ向けのプレビュー。画像を読み込み、パン・ズーム・回転・伸縮・遠近変換を組み合わせて確認できます（変換はプレビューのみ）。</p>
                             </header>
                             <div class="image-viewer-body">
                                 <div class="image-viewer-stage-wrapper">
-                                    <div id="image-viewer-stage" class="image-viewer-stage" tabindex="0" aria-label="画像プレビュー領域">
-                                        <div id="image-viewer-placeholder" class="image-viewer-placeholder">画像ファイルを選択するか、ここにドラッグ＆ドロップしてください。</div>
-                                        <img id="image-viewer-image" alt="選択した画像のプレビュー" draggable="false" />
+                                    <div id="image-viewer-stage" class="image-viewer-stage" tabindex="0" aria-label="画像プレビュー領域" data-i18n-attr="aria-label:tools.imageViewer.stage.ariaLabel">
+                                        <div id="image-viewer-placeholder" class="image-viewer-placeholder" data-i18n="tools.imageViewer.stage.placeholder">画像ファイルを選択するか、ここにドラッグ＆ドロップしてください。</div>
+                                        <img id="image-viewer-image" alt="選択した画像のプレビュー" draggable="false" data-i18n-attr="alt:tools.imageViewer.stage.imageAlt" />
                                     </div>
-                                    <p class="image-viewer-stage-hint">ホイールでズーム、ドラッグでパン、ダブルクリックでビューをリセットします。</p>
+                                    <p class="image-viewer-stage-hint" data-i18n="tools.imageViewer.stage.hint">ホイールでズーム、ドラッグでパン、ダブルクリックでビューをリセットします。</p>
                                     <div id="image-viewer-message" class="image-viewer-message" role="status" aria-live="polite"></div>
                                 </div>
                                 <div class="image-viewer-controls">
                                     <div class="image-viewer-upload">
                                         <label class="image-viewer-file-label">
-                                            <span>画像ファイルを選択</span>
+                                            <span data-i18n="tools.imageViewer.upload.select">画像ファイルを選択</span>
                                             <input type="file" id="image-viewer-file" accept="image/*" />
                                         </label>
                                         <div class="image-viewer-upload-actions">
-                                            <button type="button" id="image-viewer-reset-view">ビューリセット</button>
-                                            <button type="button" id="image-viewer-reset-all">全てリセット</button>
+                                            <button type="button" id="image-viewer-reset-view" data-i18n="tools.imageViewer.upload.resetView">ビューリセット</button>
+                                            <button type="button" id="image-viewer-reset-all" data-i18n="tools.imageViewer.upload.resetAll">全てリセット</button>
                                         </div>
                                     </div>
                                     <div class="image-viewer-control-group">
-                                        <label for="image-viewer-zoom">ズーム</label>
+                                        <label for="image-viewer-zoom" data-i18n="tools.imageViewer.controls.zoom">ズーム</label>
                                         <div class="image-viewer-control">
                                             <input type="range" id="image-viewer-zoom" min="0.1" max="8" step="0.01" value="1">
                                             <span id="image-viewer-zoom-value" class="image-viewer-value">100%</span>
                                         </div>
                                     </div>
                                     <div class="image-viewer-control-group">
-                                        <label for="image-viewer-rotation">回転</label>
+                                        <label for="image-viewer-rotation" data-i18n="tools.imageViewer.controls.rotation">回転</label>
                                         <div class="image-viewer-control">
                                             <input type="range" id="image-viewer-rotation" min="-180" max="180" step="1" value="0">
                                             <span id="image-viewer-rotation-value" class="image-viewer-value">0°</span>
@@ -908,14 +908,14 @@
                                     </div>
                                     <div class="image-viewer-control-row">
                                         <div class="image-viewer-control-group">
-                                            <label for="image-viewer-stretch-x">横伸縮</label>
+                                            <label for="image-viewer-stretch-x" data-i18n="tools.imageViewer.controls.stretchX">横伸縮</label>
                                             <div class="image-viewer-control">
                                                 <input type="range" id="image-viewer-stretch-x" min="0.2" max="4" step="0.01" value="1">
                                                 <span id="image-viewer-stretch-x-value" class="image-viewer-value">100%</span>
                                             </div>
                                         </div>
                                         <div class="image-viewer-control-group">
-                                            <label for="image-viewer-stretch-y">縦伸縮</label>
+                                            <label for="image-viewer-stretch-y" data-i18n="tools.imageViewer.controls.stretchY">縦伸縮</label>
                                             <div class="image-viewer-control">
                                                 <input type="range" id="image-viewer-stretch-y" min="0.2" max="4" step="0.01" value="1">
                                                 <span id="image-viewer-stretch-y-value" class="image-viewer-value">100%</span>
@@ -923,7 +923,7 @@
                                         </div>
                                     </div>
                                     <div class="image-viewer-control-group">
-                                        <label for="image-viewer-perspective">遠近距離</label>
+                                        <label for="image-viewer-perspective" data-i18n="tools.imageViewer.controls.perspective">遠近距離</label>
                                         <div class="image-viewer-control">
                                             <input type="range" id="image-viewer-perspective" min="200" max="2000" step="10" value="800">
                                             <span id="image-viewer-perspective-value" class="image-viewer-value">800px</span>
@@ -931,14 +931,14 @@
                                     </div>
                                     <div class="image-viewer-control-row">
                                         <div class="image-viewer-control-group">
-                                            <label for="image-viewer-rotate-x">遠近X回転</label>
+                                            <label for="image-viewer-rotate-x" data-i18n="tools.imageViewer.controls.rotateX">遠近X回転</label>
                                             <div class="image-viewer-control">
                                                 <input type="range" id="image-viewer-rotate-x" min="-75" max="75" step="1" value="0">
                                                 <span id="image-viewer-rotate-x-value" class="image-viewer-value">0°</span>
                                             </div>
                                         </div>
                                         <div class="image-viewer-control-group">
-                                            <label for="image-viewer-rotate-y">遠近Y回転</label>
+                                            <label for="image-viewer-rotate-y" data-i18n="tools.imageViewer.controls.rotateY">遠近Y回転</label>
                                             <div class="image-viewer-control">
                                                 <input type="range" id="image-viewer-rotate-y" min="-75" max="75" step="1" value="0">
                                                 <span id="image-viewer-rotate-y-value" class="image-viewer-value">0°</span>
@@ -946,26 +946,26 @@
                                         </div>
                                     </div>
                                     <div class="image-viewer-meta" aria-live="polite">
-                                        <h4>メタ情報</h4>
+                                        <h4 data-i18n="tools.imageViewer.meta.title">メタ情報</h4>
                                         <dl class="image-viewer-meta-grid">
                                             <div class="image-viewer-meta-row">
-                                                <dt>ファイル名</dt>
+                                                <dt data-i18n="tools.imageViewer.meta.name">ファイル名</dt>
                                                 <dd id="image-viewer-meta-name">-</dd>
                                             </div>
                                             <div class="image-viewer-meta-row">
-                                                <dt>種類</dt>
+                                                <dt data-i18n="tools.imageViewer.meta.type">種類</dt>
                                                 <dd id="image-viewer-meta-type">-</dd>
                                             </div>
                                             <div class="image-viewer-meta-row">
-                                                <dt>サイズ</dt>
+                                                <dt data-i18n="tools.imageViewer.meta.size">サイズ</dt>
                                                 <dd id="image-viewer-meta-size">-</dd>
                                             </div>
                                             <div class="image-viewer-meta-row">
-                                                <dt>画像解像度</dt>
+                                                <dt data-i18n="tools.imageViewer.meta.dimensions">画像解像度</dt>
                                                 <dd id="image-viewer-meta-dimensions">-</dd>
                                             </div>
                                             <div class="image-viewer-meta-row">
-                                                <dt>最終更新日</dt>
+                                                <dt data-i18n="tools.imageViewer.meta.modified">最終更新日</dt>
                                                 <dd id="image-viewer-meta-modified">-</dd>
                                             </div>
                                         </dl>

--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -15069,6 +15069,55 @@
           }
         }
       },
+      "imageViewer": {
+        "panelAriaLabel": "Image Viewer",
+        "header": {
+          "title": "Image Viewer",
+          "description": "Utility preview for reviewing screenshots with pan, zoom, rotation, stretch, and perspective transforms (preview only)."
+        },
+        "stage": {
+          "ariaLabel": "Image preview area",
+          "placeholder": "Select an image file or drag & drop it here.",
+          "hint": "Use the mouse wheel to zoom, drag to pan, and double-click to reset the view.",
+          "imageAlt": "Preview of the selected image"
+        },
+        "upload": {
+          "select": "Choose image file",
+          "resetView": "Reset view",
+          "resetAll": "Reset all"
+        },
+        "controls": {
+          "zoom": "Zoom",
+          "rotation": "Rotation",
+          "stretchX": "Horizontal stretch",
+          "stretchY": "Vertical stretch",
+          "perspective": "Perspective distance",
+          "rotateX": "Perspective X rotation",
+          "rotateY": "Perspective Y rotation"
+        },
+        "meta": {
+          "title": "Metadata",
+          "name": "File name",
+          "type": "Type",
+          "size": "Size",
+          "dimensions": "Image dimensions",
+          "modified": "Last modified",
+          "nameFallback": "(Untitled)",
+          "typeFallback": "Unknown",
+          "dimensionsValue": "{width} × {height} px"
+        },
+        "messages": {
+          "loadSuccess": "Image loaded.",
+          "loadError": "Failed to load the image.",
+          "invalidType": "Only image files are supported.",
+          "loading": "Loading image…",
+          "resetView": "View settings reset.",
+          "resetAll": "Image Viewer has been reset."
+        },
+        "errors": {
+          "missingElements": "[ImageViewer] Required elements not found."
+        }
+      },
       "blockdataEditor": {
         "panelAriaLabel": "Block Data Editor",
         "header": {

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -15015,6 +15015,55 @@
           }
         }
       },
+      "imageViewer": {
+        "panelAriaLabel": "画像ビューア",
+        "header": {
+          "title": "画像ビューア",
+          "description": "ユーティリティカテゴリ向けのプレビュー。画像を読み込み、パン・ズーム・回転・伸縮・遠近変換を組み合わせて確認できます（変換はプレビューのみ）。"
+        },
+        "stage": {
+          "ariaLabel": "画像プレビュー領域",
+          "placeholder": "画像ファイルを選択するか、ここにドラッグ＆ドロップしてください。",
+          "hint": "ホイールでズーム、ドラッグでパン、ダブルクリックでビューをリセットします。",
+          "imageAlt": "選択した画像のプレビュー"
+        },
+        "upload": {
+          "select": "画像ファイルを選択",
+          "resetView": "ビューリセット",
+          "resetAll": "全てリセット"
+        },
+        "controls": {
+          "zoom": "ズーム",
+          "rotation": "回転",
+          "stretchX": "横伸縮",
+          "stretchY": "縦伸縮",
+          "perspective": "遠近距離",
+          "rotateX": "遠近X回転",
+          "rotateY": "遠近Y回転"
+        },
+        "meta": {
+          "title": "メタ情報",
+          "name": "ファイル名",
+          "type": "種類",
+          "size": "サイズ",
+          "dimensions": "画像解像度",
+          "modified": "最終更新日",
+          "nameFallback": "(名称未設定)",
+          "typeFallback": "不明",
+          "dimensionsValue": "{width} × {height} px"
+        },
+        "messages": {
+          "loadSuccess": "画像を読み込みました。",
+          "loadError": "画像の読み込みに失敗しました。",
+          "invalidType": "画像ファイルのみ読み込み可能です。",
+          "loading": "画像を読み込み中...",
+          "resetView": "ビュー設定をリセットしました。",
+          "resetAll": "画像ビューアを初期化しました。"
+        },
+        "errors": {
+          "missingElements": "[ImageViewer] 必須要素が見つかりません。"
+        }
+      },
       "blockdataEditor": {
         "panelAriaLabel": "ブロックデータ編集ツール",
         "header": {


### PR DESCRIPTION
## Summary
- add i18n bindings and translation entries for the tools image viewer interface
- update the image viewer logic to use the shared i18n API for messages, metadata, and locale changes
- ensure metadata formatting respects the active locale

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68eb33ea23c4832bb7a6643f08d9c768