### PR TITLE
Fix sandbox gimmick suite localization

### DIFF
--- a/index.html
+++ b/index.html
@@ -639,80 +639,80 @@
                             </div>
                             <section class="sandbox-section sandbox-gimmick-suite" aria-labelledby="sandbox-gimmick-title">
                                 <div class="sandbox-section-header">
-                                    <h4 id="sandbox-gimmick-title">ギミック / ワイヤー</h4>
-                                    <div class="sandbox-gimmick-toolbar" role="group" aria-label="ギミック操作">
-                                        <label for="sandbox-gimmick-type" class="sandbox-inline-field">追加タイプ
+                                    <h4 id="sandbox-gimmick-title" data-i18n="tools.sandbox.gimmickSuite.title">ギミック / ワイヤー</h4>
+                                    <div class="sandbox-gimmick-toolbar" role="group" aria-label="ギミック操作" data-i18n-attr="aria-label:tools.sandbox.gimmickSuite.toolbarAria">
+                                        <label for="sandbox-gimmick-type" class="sandbox-inline-field" data-i18n="tools.sandbox.gimmickSuite.addTypeLabel">追加タイプ
                                             <select id="sandbox-gimmick-type">
-                                                <option value="floorSwitch">スイッチ</option>
-                                                <option value="pushableCrate">木箱</option>
-                                                <option value="door">扉</option>
-                                                <option value="sensor">センサー</option>
-                                                <option value="logic">論理ノード</option>
-                                                <option value="script">プログラム</option>
-                                                <option value="io">I/O</option>
-                                                <option value="alert">アラート</option>
+                                                <option value="floorSwitch" data-i18n="tools.sandbox.gimmicks.floorSwitch.label">スイッチ</option>
+                                                <option value="pushableCrate" data-i18n="tools.sandbox.gimmicks.pushableCrate.label">木箱</option>
+                                                <option value="door" data-i18n="tools.sandbox.gimmicks.door.label">扉</option>
+                                                <option value="sensor" data-i18n="tools.sandbox.gimmicks.sensor.label">センサー</option>
+                                                <option value="logic" data-i18n="tools.sandbox.gimmicks.logic.label">論理ノード</option>
+                                                <option value="script" data-i18n="tools.sandbox.gimmicks.script.label">プログラム</option>
+                                                <option value="io" data-i18n="tools.sandbox.gimmicks.io.label">I/O</option>
+                                                <option value="alert" data-i18n="tools.sandbox.gimmicks.alert.label">アラート</option>
                                             </select>
                                         </label>
-                                        <button type="button" id="sandbox-add-gimmick">+ ギミックを追加</button>
-                                        <button type="button" id="sandbox-auto-layout" class="sandbox-secondary-button">自動整列</button>
+                                        <button type="button" id="sandbox-add-gimmick" data-i18n="tools.sandbox.gimmickSuite.add">+ ギミックを追加</button>
+                                        <button type="button" id="sandbox-auto-layout" class="sandbox-secondary-button" data-i18n="tools.sandbox.gimmickSuite.autoLayout">自動整列</button>
                                     </div>
                                 </div>
                                 <div class="sandbox-gimmick-layout">
-                                    <aside id="sandbox-gimmick-list" class="sandbox-gimmick-list" role="listbox" aria-label="ギミック一覧"></aside>
+                                    <aside id="sandbox-gimmick-list" class="sandbox-gimmick-list" role="listbox" aria-label="ギミック一覧" data-i18n-attr="aria-label:tools.sandbox.gimmickSuite.listAria"></aside>
                                     <div id="sandbox-gimmick-detail" class="sandbox-gimmick-detail" aria-live="polite">
                                         <form id="sandbox-gimmick-form" autocomplete="off">
                                             <div class="sandbox-form-grid">
-                                                <label>名前
-                                                    <input id="sandbox-gimmick-name" type="text" maxlength="40" placeholder="ギミック名">
+                                                <label data-i18n="tools.sandbox.gimmickSuite.fields.name">名前
+                                                    <input id="sandbox-gimmick-name" type="text" maxlength="40" placeholder="ギミック名" data-i18n-attr="placeholder:tools.sandbox.gimmickSuite.fields.namePlaceholder">
                                                 </label>
-                                                <label>種類
+                                                <label data-i18n="tools.sandbox.gimmickSuite.fields.type">種類
                                                     <input id="sandbox-gimmick-type-display" type="text" readonly>
                                                 </label>
                                             </div>
                                             <div class="sandbox-form-grid">
-                                                <label>タグ (カンマ区切り)
-                                                    <input id="sandbox-gimmick-tags" type="text" maxlength="120" placeholder="例: puzzle,door">
+                                                <label data-i18n="tools.sandbox.gimmickSuite.fields.tags">タグ (カンマ区切り)
+                                                    <input id="sandbox-gimmick-tags" type="text" maxlength="120" placeholder="例: puzzle,door" data-i18n-attr="placeholder:tools.sandbox.gimmickSuite.fields.tagsPlaceholder">
                                                 </label>
                                                 <label class="sandbox-checkbox">
                                                     <input id="sandbox-gimmick-locked" type="checkbox">
-                                                    <span>ビジュアル上で固定</span>
+                                                    <span data-i18n="tools.sandbox.gimmickSuite.fields.locked">ビジュアル上で固定</span>
                                                 </label>
                                             </div>
                                             <div class="sandbox-form-grid sandbox-gimmick-tile">
-                                                <label>タイルX
-                                                    <input id="sandbox-gimmick-tile-x" type="number" min="0" step="1" placeholder="X">
+                                                <label data-i18n="tools.sandbox.gimmickSuite.fields.tileX">タイルX
+                                                    <input id="sandbox-gimmick-tile-x" type="number" min="0" step="1" placeholder="X" data-i18n-attr="placeholder:tools.sandbox.gimmickSuite.fields.tileXPlaceholder">
                                                 </label>
-                                                <label>タイルY
-                                                    <input id="sandbox-gimmick-tile-y" type="number" min="0" step="1" placeholder="Y">
+                                                <label data-i18n="tools.sandbox.gimmickSuite.fields.tileY">タイルY
+                                                    <input id="sandbox-gimmick-tile-y" type="number" min="0" step="1" placeholder="Y" data-i18n-attr="placeholder:tools.sandbox.gimmickSuite.fields.tileYPlaceholder">
                                                 </label>
                                                 <div class="sandbox-gimmick-tile-actions">
-                                                    <button type="button" id="sandbox-gimmick-use-selected">選択セルを使用</button>
-                                                    <button type="button" id="sandbox-gimmick-clear-tile" class="sandbox-secondary-button">解除</button>
+                                                    <button type="button" id="sandbox-gimmick-use-selected" data-i18n="tools.sandbox.gimmickSuite.actions.useSelected">選択セルを使用</button>
+                                                    <button type="button" id="sandbox-gimmick-clear-tile" class="sandbox-secondary-button" data-i18n="tools.sandbox.gimmickSuite.actions.clearTile">解除</button>
                                                 </div>
                                             </div>
-                                            <label>メモ
-                                                <textarea id="sandbox-gimmick-notes" rows="3" maxlength="400" placeholder="メモや注意事項"></textarea>
+                                            <label data-i18n="tools.sandbox.gimmickSuite.fields.notes">メモ
+                                                <textarea id="sandbox-gimmick-notes" rows="3" maxlength="400" placeholder="メモや注意事項" data-i18n-attr="placeholder:tools.sandbox.gimmickSuite.fields.notesPlaceholder"></textarea>
                                             </label>
                                             <div class="sandbox-gimmick-config">
-                                                <h5 class="sandbox-subheader">設定</h5>
+                                                <h5 class="sandbox-subheader" data-i18n="tools.sandbox.gimmickSuite.subheaders.config">設定</h5>
                                                 <div id="sandbox-gimmick-config-fields" class="sandbox-gimmick-config-fields"></div>
                                             </div>
                                             <div class="sandbox-gimmick-actions">
-                                                <button type="button" id="sandbox-gimmick-duplicate" class="sandbox-secondary-button">複製</button>
-                                                <button type="button" id="sandbox-gimmick-delete" class="sandbox-danger-button">削除</button>
+                                                <button type="button" id="sandbox-gimmick-duplicate" class="sandbox-secondary-button" data-i18n="tools.sandbox.common.actions.duplicate">複製</button>
+                                                <button type="button" id="sandbox-gimmick-delete" class="sandbox-danger-button" data-i18n="tools.sandbox.common.actions.delete">削除</button>
                                             </div>
                                         </form>
                                         <div class="sandbox-wire-list-wrapper">
-                                            <h5 class="sandbox-subheader">接続一覧</h5>
+                                            <h5 class="sandbox-subheader" data-i18n="tools.sandbox.gimmickSuite.subheaders.wires">接続一覧</h5>
                                             <div id="sandbox-wire-list" class="sandbox-wire-list" aria-live="polite"></div>
                                         </div>
                                     </div>
-                                    <div id="sandbox-wire-editor" class="sandbox-wire-editor" role="application" aria-label="ワイヤー編集エリア">
+                                    <div id="sandbox-wire-editor" class="sandbox-wire-editor" role="application" aria-label="ワイヤー編集エリア" data-i18n-attr="aria-label:tools.sandbox.gimmickSuite.wireEditorAria">
                                         <svg id="sandbox-wire-canvas" class="sandbox-wire-canvas" aria-hidden="true"></svg>
                                         <div id="sandbox-wire-nodes" class="sandbox-wire-nodes"></div>
                                         <div class="sandbox-wire-statusbar">
                                             <span id="sandbox-wire-status" role="status" aria-live="polite"></span>
-                                            <button type="button" id="sandbox-wire-clear-selection" class="sandbox-secondary-button">選択解除</button>
+                                            <button type="button" id="sandbox-wire-clear-selection" class="sandbox-secondary-button" data-i18n="tools.sandbox.gimmickSuite.actions.clearSelection">選択解除</button>
                                         </div>
                                     </div>
                                 </div>

--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -15434,12 +15434,45 @@
         "common": {
           "actions": {
             "select": "Select",
-            "delete": "Delete"
+            "delete": "Delete",
+            "duplicate": "Duplicate"
           },
           "axes": {
             "x": "X",
             "y": "Y"
           }
+        },
+        "gimmickSuite": {
+          "title": "Gimmicks / Wires",
+          "toolbarAria": "Gimmick controls",
+          "addTypeLabel": "Add type",
+          "add": "+ Add gimmick",
+          "autoLayout": "Auto layout",
+          "listAria": "Gimmick list",
+          "fields": {
+            "name": "Name",
+            "namePlaceholder": "Gimmick name",
+            "type": "Type",
+            "tags": "Tags (comma-separated)",
+            "tagsPlaceholder": "e.g. puzzle,door",
+            "locked": "Lock position in layout",
+            "tileX": "Tile X",
+            "tileY": "Tile Y",
+            "tileXPlaceholder": "X",
+            "tileYPlaceholder": "Y",
+            "notes": "Notes",
+            "notesPlaceholder": "Notes or warnings"
+          },
+          "actions": {
+            "useSelected": "Use selected cell",
+            "clearTile": "Clear",
+            "clearSelection": "Clear selection"
+          },
+          "subheaders": {
+            "config": "Configuration",
+            "wires": "Connections"
+          },
+          "wireEditorAria": "Wire editor area"
         },
         "enemies": {
           "title": "Enemy Placement",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -15505,12 +15505,45 @@
         "common": {
           "actions": {
             "select": "選択",
-            "delete": "削除"
+            "delete": "削除",
+            "duplicate": "複製"
           },
           "axes": {
             "x": "X",
             "y": "Y"
           }
+        },
+        "gimmickSuite": {
+          "title": "ギミック / ワイヤー",
+          "toolbarAria": "ギミック操作",
+          "addTypeLabel": "追加タイプ",
+          "add": "+ ギミックを追加",
+          "autoLayout": "自動整列",
+          "listAria": "ギミック一覧",
+          "fields": {
+            "name": "名前",
+            "namePlaceholder": "ギミック名",
+            "type": "種類",
+            "tags": "タグ (カンマ区切り)",
+            "tagsPlaceholder": "例: puzzle,door",
+            "locked": "ビジュアル上で固定",
+            "tileX": "タイルX",
+            "tileY": "タイルY",
+            "tileXPlaceholder": "X",
+            "tileYPlaceholder": "Y",
+            "notes": "メモ",
+            "notesPlaceholder": "メモや注意事項"
+          },
+          "actions": {
+            "useSelected": "選択セルを使用",
+            "clearTile": "解除",
+            "clearSelection": "選択解除"
+          },
+          "subheaders": {
+            "config": "設定",
+            "wires": "接続一覧"
+          },
+          "wireEditorAria": "ワイヤー編集エリア"
         },
         "enemies": {
           "title": "敵配置",


### PR DESCRIPTION
## Summary
- wire sandbox gimmick and wire controls in the editor to the i18n system
- add Japanese and English strings for the new sandbox gimmick suite labels and placeholders

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ec61ddec98832ba271b3d3f4bc1df8