### PR TITLE
Fix localization gaps in ToDo list mod

### DIFF
--- a/games/todo_list.js
+++ b/games/todo_list.js
@@ -598,16 +598,22 @@
     })();
 
     const DEFAULT_ITEM_IDS = Object.freeze(['potion30', 'hpBoost', 'atkBoost', 'defBoost', 'hpBoostMajor', 'atkBoostMajor', 'defBoostMajor', 'spElixir']);
-    const DEFAULT_ITEM_LABEL_MAP = Object.freeze({
-      potion30: 'Potion (30%)',
-      hpBoost: 'HP Boost',
-      atkBoost: 'ATK Boost',
-      defBoost: 'DEF Boost',
-      hpBoostMajor: 'Grand HP Boost',
-      atkBoostMajor: 'Grand ATK Boost',
-      defBoostMajor: 'Grand DEF Boost',
-      spElixir: 'SP Elixir'
+    const DEFAULT_ITEM_LABEL_FALLBACKS = Object.freeze({
+      potion30: { key: 'games.todoList.form.rewards.item.defaults.potion30', defaultText: 'Potion (30%)' },
+      hpBoost: { key: 'games.todoList.form.rewards.item.defaults.hpBoost', defaultText: 'HP Boost' },
+      atkBoost: { key: 'games.todoList.form.rewards.item.defaults.atkBoost', defaultText: 'ATK Boost' },
+      defBoost: { key: 'games.todoList.form.rewards.item.defaults.defBoost', defaultText: 'DEF Boost' },
+      hpBoostMajor: { key: 'games.todoList.form.rewards.item.defaults.hpBoostMajor', defaultText: 'Grand HP Boost' },
+      atkBoostMajor: { key: 'games.todoList.form.rewards.item.defaults.atkBoostMajor', defaultText: 'Grand ATK Boost' },
+      defBoostMajor: { key: 'games.todoList.form.rewards.item.defaults.defBoostMajor', defaultText: 'Grand DEF Boost' },
+      spElixir: { key: 'games.todoList.form.rewards.item.defaults.spElixir', defaultText: 'SP Elixir' }
     });
+
+    function getDefaultItemLabel(id){
+      const fallback = DEFAULT_ITEM_LABEL_FALLBACKS[id];
+      if (!fallback) return id;
+      return translate(fallback.key, fallback.defaultText);
+    }
 
     function ensureSelectHasValue(select, value, label){
       if (!select || !value) return;
@@ -633,12 +639,12 @@
 
     function getItemLabel(id){
       if (!id) return '';
-      const fallback = DEFAULT_ITEM_LABEL_MAP[id] || id;
+      const fallback = DEFAULT_ITEM_IDS.includes(id) ? getDefaultItemLabel(id) : id;
       let label = translate(`game.items.${id}.label`, () => fallback);
       if ((!DEFAULT_ITEM_IDS.includes(id)) && (!label || label === fallback || label === id)){
         label = translate('games.todoList.form.rewards.item.customOption', '{value} (保存済み)', { value: id });
       }
-      return label || id;
+      return label || fallback || id;
     }
 
     function collectPassiveOrbIds(){

--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -17442,12 +17442,26 @@
             "passiveOrb": {
               "label": "Passive Orb",
               "placeholder": "e.g., attackBoost",
+              "selectPlaceholder": "Select a passive orb",
+              "customOption": "{value} (saved)",
               "amount": "Quantity"
             },
             "item": {
               "label": "Item",
               "placeholder": "e.g., potion30",
-              "amount": "Quantity"
+              "selectPlaceholder": "Select an item",
+              "customOption": "{value} (saved)",
+              "amount": "Quantity",
+              "defaults": {
+                "potion30": "Potion (30%)",
+                "hpBoost": "HP Boost",
+                "atkBoost": "ATK Boost",
+                "defBoost": "DEF Boost",
+                "hpBoostMajor": "Grand HP Boost",
+                "atkBoostMajor": "Grand ATK Boost",
+                "defBoostMajor": "Grand DEF Boost",
+                "spElixir": "SP Elixir"
+              }
             },
             "sp": {
               "label": "SP",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -17388,12 +17388,26 @@
             "passiveOrb": {
               "label": "パッシブオーブ",
               "placeholder": "例: attackBoost",
+              "selectPlaceholder": "パッシブオーブを選択",
+              "customOption": "{value} (保存済み)",
               "amount": "個数"
             },
             "item": {
               "label": "アイテム",
               "placeholder": "例: potion30",
-              "amount": "個数"
+              "selectPlaceholder": "アイテムを選択",
+              "customOption": "{value} (保存済み)",
+              "amount": "個数",
+              "defaults": {
+                "potion30": "ポーション（30%）",
+                "hpBoost": "HPブースト",
+                "atkBoost": "攻撃ブースト",
+                "defBoost": "防御ブースト",
+                "hpBoostMajor": "特大HPブースト",
+                "atkBoostMajor": "特大攻撃ブースト",
+                "defBoostMajor": "特大防御ブースト",
+                "spElixir": "SPエリクサー"
+              }
             },
             "sp": {
               "label": "SP",


### PR DESCRIPTION
## Summary
- expose default ToDo reward labels through the translation system so they can be localized
- add translation entries for reward dropdown placeholders and saved-value labels in both English and Japanese

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ec550de47c832ba9d981f7758f8061