### PR TITLE
Add configurable rewards to To-Do mini-game

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -16643,6 +16643,7 @@
         "detailSeparator": " / ",
         "obtainDetail": " ({details})",
         "obtain": "Obtained passive orb \"{label}\"!{detail}",
+        "obtainMultiple": "Obtained passive orb \"{label}\" ×{delta}!{detail}",
         "orbs": {
           "attackBoost": { "name": "Attack +1% Orb" },
           "defenseBoost": { "name": "Defense +1% Orb" },
@@ -17425,14 +17426,34 @@
         "header": {
           "title": "To-Do List",
           "today": "Today · {date}",
-          "stats": "Pending: {pending} / Completed: {completed}"
+          "stats": "Pending: {pending} / Completed: {completed} / Achievements: {achievements}"
         },
         "form": {
           "titleCreate": "Add New To-Do",
           "titleEdit": "Edit To-Do",
           "name": "Name",
           "namePlaceholder": "e.g., Send daily report",
+          "type": "Type",
+          "typeSingle": "Single",
+          "typeRepeatable": "Repeatable",
           "xp": "EXP Reward",
+          "rewards": {
+            "title": "Additional Rewards",
+            "passiveOrb": {
+              "label": "Passive Orb",
+              "placeholder": "e.g., attackBoost",
+              "amount": "Quantity"
+            },
+            "item": {
+              "label": "Item",
+              "placeholder": "e.g., potion30",
+              "amount": "Quantity"
+            },
+            "sp": {
+              "label": "SP",
+              "amount": "Amount"
+            }
+          },
           "color": "Color",
           "memo": "Notes",
           "memoPlaceholder": "Add notes or checkpoints",
@@ -17448,12 +17469,19 @@
         },
         "task": {
           "xpChip": "{xp} EXP",
+          "rewards": {
+            "passiveOrb": "Orb: {orb} ×{amount}",
+            "item": "{item} ×{amount}",
+            "sp": "+{amount} SP"
+          },
           "memoEmpty": "No notes",
           "createdAt": "Created: {date}",
           "completedAt": "Completed: {date}",
+          "repeatableCount": "Achieved: {count} times",
           "statusCompleted": "Success",
           "statusFailed": "Failed",
           "actions": {
+            "achieve": "Achieve",
             "complete": "Complete",
             "fail": "Fail",
             "edit": "Edit",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -16589,6 +16589,7 @@
         "detailSeparator": " / ",
         "obtainDetail": "（{details}）",
         "obtain": "パッシブオーブ「{label}」を手に入れた！{detail}",
+        "obtainMultiple": "パッシブオーブ「{label}」を{delta}個手に入れた！{detail}",
         "orbs": {
           "attackBoost": { "name": "攻撃力+1%の玉" },
           "defenseBoost": { "name": "防御力+1%の玉" },
@@ -17371,14 +17372,34 @@
         "header": {
           "title": "ToDoリスト",
           "today": "{date}",
-          "stats": "未完了: {pending}件 / 完了: {completed}件"
+          "stats": "未完了: {pending}件 / 完了: {completed}件 / 達成: {achievements}回"
         },
         "form": {
           "titleCreate": "新規ToDoを登録",
           "titleEdit": "ToDoを編集",
           "name": "名前",
           "namePlaceholder": "例: 日次レポートを送信",
+          "type": "タイプ",
+          "typeSingle": "単発",
+          "typeRepeatable": "繰り返し",
           "xp": "獲得EXP",
+          "rewards": {
+            "title": "追加報酬",
+            "passiveOrb": {
+              "label": "パッシブオーブ",
+              "placeholder": "例: attackBoost",
+              "amount": "個数"
+            },
+            "item": {
+              "label": "アイテム",
+              "placeholder": "例: potion30",
+              "amount": "個数"
+            },
+            "sp": {
+              "label": "SP",
+              "amount": "回復量"
+            }
+          },
           "color": "カラー",
           "memo": "メモ",
           "memoPlaceholder": "補足情報やチェックポイントなどを入力",
@@ -17394,12 +17415,19 @@
         },
         "task": {
           "xpChip": "{xp} EXP",
+          "rewards": {
+            "passiveOrb": "オーブ: {orb} ×{amount}",
+            "item": "{item} ×{amount}",
+            "sp": "SP +{amount}"
+          },
           "memoEmpty": "メモなし",
           "createdAt": "登録: {date}",
           "completedAt": "完了: {date}",
+          "repeatableCount": "達成回数: {count}回",
           "statusCompleted": "成功",
           "statusFailed": "失敗",
           "actions": {
+            "achieve": "達成",
             "complete": "完了",
             "fail": "失敗",
             "edit": "編集",


### PR DESCRIPTION
## Summary
- raise the To-Do mini-game XP cap and store sanitized reward settings for passive orbs, items, and SP
- surface reward configuration controls in the To-Do form and display reward chips on task cards with updated localization strings
- extend the mini-game player API with a specific passive-orb award helper for modules like To-Do

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68eb65d4e5e4832bab9ed80bf0826afc