### PR TITLE
Fix chest bias configuration for BlockDim addons

### DIFF
--- a/dungeontypes/axis_gallery.js
+++ b/dungeontypes/axis_gallery.js
@@ -85,6 +85,7 @@
     mixin: { normalMixed: 0.3, blockDimMixed: 0.5, tags: ['gallery', 'hazard'] }
   };
 
+  // Chest bias mapping note: legacy labels mapped as 'rich'→'more', 'rare'→'less', 'legendary'→'more'
   const blocks = {
     blocks1: [
       {
@@ -124,7 +125,7 @@
         level: +26,
         size: +2,
         depth: +3,
-        chest: 'rich',
+        chest: 'more',
         type: 'axis-gallery'
       }
     ],
@@ -136,7 +137,7 @@
         level: +26,
         size: +1,
         depth: +2,
-        chest: 'rich',
+        chest: 'more',
         type: 'axis-gallery'
       },
       {
@@ -156,7 +157,7 @@
         level: +32,
         size: +2,
         depth: +3,
-        chest: 'rich',
+        chest: 'more',
         type: 'axis-gallery'
       },
       {
@@ -166,7 +167,7 @@
         level: +34,
         size: +2,
         depth: +3,
-        chest: 'rare',
+        chest: 'less',
         type: 'axis-gallery'
       }
     ],
@@ -178,7 +179,7 @@
         level: +34,
         size: +2,
         depth: +3,
-        chest: 'rich',
+        chest: 'more',
         type: 'axis-gallery',
         bossFloors: [7, 14]
       },
@@ -189,7 +190,7 @@
         level: +38,
         size: +2,
         depth: +3,
-        chest: 'rich',
+        chest: 'more',
         type: 'axis-gallery',
         bossFloors: [10, 18]
       },
@@ -200,7 +201,7 @@
         level: +42,
         size: +3,
         depth: +4,
-        chest: 'rare',
+        chest: 'less',
         type: 'axis-gallery',
         bossFloors: [14]
       },
@@ -211,7 +212,7 @@
         level: +46,
         size: +3,
         depth: +4,
-        chest: 'legendary',
+        chest: 'more',
         type: 'axis-gallery',
         bossFloors: [21]
       }

--- a/dungeontypes/conveyor_foundry.js
+++ b/dungeontypes/conveyor_foundry.js
@@ -75,6 +75,7 @@
     mixin: { normalMixed: 0.35, blockDimMixed: 0.45, tags: ['mechanical', 'hazard'] }
   };
 
+  // Chest bias mapping note: legacy labels mapped as 'rich'→'more', 'rare'→'less', 'legendary'→'more'
   const blocks = {
     blocks1: [
       {
@@ -136,7 +137,7 @@
         level: +28,
         size: +1,
         depth: +2,
-        chest: 'rich',
+        chest: 'more',
         type: 'conveyor-foundry'
       },
       {
@@ -146,7 +147,7 @@
         level: +30,
         size: +2,
         depth: +3,
-        chest: 'rich',
+        chest: 'more',
         type: 'conveyor-foundry'
       },
       {
@@ -156,7 +157,7 @@
         level: +32,
         size: +2,
         depth: +3,
-        chest: 'rare',
+        chest: 'less',
         type: 'conveyor-foundry'
       }
     ],
@@ -168,7 +169,7 @@
         level: +32,
         size: +2,
         depth: +3,
-        chest: 'rich',
+        chest: 'more',
         type: 'conveyor-foundry',
         bossFloors: [6, 12]
       },
@@ -179,7 +180,7 @@
         level: +36,
         size: +2,
         depth: +3,
-        chest: 'rich',
+        chest: 'more',
         type: 'conveyor-foundry',
         bossFloors: [9, 15]
       },
@@ -190,7 +191,7 @@
         level: +40,
         size: +3,
         depth: +4,
-        chest: 'rare',
+        chest: 'less',
         type: 'conveyor-foundry',
         bossFloors: [12]
       },
@@ -201,7 +202,7 @@
         level: +44,
         size: +3,
         depth: +4,
-        chest: 'legendary',
+        chest: 'more',
         type: 'conveyor-foundry',
         bossFloors: [18]
       }

--- a/dungeontypes/oneway_labyrinth.js
+++ b/dungeontypes/oneway_labyrinth.js
@@ -99,6 +99,7 @@
     mixin: { normalMixed: 0.25, blockDimMixed: 0.5, tags: ['labyrinth', 'hazard'] }
   };
 
+  // Chest bias mapping note: legacy labels mapped as 'rich'→'more', 'rare'→'less', 'legendary'→'more'
   const blocks = {
     blocks1: [
       {
@@ -138,7 +139,7 @@
         level: +28,
         size: +2,
         depth: +3,
-        chest: 'rich',
+        chest: 'more',
         type: 'oneway-labyrinth'
       }
     ],
@@ -150,7 +151,7 @@
         level: +28,
         size: +1,
         depth: +2,
-        chest: 'rich',
+        chest: 'more',
         type: 'oneway-labyrinth'
       },
       {
@@ -160,7 +161,7 @@
         level: +32,
         size: +1,
         depth: +2,
-        chest: 'rich',
+        chest: 'more',
         type: 'oneway-labyrinth'
       },
       {
@@ -170,7 +171,7 @@
         level: +34,
         size: +2,
         depth: +3,
-        chest: 'rare',
+        chest: 'less',
         type: 'oneway-labyrinth'
       },
       {
@@ -180,7 +181,7 @@
         level: +36,
         size: +2,
         depth: +3,
-        chest: 'rare',
+        chest: 'less',
         type: 'oneway-labyrinth'
       }
     ],
@@ -192,7 +193,7 @@
         level: +36,
         size: +2,
         depth: +3,
-        chest: 'rich',
+        chest: 'more',
         type: 'oneway-labyrinth',
         bossFloors: [8, 16]
       },
@@ -203,7 +204,7 @@
         level: +40,
         size: +2,
         depth: +3,
-        chest: 'rich',
+        chest: 'more',
         type: 'oneway-labyrinth',
         bossFloors: [10, 18]
       },
@@ -214,7 +215,7 @@
         level: +44,
         size: +3,
         depth: +4,
-        chest: 'rare',
+        chest: 'less',
         type: 'oneway-labyrinth',
         bossFloors: [12, 20]
       },
@@ -225,7 +226,7 @@
         level: +48,
         size: +3,
         depth: +4,
-        chest: 'legendary',
+        chest: 'more',
         type: 'oneway-labyrinth',
         bossFloors: [24]
       }


### PR DESCRIPTION
## Summary
- replace legacy chest bias labels with the allowed less/normal/more values across the Axis Gallery, One-Way Labyrinth, and Conveyor Foundry packs
- document the mapping from the old labels to the supported values so future edits stay consistent

## Testing
- npm test
- node - <<'NODE' ...

------
https://chatgpt.com/codex/tasks/task_e_68eb3e447494832b8c0445e5a73dd6a7