### PR TITLE
Add tool state registry integration for tools state manager

### DIFF
--- a/index.html
+++ b/index.html
@@ -1554,6 +1554,7 @@
             <button class="close-modal" data-target="enemy-info-modal" data-i18n="game.items.actions.close">閉じる</button>
         </div>
     </div>
+    <script src="js/tools/tool-state-registry.js"></script>
     <script src="js/tools/tools-tab.js"></script>
     <script src="js/tools/modmaker.js"></script>
     <script src="js/tools/blockdata-editor.js"></script>

--- a/js/tools/blockdata-editor.js
+++ b/js/tools/blockdata-editor.js
@@ -1096,4 +1096,12 @@
     if (global.ToolsTab?.registerTool) {
         global.ToolsTab.registerTool('blockdata-editor', initBlockDataEditor);
     }
+    if (global.ToolStateRegistry?.register) {
+        global.ToolStateRegistry.register('blockDataEditor', {
+            getState: () => exportSerializedState(),
+            setState: (snapshot) => importSerializedState(snapshot),
+            labelKey: 'tools.sidebar.stateManager.toolNames.blockDataEditor',
+            labelFallback: 'BlockData編集'
+        });
+    }
 })(window);

--- a/js/tools/image-viewer.js
+++ b/js/tools/image-viewer.js
@@ -915,4 +915,12 @@
     if (global.ToolsTab?.registerTool) {
         global.ToolsTab.registerTool(TOOL_ID, (context) => api.init(context));
     }
+    if (global.ToolStateRegistry?.register) {
+        global.ToolStateRegistry.register('imageViewer', {
+            getState: () => getSerializedState(),
+            setState: (snapshot) => applySerializedState(snapshot),
+            labelKey: 'tools.sidebar.stateManager.toolNames.imageViewer',
+            labelFallback: '画像ビューア'
+        });
+    }
 })(window);

--- a/js/tools/sandbox.js
+++ b/js/tools/sandbox.js
@@ -4979,4 +4979,12 @@
         getState: exportSerializedState,
         setState: importSerializedState
     };
+    if (global.ToolStateRegistry?.register) {
+        global.ToolStateRegistry.register('sandbox', {
+            getState: () => exportSerializedState(),
+            setState: (snapshot) => importSerializedState(snapshot),
+            labelKey: 'tools.sidebar.stateManager.toolNames.sandbox',
+            labelFallback: 'サンドボックス'
+        });
+    }
 })(window);

--- a/js/tools/tool-state-registry.js
+++ b/js/tools/tool-state-registry.js
@@ -1,0 +1,66 @@
+(function (global) {
+    'use strict';
+
+    const registry = new Map();
+    const listeners = new Set();
+
+    function toArray(value) {
+        return Array.isArray(value) ? value.slice() : [];
+    }
+
+    function notify() {
+        if (!listeners.size) return;
+        const callbacks = toArray(listeners);
+        callbacks.forEach((listener) => {
+            try {
+                listener();
+            } catch (err) {
+                console.error('[ToolStateRegistry] Listener failed:', err);
+            }
+        });
+    }
+
+    function register(toolId, descriptor) {
+        if (!toolId || typeof descriptor !== 'object' || descriptor === null) return;
+        const normalized = {
+            id: String(toolId),
+            getState: typeof descriptor.getState === 'function' ? descriptor.getState : null,
+            setState: typeof descriptor.setState === 'function' ? descriptor.setState : null,
+            labelKey: typeof descriptor.labelKey === 'string' ? descriptor.labelKey : null,
+            labelFallback: descriptor.labelFallback !== undefined ? descriptor.labelFallback : null
+        };
+        if (!normalized.getState && !normalized.setState) return;
+        registry.set(normalized.id, normalized);
+        notify();
+    }
+
+    function unregister(toolId) {
+        if (!toolId || !registry.delete(toolId)) return;
+        notify();
+    }
+
+    function get(toolId) {
+        if (!toolId) return null;
+        return registry.get(toolId) || null;
+    }
+
+    function list() {
+        return Array.from(registry.values());
+    }
+
+    function subscribe(listener) {
+        if (typeof listener !== 'function') return () => {};
+        listeners.add(listener);
+        return () => {
+            listeners.delete(listener);
+        };
+    }
+
+    global.ToolStateRegistry = {
+        register,
+        unregister,
+        get,
+        list,
+        subscribe
+    };
+})(window);


### PR DESCRIPTION
## Summary
- introduce a shared ToolStateRegistry so tools can expose import/export handlers
- update the state manager to consume registry entries and improve fallback handling
- register each tools tab module with the registry so their state is exported and restored consistently

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eb3ba11af4832bb86a581fda1ab876