### PR TITLE
Localize sandbox map settings UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -454,116 +454,116 @@
                                 <pre id="state-manager-summary" class="state-manager-summary" aria-live="polite"></pre>
                             </div>
                         </section>
-                        <section id="tool-sandbox-editor" class="tool-panel" data-tool-panel="sandbox-editor" aria-label="サンドボックスダンジョンツール">
+                        <section id="tool-sandbox-editor" class="tool-panel" data-tool-panel="sandbox-editor" aria-label="サンドボックスダンジョンツール" data-i18n-attr="aria-label:tools.sandbox.panelAriaLabel">
                             <header class="tool-panel-header">
-                                <h3>サンドボックスダンジョン</h3>
-                                <p>自由にマップと敵を配置して、経験値に影響しないテスト用ダンジョンをその場で試走できます。</p>
+                                <h3 data-i18n="tools.sandbox.header.title">サンドボックスダンジョン</h3>
+                                <p data-i18n="tools.sandbox.header.description">自由にマップと敵を配置して、経験値に影響しないテスト用ダンジョンをその場で試走できます。</p>
                             </header>
                             <div class="sandbox-layout">
                                 <div class="sandbox-config">
                                     <section class="sandbox-section" aria-labelledby="sandbox-map-title">
                                         <div class="sandbox-section-header">
-                                            <h4 id="sandbox-map-title">マップ設定</h4>
+                                            <h4 id="sandbox-map-title" data-i18n="tools.sandbox.map.title">マップ設定</h4>
                                             <div class="sandbox-map-actions">
-                                                <button type="button" id="sandbox-fill-floor">全て床</button>
-                                                <button type="button" id="sandbox-fill-wall">全て壁</button>
-                                                <button type="button" id="sandbox-clear-markers">階段/開始位置をリセット</button>
+                                                <button type="button" id="sandbox-fill-floor" data-i18n="tools.sandbox.map.actions.fillFloor">全て床</button>
+                                                <button type="button" id="sandbox-fill-wall" data-i18n="tools.sandbox.map.actions.fillWall">全て壁</button>
+                                                <button type="button" id="sandbox-clear-markers" data-i18n="tools.sandbox.map.actions.resetMarkers">階段/開始位置をリセット</button>
                                             </div>
                                         </div>
                                         <div class="sandbox-form-grid">
-                                            <label>幅
+                                            <label data-i18n="tools.sandbox.map.fields.width.label">幅
                                                 <input id="sandbox-width" type="number" min="5" max="60" value="21">
                                             </label>
-                                            <label>高さ
+                                            <label data-i18n="tools.sandbox.map.fields.height.label">高さ
                                                 <input id="sandbox-height" type="number" min="5" max="60" value="15">
                                             </label>
                                         </div>
-                                        <div class="sandbox-brush-select" role="radiogroup" aria-label="ブラシ選択">
-                                            <button type="button" class="sandbox-brush" data-brush="select" aria-pressed="false">選択</button>
-                                            <button type="button" class="sandbox-brush" data-brush="floor" aria-pressed="true">床</button>
-                                            <button type="button" class="sandbox-brush" data-brush="wall" aria-pressed="false">壁</button>
-                                            <button type="button" class="sandbox-brush" data-brush="start" aria-pressed="false">開始位置</button>
-                                            <button type="button" class="sandbox-brush" data-brush="stairs" aria-pressed="false">階段</button>
-                                            <button type="button" class="sandbox-brush" data-brush="gate" aria-pressed="false">ゲート</button>
-                                            <button type="button" class="sandbox-brush" data-brush="enemy" aria-pressed="false">敵配置</button>
-                                            <button type="button" class="sandbox-brush" data-brush="domain" aria-pressed="false">領域</button>
+                                        <div class="sandbox-brush-select" role="radiogroup" aria-label="ブラシ選択" data-i18n-attr="aria-label:tools.sandbox.map.brush.ariaLabel">
+                                            <button type="button" class="sandbox-brush" data-brush="select" aria-pressed="false" data-i18n="tools.sandbox.map.brush.modes.select">選択</button>
+                                            <button type="button" class="sandbox-brush" data-brush="floor" aria-pressed="true" data-i18n="tools.sandbox.map.brush.modes.floor">床</button>
+                                            <button type="button" class="sandbox-brush" data-brush="wall" aria-pressed="false" data-i18n="tools.sandbox.map.brush.modes.wall">壁</button>
+                                            <button type="button" class="sandbox-brush" data-brush="start" aria-pressed="false" data-i18n="tools.sandbox.map.brush.modes.start">開始位置</button>
+                                            <button type="button" class="sandbox-brush" data-brush="stairs" aria-pressed="false" data-i18n="tools.sandbox.map.brush.modes.stairs">階段</button>
+                                            <button type="button" class="sandbox-brush" data-brush="gate" aria-pressed="false" data-i18n="tools.sandbox.map.brush.modes.gate">ゲート</button>
+                                            <button type="button" class="sandbox-brush" data-brush="enemy" aria-pressed="false" data-i18n="tools.sandbox.map.brush.modes.enemy">敵配置</button>
+                                            <button type="button" class="sandbox-brush" data-brush="domain" aria-pressed="false" data-i18n="tools.sandbox.map.brush.modes.domain">領域</button>
                                         </div>
                                         <p id="sandbox-selected-cell" class="sandbox-selected-cell" aria-live="polite">セルをクリックして編集します。</p>
                                         <section class="sandbox-subsection" aria-labelledby="sandbox-maplist-title">
                                             <div class="sandbox-subsection-header">
-                                                <h5 id="sandbox-maplist-title">マップ一覧</h5>
+                                                <h5 id="sandbox-maplist-title" data-i18n="tools.sandbox.map.list.title">マップ一覧</h5>
                                                 <div class="sandbox-maplist-actions">
-                                                    <button type="button" id="sandbox-add-map">+ マップ追加</button>
-                                                    <button type="button" id="sandbox-node-map-button">ノードマップ</button>
+                                                    <button type="button" id="sandbox-add-map" data-i18n="tools.sandbox.map.list.actions.add">+ マップ追加</button>
+                                                    <button type="button" id="sandbox-node-map-button" data-i18n="tools.sandbox.map.list.actions.node">ノードマップ</button>
                                                 </div>
                                             </div>
                                             <div class="sandbox-maplist">
-                                                <div id="sandbox-map-list" class="sandbox-map-list" role="listbox" aria-label="マップ一覧"></div>
+                                                <div id="sandbox-map-list" class="sandbox-map-list" role="listbox" aria-label="マップ一覧" data-i18n-attr="aria-label:tools.sandbox.map.list.ariaLabel"></div>
                                                 <div class="sandbox-map-detail">
-                                                    <label>名前
+                                                    <label data-i18n="tools.sandbox.map.list.fields.name.label">名前
                                                         <input id="sandbox-map-name" type="text" maxlength="40" data-preserve-key="map-name">
                                                     </label>
-                                                    <label>階層
+                                                    <label data-i18n="tools.sandbox.map.list.fields.floor.label">階層
                                                         <input id="sandbox-map-floor" type="number" min="1" max="999" data-preserve-key="map-floor">
                                                     </label>
-                                                    <label>ブランチキー
+                                                    <label data-i18n="tools.sandbox.map.list.fields.branch.label">ブランチキー
                                                         <input id="sandbox-map-branch" type="text" maxlength="12" data-preserve-key="map-branch">
                                                     </label>
-                                                    <button type="button" id="sandbox-set-entry-map" class="sandbox-secondary-button">開始マップに設定</button>
+                                                    <button type="button" id="sandbox-set-entry-map" class="sandbox-secondary-button" data-i18n="tools.sandbox.map.list.actions.setEntry">開始マップに設定</button>
                                                 </div>
                                             </div>
                                         </section>
                                         <div class="sandbox-brush-options" aria-labelledby="sandbox-brush-options-title">
-                                            <h5 id="sandbox-brush-options-title">ブラシオプション</h5>
+                                            <h5 id="sandbox-brush-options-title" data-i18n="tools.sandbox.map.options.title">ブラシオプション</h5>
                                             <div class="sandbox-brush-option-grid">
-                                                <label class="sandbox-field-group">床タイプ
+                                                <label class="sandbox-field-group" data-i18n="tools.sandbox.map.options.floorType.label">床タイプ
                                                     <select id="sandbox-brush-floor-type">
-                                                        <option value="normal">通常</option>
-                                                        <option value="ice">氷</option>
-                                                        <option value="poison">毒</option>
-                                                        <option value="bomb">爆弾</option>
-                                                        <option value="conveyor">コンベヤー</option>
-                                                        <option value="one-way">一方通行</option>
-                                                        <option value="vertical">縦通行のみ</option>
-                                                        <option value="horizontal">横通行のみ</option>
+                                                        <option value="normal" data-i18n="tools.sandbox.map.options.floorType.options.normal">通常</option>
+                                                        <option value="ice" data-i18n="tools.sandbox.map.options.floorType.options.ice">氷</option>
+                                                        <option value="poison" data-i18n="tools.sandbox.map.options.floorType.options.poison">毒</option>
+                                                        <option value="bomb" data-i18n="tools.sandbox.map.options.floorType.options.bomb">爆弾</option>
+                                                        <option value="conveyor" data-i18n="tools.sandbox.map.options.floorType.options.conveyor">コンベヤー</option>
+                                                        <option value="one-way" data-i18n="tools.sandbox.map.options.floorType.options.oneWay">一方通行</option>
+                                                        <option value="vertical" data-i18n="tools.sandbox.map.options.floorType.options.vertical">縦通行のみ</option>
+                                                        <option value="horizontal" data-i18n="tools.sandbox.map.options.floorType.options.horizontal">横通行のみ</option>
                                                     </select>
                                                 </label>
-                                                <label class="sandbox-field-group">進行方向
+                                                <label class="sandbox-field-group" data-i18n="tools.sandbox.map.options.floorDirection.label">進行方向
                                                     <select id="sandbox-brush-floor-direction">
-                                                        <option value="">指定なし</option>
-                                                        <option value="up">↑ 上</option>
-                                                        <option value="right">→ 右</option>
-                                                        <option value="down">↓ 下</option>
-                                                        <option value="left">← 左</option>
+                                                        <option value="" data-i18n="tools.sandbox.map.options.floorDirection.options.none">指定なし</option>
+                                                        <option value="up" data-i18n="tools.sandbox.map.options.floorDirection.options.up">↑ 上</option>
+                                                        <option value="right" data-i18n="tools.sandbox.map.options.floorDirection.options.right">→ 右</option>
+                                                        <option value="down" data-i18n="tools.sandbox.map.options.floorDirection.options.down">↓ 下</option>
+                                                        <option value="left" data-i18n="tools.sandbox.map.options.floorDirection.options.left">← 左</option>
                                                     </select>
-                                                    <span class="sandbox-hint">※ コンベヤー / 一方通行床で使用</span>
+                                                    <span class="sandbox-hint" data-i18n="tools.sandbox.map.options.floorDirection.hint">※ コンベヤー / 一方通行床で使用</span>
                                                 </label>
-                                                <label class="sandbox-field-group">床の色
+                                                <label class="sandbox-field-group" data-i18n="tools.sandbox.map.options.floorColor.label">床の色
                                                     <div class="sandbox-color-control">
                                                         <input id="sandbox-brush-floor-color" type="color" value="#ced6e0" data-has-custom="false">
-                                                        <button type="button" id="sandbox-brush-floor-color-clear" class="sandbox-color-clear">自動</button>
+                                                        <button type="button" id="sandbox-brush-floor-color-clear" class="sandbox-color-clear" data-i18n="tools.sandbox.map.options.color.auto">自動</button>
                                                     </div>
-                                                    <span class="sandbox-color-hint" id="sandbox-floor-color-hint">自動</span>
+                                                    <span class="sandbox-color-hint" id="sandbox-floor-color-hint" data-i18n="tools.sandbox.map.options.color.auto">自動</span>
                                                 </label>
-                                                <label class="sandbox-field-group">壁の色
+                                                <label class="sandbox-field-group" data-i18n="tools.sandbox.map.options.wallColor.label">壁の色
                                                     <div class="sandbox-color-control">
                                                         <input id="sandbox-brush-wall-color" type="color" value="#2f3542" data-has-custom="false">
-                                                        <button type="button" id="sandbox-brush-wall-color-clear" class="sandbox-color-clear">自動</button>
+                                                        <button type="button" id="sandbox-brush-wall-color-clear" class="sandbox-color-clear" data-i18n="tools.sandbox.map.options.color.auto">自動</button>
                                                     </div>
-                                                    <span class="sandbox-color-hint" id="sandbox-wall-color-hint">自動</span>
+                                                    <span class="sandbox-color-hint" id="sandbox-wall-color-hint" data-i18n="tools.sandbox.map.options.color.auto">自動</span>
                                                 </label>
                                                 <div class="sandbox-field-group sandbox-palette-group">
-                                                    <span>カラーパレット</span>
-                                                    <div id="sandbox-color-palette" class="sandbox-color-palette" role="listbox" aria-label="保存済みカラー"></div>
+                                                    <span data-i18n="tools.sandbox.map.palette.title">カラーパレット</span>
+                                                    <div id="sandbox-color-palette" class="sandbox-color-palette" role="listbox" aria-label="保存済みカラー" data-i18n-attr="aria-label:tools.sandbox.map.palette.ariaLabel"></div>
                                                     <div class="sandbox-palette-actions">
-                                                        <button type="button" id="sandbox-save-floor-color">床色を保存</button>
-                                                        <button type="button" id="sandbox-save-wall-color">壁色を保存</button>
-                                                        <button type="button" id="sandbox-clear-palette" class="sandbox-secondary-button">パレットをクリア</button>
-                                                        <button type="button" id="sandbox-eyedropper-button" class="sandbox-secondary-button">スポイト</button>
+                                                        <button type="button" id="sandbox-save-floor-color" data-i18n="tools.sandbox.map.palette.actions.saveFloor">床色を保存</button>
+                                                        <button type="button" id="sandbox-save-wall-color" data-i18n="tools.sandbox.map.palette.actions.saveWall">壁色を保存</button>
+                                                        <button type="button" id="sandbox-clear-palette" class="sandbox-secondary-button" data-i18n="tools.sandbox.map.palette.actions.clear">パレットをクリア</button>
+                                                        <button type="button" id="sandbox-eyedropper-button" class="sandbox-secondary-button" data-i18n="tools.sandbox.map.palette.actions.eyedropper">スポイト</button>
                                                     </div>
                                                 </div>
                                             </div>
-                                            <p class="sandbox-note small">選択セルや塗りつぶすマスに色・床タイプを適用できます。</p>
+                                            <p class="sandbox-note small" data-i18n="tools.sandbox.map.notes.apply">選択セルや塗りつぶすマスに色・床タイプを適用できます。</p>
                                         </div>
                                     </section>
                                     <section class="sandbox-section" aria-labelledby="sandbox-player-title">
@@ -615,25 +615,25 @@
                                 </div>
                                 <div class="sandbox-map-wrapper">
                                     <div class="sandbox-map-header">
-                                        <h4>マッププレビュー</h4>
+                                        <h4 data-i18n="tools.sandbox.map.preview.title">マッププレビュー</h4>
                                     </div>
-                                    <div id="sandbox-grid" class="sandbox-grid" role="grid" aria-label="サンドボックスマップ">
+                                    <div id="sandbox-grid" class="sandbox-grid" role="grid" aria-label="サンドボックスマップ" data-i18n-attr="aria-label:tools.sandbox.map.preview.ariaLabel">
                                         <canvas id="sandbox-grid-canvas" role="presentation" aria-hidden="true"></canvas>
                                         <div id="sandbox-grid-aria" class="visually-hidden" aria-live="polite"></div>
                                     </div>
                                     <dl class="sandbox-legend">
-                                        <div><dt>■</dt><dd>壁</dd></div>
-                                        <div><dt>□</dt><dd>床</dd></div>
-                                        <div><dt>★</dt><dd>開始位置</dd></div>
-                                        <div><dt>⬆</dt><dd>階段</dd></div>
-                                        <div><dt>✦</dt><dd>敵</dd></div>
-                                        <div><dt class="legend-ice">■</dt><dd>氷床</dd></div>
-                                        <div><dt class="legend-poison">■</dt><dd>毒床</dd></div>
-                                        <div><dt class="legend-bomb">■</dt><dd>爆弾床</dd></div>
-                                        <div><dt class="legend-conveyor">■</dt><dd>コンベヤー床</dd></div>
-                                        <div><dt class="legend-oneway">■</dt><dd>一方通行床</dd></div>
-                                        <div><dt class="legend-vertical">■</dt><dd>縦通行のみ床</dd></div>
-                                        <div><dt class="legend-horizontal">■</dt><dd>横通行のみ床</dd></div>
+                                        <div><dt>■</dt><dd data-i18n="tools.sandbox.map.preview.legend.wall">壁</dd></div>
+                                        <div><dt>□</dt><dd data-i18n="tools.sandbox.map.preview.legend.floor">床</dd></div>
+                                        <div><dt>★</dt><dd data-i18n="tools.sandbox.map.preview.legend.start">開始位置</dd></div>
+                                        <div><dt>⬆</dt><dd data-i18n="tools.sandbox.map.preview.legend.stairs">階段</dd></div>
+                                        <div><dt>✦</dt><dd data-i18n="tools.sandbox.map.preview.legend.enemy">敵</dd></div>
+                                        <div><dt class="legend-ice">■</dt><dd data-i18n="tools.sandbox.map.preview.legend.ice">氷床</dd></div>
+                                        <div><dt class="legend-poison">■</dt><dd data-i18n="tools.sandbox.map.preview.legend.poison">毒床</dd></div>
+                                        <div><dt class="legend-bomb">■</dt><dd data-i18n="tools.sandbox.map.preview.legend.bomb">爆弾床</dd></div>
+                                        <div><dt class="legend-conveyor">■</dt><dd data-i18n="tools.sandbox.map.preview.legend.conveyor">コンベヤー床</dd></div>
+                                        <div><dt class="legend-oneway">■</dt><dd data-i18n="tools.sandbox.map.preview.legend.oneWay">一方通行床</dd></div>
+                                        <div><dt class="legend-vertical">■</dt><dd data-i18n="tools.sandbox.map.preview.legend.vertical">縦通行のみ床</dd></div>
+                                        <div><dt class="legend-horizontal">■</dt><dd data-i18n="tools.sandbox.map.preview.legend.horizontal">横通行のみ床</dd></div>
                                     </dl>
                                 </div>
                             </div>

--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -15063,6 +15063,176 @@
         }
       },
       "sandbox": {
+        "panelAriaLabel": "Sandbox Dungeon Tool",
+        "header": {
+          "title": "Sandbox Dungeon",
+          "description": "Assemble a test dungeon on the fly with custom maps and enemy placements without affecting experience gain."
+        },
+        "map": {
+          "title": "Map Settings",
+          "actions": {
+            "fillFloor": "Fill floor",
+            "fillWall": "Fill walls",
+            "resetMarkers": "Reset stairs/start"
+          },
+          "fields": {
+            "width": { "label": "Width" },
+            "height": { "label": "Height" }
+          },
+          "brush": {
+            "ariaLabel": "Brush selection",
+            "modes": {
+              "select": "Select",
+              "floor": "Floor",
+              "wall": "Wall",
+              "start": "Start point",
+              "stairs": "Stairs",
+              "gate": "Gate",
+              "enemy": "Enemy placement",
+              "domain": "Domain"
+            }
+          },
+          "selectedCell": {
+            "hint": "Click a cell to edit.",
+            "selectedWithDescription": "Selected cell: {description}",
+            "selected": "Selected cell: ({x}, {y})"
+          },
+          "list": {
+            "title": "Map list",
+            "actions": {
+              "add": "+ Add map",
+              "node": "Node map",
+              "setEntry": "Set as entry map"
+            },
+            "ariaLabel": "Map list",
+            "fields": {
+              "name": { "label": "Name" },
+              "floor": { "label": "Floor" },
+              "branch": { "label": "Branch key" }
+            }
+          },
+          "options": {
+            "title": "Brush options",
+            "floorType": {
+              "label": "Floor type",
+              "options": {
+                "normal": "Normal",
+                "ice": "Ice",
+                "poison": "Poison",
+                "bomb": "Bomb",
+                "conveyor": "Conveyor",
+                "oneWay": "One-way",
+                "vertical": "Vertical only",
+                "horizontal": "Horizontal only"
+              }
+            },
+            "floorDirection": {
+              "label": "Direction",
+              "options": {
+                "none": "None",
+                "up": "↑ Up",
+                "right": "→ Right",
+                "down": "↓ Down",
+                "left": "← Left"
+              },
+              "hint": "Use with conveyor / one-way tiles"
+            },
+            "floorColor": { "label": "Floor color" },
+            "wallColor": { "label": "Wall color" },
+            "color": { "auto": "Auto" }
+          },
+          "palette": {
+            "title": "Color palette",
+            "ariaLabel": "Saved colors",
+            "actions": {
+              "saveFloor": "Save floor color",
+              "saveWall": "Save wall color",
+              "clear": "Clear palette",
+              "eyedropper": "Eyedropper"
+            }
+          },
+          "notes": {
+            "apply": "Apply colors and floor types to the selected cell or fill target."
+          },
+          "preview": {
+            "title": "Map preview",
+            "ariaLabel": "Sandbox map",
+            "legend": {
+              "wall": "Wall",
+              "floor": "Floor",
+              "start": "Start",
+              "stairs": "Stairs",
+              "enemy": "Enemy",
+              "ice": "Ice floor",
+              "poison": "Poison floor",
+              "bomb": "Bomb floor",
+              "conveyor": "Conveyor floor",
+              "oneWay": "One-way floor",
+              "vertical": "Vertical-only floor",
+              "horizontal": "Horizontal-only floor"
+            }
+          },
+          "cell": {
+            "types": {
+              "floor": "Floor",
+              "wall": "Wall"
+            },
+            "base": "{type} ({x}, {y})",
+            "details": {
+              "playerStart": "Start",
+              "stairs": "Stairs",
+              "gate": "Gate",
+              "gateWithLabel": "Gate: {label}",
+              "floorType": "Floor type: {label}{suffix}",
+              "floorTypeDirectionSuffix": " ({icon})",
+              "floorColor": "Floor color: {color}",
+              "wallColor": "Wall color: {color}",
+              "enemy": {
+                "singleNamed": "Enemy: {name}",
+                "singleNamedBoss": "Enemy: {name} (Boss)",
+                "singleBoss": "Enemy: Boss x1",
+                "single": "Enemy: x1",
+                "bossSuffix": " (Boss)",
+                "nameSeparator": ", ",
+                "multipleNamed": "Enemies: {list}",
+                "multipleAllBoss": "Enemies: {count} bosses",
+                "multipleWithBoss": "Enemies: {count} (includes {bossCount} bosses)",
+                "multiple": "Enemies: {count}"
+              },
+              "domain": {
+                "effectSeparator": ", ",
+                "separator": " / ",
+                "effectNone": "No effect",
+                "named": "{name}: {effects}",
+                "unnamed": "{effects}",
+                "summary": "Domain: {summary}"
+              },
+              "joiner": " / "
+            },
+            "summary": "{base} - {details}"
+          },
+          "domain": {
+            "effects": {
+              "attackUp": "Attack up",
+              "defenseUp": "Defense up",
+              "attackDown": "Attack down",
+              "defenseDown": "Defense down",
+              "allyBoost": "Ally boost",
+              "enemyBoost": "Enemy boost",
+              "enemyOverpower": "Overpowering enemies",
+              "levelUp": "Higher level",
+              "levelDown": "Lower level",
+              "abilityUp": "Ability up",
+              "abilityDown": "Ability down",
+              "enemyInvincible": "Enemy invincible",
+              "allInvincible": "Invincibility",
+              "damageReverse": "Damage reversal",
+              "slow": "Slow",
+              "fast": "Fast",
+              "ailment": "Status ailments"
+            }
+          }
+        },
         "controls": {
           "domain": {
             "noneAvailable": "No domain crystals available"

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -15009,6 +15009,176 @@
         }
       },
       "sandbox": {
+        "panelAriaLabel": "サンドボックスダンジョンツール",
+        "header": {
+          "title": "サンドボックスダンジョン",
+          "description": "自由にマップと敵を配置して、経験値に影響しないテスト用ダンジョンをその場で試走できます。"
+        },
+        "map": {
+          "title": "マップ設定",
+          "actions": {
+            "fillFloor": "全て床",
+            "fillWall": "全て壁",
+            "resetMarkers": "階段/開始位置をリセット"
+          },
+          "fields": {
+            "width": { "label": "幅" },
+            "height": { "label": "高さ" }
+          },
+          "brush": {
+            "ariaLabel": "ブラシ選択",
+            "modes": {
+              "select": "選択",
+              "floor": "床",
+              "wall": "壁",
+              "start": "開始位置",
+              "stairs": "階段",
+              "gate": "ゲート",
+              "enemy": "敵配置",
+              "domain": "領域"
+            }
+          },
+          "selectedCell": {
+            "hint": "セルをクリックして編集します。",
+            "selectedWithDescription": "選択セル: {description}",
+            "selected": "選択セル: ({x}, {y})"
+          },
+          "list": {
+            "title": "マップ一覧",
+            "actions": {
+              "add": "+ マップ追加",
+              "node": "ノードマップ",
+              "setEntry": "開始マップに設定"
+            },
+            "ariaLabel": "マップ一覧",
+            "fields": {
+              "name": { "label": "名前" },
+              "floor": { "label": "階層" },
+              "branch": { "label": "ブランチキー" }
+            }
+          },
+          "options": {
+            "title": "ブラシオプション",
+            "floorType": {
+              "label": "床タイプ",
+              "options": {
+                "normal": "通常",
+                "ice": "氷",
+                "poison": "毒",
+                "bomb": "爆弾",
+                "conveyor": "コンベヤー",
+                "oneWay": "一方通行",
+                "vertical": "縦通行のみ",
+                "horizontal": "横通行のみ"
+              }
+            },
+            "floorDirection": {
+              "label": "進行方向",
+              "options": {
+                "none": "指定なし",
+                "up": "↑ 上",
+                "right": "→ 右",
+                "down": "↓ 下",
+                "left": "← 左"
+              },
+              "hint": "※ コンベヤー / 一方通行床で使用"
+            },
+            "floorColor": { "label": "床の色" },
+            "wallColor": { "label": "壁の色" },
+            "color": { "auto": "自動" }
+          },
+          "palette": {
+            "title": "カラーパレット",
+            "ariaLabel": "保存済みカラー",
+            "actions": {
+              "saveFloor": "床色を保存",
+              "saveWall": "壁色を保存",
+              "clear": "パレットをクリア",
+              "eyedropper": "スポイト"
+            }
+          },
+          "notes": {
+            "apply": "選択セルや塗りつぶすマスに色・床タイプを適用できます。"
+          },
+          "preview": {
+            "title": "マッププレビュー",
+            "ariaLabel": "サンドボックスマップ",
+            "legend": {
+              "wall": "壁",
+              "floor": "床",
+              "start": "開始位置",
+              "stairs": "階段",
+              "enemy": "敵",
+              "ice": "氷床",
+              "poison": "毒床",
+              "bomb": "爆弾床",
+              "conveyor": "コンベヤー床",
+              "oneWay": "一方通行床",
+              "vertical": "縦通行のみ床",
+              "horizontal": "横通行のみ床"
+            }
+          },
+          "cell": {
+            "types": {
+              "floor": "床",
+              "wall": "壁"
+            },
+            "base": "{type} ({x}, {y})",
+            "details": {
+              "playerStart": "開始位置",
+              "stairs": "階段",
+              "gate": "ゲート",
+              "gateWithLabel": "ゲート: {label}",
+              "floorType": "床タイプ: {label}{suffix}",
+              "floorTypeDirectionSuffix": "（{icon}）",
+              "floorColor": "床色: {color}",
+              "wallColor": "壁色: {color}",
+              "enemy": {
+                "singleNamed": "敵: {name}",
+                "singleNamedBoss": "敵: {name}（ボス）",
+                "singleBoss": "敵: ボス1体",
+                "single": "敵: 1体",
+                "bossSuffix": "（ボス）",
+                "nameSeparator": "、",
+                "multipleNamed": "敵: {list}",
+                "multipleAllBoss": "敵: ボス{count}体",
+                "multipleWithBoss": "敵: {count}体（ボス{bossCount}体含む）",
+                "multiple": "敵: {count}体"
+              },
+              "domain": {
+                "effectSeparator": "・",
+                "separator": " / ",
+                "effectNone": "効果なし",
+                "named": "{name}: {effects}",
+                "unnamed": "{effects}",
+                "summary": "領域: {summary}"
+              },
+              "joiner": " / "
+            },
+            "summary": "{base} - {details}"
+          },
+          "domain": {
+            "effects": {
+              "attackUp": "攻撃力アップ",
+              "defenseUp": "防御力アップ",
+              "attackDown": "攻撃力ダウン",
+              "defenseDown": "防御力ダウン",
+              "allyBoost": "味方強化",
+              "enemyBoost": "敵強化",
+              "enemyOverpower": "超敵強化",
+              "levelUp": "高レベル化",
+              "levelDown": "低レベル化",
+              "abilityUp": "能力アップ",
+              "abilityDown": "能力ダウン",
+              "enemyInvincible": "敵無敵",
+              "allInvincible": "無敵",
+              "damageReverse": "ダメージ反転",
+              "slow": "遅い",
+              "fast": "速い",
+              "ailment": "状態異常化"
+            }
+          }
+        },
         "controls": {
           "domain": {
             "noneAvailable": "配置可能なクリスタルなし"

--- a/js/tools/sandbox.js
+++ b/js/tools/sandbox.js
@@ -2,6 +2,33 @@
     'use strict';
 
     const ToolsTab = global.ToolsTab;
+    const i18n = global.I18n || null;
+
+    function translate(key, params, fallback) {
+        if (key && i18n && typeof i18n.t === 'function') {
+            const value = i18n.t(key, params);
+            if (value !== undefined && value !== null && value !== key) {
+                return value;
+            }
+        }
+        if (typeof fallback === 'function') {
+            return fallback();
+        }
+        if (fallback !== undefined && fallback !== null) {
+            return fallback;
+        }
+        if (typeof key === 'string') {
+            return key;
+        }
+        return '';
+    }
+
+    function translateSandbox(key, params, fallback) {
+        if (typeof key === 'string' && !key.startsWith('tools.sandbox')) {
+            return translate(`tools.sandbox.${key}`, params, fallback);
+        }
+        return translate(key, params, fallback);
+    }
     let Bridge = null;
 
     if (!ToolsTab || typeof ToolsTab.registerTool !== 'function') {
@@ -28,7 +55,7 @@
     };
     const FLOOR_TYPES = ['normal', 'ice', 'poison', 'bomb', 'conveyor', 'one-way', 'vertical', 'horizontal'];
     const FLOOR_TYPES_NEED_DIRECTION = new Set(['conveyor', 'one-way']);
-    const FLOOR_DIRECTION_OPTIONS = ['','up','down','left','right'];
+    const FLOOR_DIRECTION_OPTIONS = ['', 'up', 'down', 'left', 'right'];
     const DEFAULT_FLOOR_COLOR = '#ced6e0';
     const DEFAULT_WALL_COLOR = '#2f3542';
     const PORTAL_TYPES = ['stairs', 'gate'];
@@ -48,14 +75,15 @@
     const GRID_SELECTED_ENEMY_COLOR = '#f97316';
     const GRID_DOMAIN_COLOR = '#7c3aed';
     const GRID_GATE_COLOR = '#f59f00';
-    const FLOOR_TYPE_LABELS = {
-        ice: '氷',
-        poison: '毒',
-        bomb: '爆弾',
-        conveyor: 'コンベヤー',
-        'one-way': '一方通行',
-        vertical: '縦通行のみ',
-        horizontal: '横通行のみ'
+    const FLOOR_TYPE_DEFINITIONS = {
+        normal: { key: 'tools.sandbox.map.options.floorType.options.normal', fallback: '通常' },
+        ice: { key: 'tools.sandbox.map.options.floorType.options.ice', fallback: '氷' },
+        poison: { key: 'tools.sandbox.map.options.floorType.options.poison', fallback: '毒' },
+        bomb: { key: 'tools.sandbox.map.options.floorType.options.bomb', fallback: '爆弾' },
+        conveyor: { key: 'tools.sandbox.map.options.floorType.options.conveyor', fallback: 'コンベヤー' },
+        'one-way': { key: 'tools.sandbox.map.options.floorType.options.oneWay', fallback: '一方通行' },
+        vertical: { key: 'tools.sandbox.map.options.floorType.options.vertical', fallback: '縦通行のみ' },
+        horizontal: { key: 'tools.sandbox.map.options.floorType.options.horizontal', fallback: '横通行のみ' }
     };
     const FLOOR_TYPE_COLORS = {
         ice: '#74c0fc',
@@ -72,6 +100,17 @@
         left: '←',
         right: '→'
     };
+
+    function getFloorTypeLabel(type) {
+        const def = FLOOR_TYPE_DEFINITIONS?.[type];
+        if (def) {
+            return translate(def.key, null, def.fallback);
+        }
+        if (typeof type === 'string' && type) {
+            return type;
+        }
+        return '';
+    }
 
     const WIRE_SIGNAL_TYPES = ['binary', 'pulse', 'value'];
     const DEFAULT_WIRE_SIGNAL_TYPE = 'binary';
@@ -327,23 +366,23 @@
 
     let refs = {};
     const DOMAIN_EFFECT_OPTIONS = [
-        { id: 'attackUp', label: '攻撃力アップ' },
-        { id: 'defenseUp', label: '防御力アップ' },
-        { id: 'attackDown', label: '攻撃力ダウン' },
-        { id: 'defenseDown', label: '防御力ダウン' },
-        { id: 'allyBoost', label: '味方強化' },
-        { id: 'enemyBoost', label: '敵強化' },
-        { id: 'enemyOverpower', label: '超敵強化' },
-        { id: 'levelUp', label: '高レベル化' },
-        { id: 'levelDown', label: '低レベル化' },
-        { id: 'abilityUp', label: '能力アップ' },
-        { id: 'abilityDown', label: '能力ダウン' },
-        { id: 'enemyInvincible', label: '敵無敵' },
-        { id: 'allInvincible', label: '無敵' },
-        { id: 'damageReverse', label: 'ダメージ反転' },
-        { id: 'slow', label: '遅い' },
-        { id: 'fast', label: '速い' },
-        { id: 'ailment', label: '状態異常化' }
+        { id: 'attackUp', label: '攻撃力アップ', labelKey: 'map.domain.effects.attackUp' },
+        { id: 'defenseUp', label: '防御力アップ', labelKey: 'map.domain.effects.defenseUp' },
+        { id: 'attackDown', label: '攻撃力ダウン', labelKey: 'map.domain.effects.attackDown' },
+        { id: 'defenseDown', label: '防御力ダウン', labelKey: 'map.domain.effects.defenseDown' },
+        { id: 'allyBoost', label: '味方強化', labelKey: 'map.domain.effects.allyBoost' },
+        { id: 'enemyBoost', label: '敵強化', labelKey: 'map.domain.effects.enemyBoost' },
+        { id: 'enemyOverpower', label: '超敵強化', labelKey: 'map.domain.effects.enemyOverpower' },
+        { id: 'levelUp', label: '高レベル化', labelKey: 'map.domain.effects.levelUp' },
+        { id: 'levelDown', label: '低レベル化', labelKey: 'map.domain.effects.levelDown' },
+        { id: 'abilityUp', label: '能力アップ', labelKey: 'map.domain.effects.abilityUp' },
+        { id: 'abilityDown', label: '能力ダウン', labelKey: 'map.domain.effects.abilityDown' },
+        { id: 'enemyInvincible', label: '敵無敵', labelKey: 'map.domain.effects.enemyInvincible' },
+        { id: 'allInvincible', label: '無敵', labelKey: 'map.domain.effects.allInvincible' },
+        { id: 'damageReverse', label: 'ダメージ反転', labelKey: 'map.domain.effects.damageReverse' },
+        { id: 'slow', label: '遅い', labelKey: 'map.domain.effects.slow' },
+        { id: 'fast', label: '速い', labelKey: 'map.domain.effects.fast' },
+        { id: 'ailment', label: '状態異常化', labelKey: 'map.domain.effects.ailment' }
     ];
 
     const DOMAIN_EFFECT_PARAM_DEFAULTS = {
@@ -1169,7 +1208,13 @@
 
     function getDomainEffectLabel(effectId) {
         const option = DOMAIN_EFFECT_OPTIONS.find(opt => opt.id === effectId);
-        return option ? option.label : effectId;
+        if (!option) {
+            return effectId;
+        }
+        const key = option.labelKey ? `tools.sandbox.${option.labelKey}` : null;
+        return key
+            ? translateSandbox(key, null, option.label || effectId)
+            : translateSandbox(`map.domain.effects.${option.id}`, null, option.label || effectId);
     }
 
     function normalizeDomainEffects(list, width, height) {
@@ -2004,44 +2049,51 @@
         }
         const cell = state.grid[y][x];
         const meta = state.meta?.[y]?.[x] || null;
-        const baseLabel = `${cell === 0 ? '床' : '壁'} (${x}, ${y})`;
+        const typeKey = cell === 0 ? 'floor' : 'wall';
+        const typeLabel = translateSandbox(`map.cell.types.${typeKey}`, null, cell === 0 ? '床' : '壁');
+        const baseLabel = translateSandbox('map.cell.base', { type: typeLabel, x, y }, `${typeLabel} (${x}, ${y})`);
         const detailParts = [];
         if (state.playerStart && state.playerStart.x === x && state.playerStart.y === y) {
-            detailParts.push('開始位置');
+            detailParts.push(translateSandbox('map.cell.details.playerStart', null, '開始位置'));
         }
         const portalHere = Array.isArray(state.portals)
             ? state.portals.find(portal => portal && portal.x === x && portal.y === y)
             : null;
         if (portalHere) {
             if (portalHere.type === 'stairs') {
-                detailParts.push('階段');
+                detailParts.push(translateSandbox('map.cell.details.stairs', null, '階段'));
             } else {
                 const label = (portalHere.label || '').trim();
-                detailParts.push(label ? `ゲート: ${label}` : 'ゲート');
+                detailParts.push(label
+                    ? translateSandbox('map.cell.details.gateWithLabel', { label }, `ゲート: ${label}`)
+                    : translateSandbox('map.cell.details.gate', null, 'ゲート'));
             }
         }
         if (cell === 0) {
             const floorType = meta?.floorType || '';
             if (floorType && floorType !== 'normal') {
-                const label = FLOOR_TYPE_LABELS[floorType] || floorType;
-                let suffix = '';
+                const label = getFloorTypeLabel(floorType) || floorType;
+                let directionIcon = '';
                 if (FLOOR_TYPES_NEED_DIRECTION.has(floorType)) {
                     const dir = meta?.floorDir || '';
                     if (dir && FLOOR_DIRECTION_ICONS[dir]) {
-                        suffix = `（${FLOOR_DIRECTION_ICONS[dir]}）`;
+                        directionIcon = FLOOR_DIRECTION_ICONS[dir];
                     }
                 } else if (floorType === 'vertical') {
-                    suffix = '（↕）';
+                    directionIcon = '↕';
                 } else if (floorType === 'horizontal') {
-                    suffix = '（↔）';
+                    directionIcon = '↔';
                 }
-                detailParts.push(`床タイプ: ${label}${suffix}`);
+                const suffix = directionIcon
+                    ? translateSandbox('map.cell.details.floorTypeDirectionSuffix', { icon: directionIcon }, `（${directionIcon}）`)
+                    : '';
+                detailParts.push(translateSandbox('map.cell.details.floorType', { label, suffix }, `床タイプ: ${label}${suffix}`));
             }
             if (meta?.floorColor) {
-                detailParts.push(`床色: ${meta.floorColor}`);
+                detailParts.push(translateSandbox('map.cell.details.floorColor', { color: meta.floorColor }, `床色: ${meta.floorColor}`));
             }
         } else if (meta?.wallColor) {
-            detailParts.push(`壁色: ${meta.wallColor}`);
+            detailParts.push(translateSandbox('map.cell.details.wallColor', { color: meta.wallColor }, `壁色: ${meta.wallColor}`));
         }
         const enemiesHere = Array.isArray(state.enemies) ? state.enemies.filter(e => e.x === x && e.y === y) : [];
         if (enemiesHere.length) {
@@ -2050,43 +2102,69 @@
                 const enemy = enemiesHere[0];
                 const name = (enemy.name || '').trim();
                 if (name) {
-                    enemyDetail = `敵: ${name}${enemy.boss ? '（ボス）' : ''}`;
+                    enemyDetail = translateSandbox(
+                        enemy.boss ? 'map.cell.details.enemy.singleNamedBoss' : 'map.cell.details.enemy.singleNamed',
+                        { name },
+                        enemy.boss ? `敵: ${name}（ボス）` : `敵: ${name}`
+                    );
                 } else {
-                    enemyDetail = enemy.boss ? '敵: ボス1体' : '敵: 1体';
+                    enemyDetail = translateSandbox(
+                        enemy.boss ? 'map.cell.details.enemy.singleBoss' : 'map.cell.details.enemy.single',
+                        { count: 1 },
+                        enemy.boss ? '敵: ボス1体' : '敵: 1体'
+                    );
                 }
             } else {
                 const nameParts = enemiesHere
                     .map(e => {
                         const nm = (e.name || '').trim();
-                        return nm ? `${nm}${e.boss ? '（ボス）' : ''}` : '';
+                        return nm ? `${nm}${e.boss ? translateSandbox('map.cell.details.enemy.bossSuffix', null, '（ボス）') : ''}` : '';
                     })
                     .filter(Boolean);
                 if (nameParts.length === enemiesHere.length) {
-                    enemyDetail = `敵: ${nameParts.join('、')}`;
+                    const list = nameParts.join(translateSandbox('map.cell.details.enemy.nameSeparator', null, '、'));
+                    enemyDetail = translateSandbox('map.cell.details.enemy.multipleNamed', { list }, `敵: ${list}`);
                 } else {
                     const bossCount = enemiesHere.filter(e => e.boss).length;
                     if (bossCount && bossCount === enemiesHere.length) {
-                        enemyDetail = `敵: ボス${enemiesHere.length}体`;
+                        enemyDetail = translateSandbox('map.cell.details.enemy.multipleAllBoss', { count: enemiesHere.length }, `敵: ボス${enemiesHere.length}体`);
                     } else if (bossCount) {
-                        enemyDetail = `敵: ${enemiesHere.length}体（ボス${bossCount}体含む）`;
+                        enemyDetail = translateSandbox(
+                            'map.cell.details.enemy.multipleWithBoss',
+                            { count: enemiesHere.length, bossCount },
+                            `敵: ${enemiesHere.length}体（ボス${bossCount}体含む）`
+                        );
                     } else {
-                        enemyDetail = `敵: ${enemiesHere.length}体`;
+                        enemyDetail = translateSandbox('map.cell.details.enemy.multiple', { count: enemiesHere.length }, `敵: ${enemiesHere.length}体`);
                     }
                 }
             }
-            detailParts.push(enemyDetail);
+            if (enemyDetail) detailParts.push(enemyDetail);
         }
         const domainsHere = Array.isArray(state.domainEffects) ? state.domainEffects.filter(e => e.x === x && e.y === y) : [];
         if (domainsHere.length) {
+            const effectSeparator = translateSandbox('map.cell.details.domain.effectSeparator', null, '・');
+            const domainSeparator = translateSandbox('map.cell.details.domain.separator', null, ' / ');
             const labels = domainsHere.map(effect => {
                 const name = (effect.name || '').trim();
                 const effects = Array.isArray(effect.effects) ? effect.effects.map(getDomainEffectLabel) : [];
-                const effectLabel = effects.length ? effects.join('・') : '効果なし';
-                return name ? `${name}: ${effectLabel}` : effectLabel;
+                const effectLabel = effects.length
+                    ? effects.join(effectSeparator)
+                    : translateSandbox('map.cell.details.domain.effectNone', null, '効果なし');
+                if (name) {
+                    return translateSandbox('map.cell.details.domain.named', { name, effects: effectLabel }, `${name}: ${effectLabel}`);
+                }
+                return translateSandbox('map.cell.details.domain.unnamed', { effects: effectLabel }, effectLabel);
             });
-            detailParts.push(`領域: ${labels.join(' / ')}`);
+            const summary = labels.join(domainSeparator);
+            detailParts.push(translateSandbox('map.cell.details.domain.summary', { summary }, `領域: ${summary}`));
         }
-        return detailParts.length ? `${baseLabel} - ${detailParts.join(' / ')}` : baseLabel;
+        if (!detailParts.length) {
+            return baseLabel;
+        }
+        const detailJoiner = translateSandbox('map.cell.details.joiner', null, ' / ');
+        const detailText = detailParts.join(detailJoiner);
+        return translateSandbox('map.cell.summary', { base: baseLabel, details: detailText }, `${baseLabel} - ${detailText}`);
     }
 
     function renderGrid() {
@@ -2329,13 +2407,21 @@
     }
 
     function updateSelectedCellLabel() {
-        const fallbackText = 'セルをクリックして編集します。';
+        const fallbackText = translateSandbox('map.selectedCell.hint', null, 'セルをクリックして編集します。');
         const description = state.lastCell ? describeCell(state.lastCell.x, state.lastCell.y) : '';
         if (refs.selectedCell) {
             if (state.lastCell && description) {
-                refs.selectedCell.textContent = `選択セル: ${description}`;
+                refs.selectedCell.textContent = translateSandbox(
+                    'map.selectedCell.selectedWithDescription',
+                    { description },
+                    `選択セル: ${description}`
+                );
             } else if (state.lastCell) {
-                refs.selectedCell.textContent = `選択セル: (${state.lastCell.x}, ${state.lastCell.y})`;
+                refs.selectedCell.textContent = translateSandbox(
+                    'map.selectedCell.selected',
+                    { x: state.lastCell.x, y: state.lastCell.y },
+                    `選択セル: (${state.lastCell.x}, ${state.lastCell.y})`
+                );
             } else {
                 refs.selectedCell.textContent = fallbackText;
             }


### PR DESCRIPTION
## Summary
- localize the sandbox map configuration UI and preview elements via data-i18n hooks
- add Japanese and English locale strings covering sandbox map settings and cell descriptions
- update the sandbox tool script to translate selected cell descriptions, floor types, and domain effects

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eb34159470832bbc2ea2f82101f79d