### PR TITLE
Add addon statistics to achievements tab

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -16284,7 +16284,8 @@
           "core": { "title": "Dungeon Records" },
           "blockdim": { "title": "Block Dimension Records" },
           "hatena": { "title": "Hatena Block Records" },
-          "tools": { "title": "Tools Usage" }
+          "tools": { "title": "Tools Usage" },
+          "addons": { "title": "Addon Status" }
         },
         "entries": {
           "core": {
@@ -16343,6 +16344,18 @@
             "blockdataSaves": { "label": "BlockData Saves", "description": "Times data was saved in the BlockData editor." },
             "blockdataDownloads": { "label": "BlockData Downloads", "description": "Times data was downloaded from the BlockData editor." },
             "sandboxSessions": { "label": "Sandbox Sessions", "description": "Times the sandbox interface was opened." }
+          },
+          "addons": {
+            "activeGenerators": {
+              "label": "Active generation types",
+              "description": "Number of registered addon generation types currently loaded.",
+              "value": "{value} types"
+            },
+            "miniGameMods": {
+              "label": "Mini game mods",
+              "description": "Count of MiniExp games provided by mods.",
+              "value": "{value} titles"
+            }
           }
         }
       },

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -16355,7 +16355,8 @@
           "core": { "title": "ダンジョンの記録" },
           "blockdim": { "title": "ブロック次元の記録" },
           "hatena": { "title": "ハテナブロックの記録" },
-          "tools": { "title": "ツール利用状況" }
+          "tools": { "title": "ツール利用状況" },
+          "addons": { "title": "アドオン状況" }
         },
         "entries": {
           "core": {
@@ -16414,6 +16415,18 @@
             "blockdataSaves": { "label": "BlockData 保存回数", "description": "BlockData エディタで保存した回数。" },
             "blockdataDownloads": { "label": "BlockData ダウンロード回数", "description": "BlockData エディタからダウンロードした回数。" },
             "sandboxSessions": { "label": "サンドボックス操作回数", "description": "サンドボックスUIを開いた回数。" }
+          },
+          "addons": {
+            "activeGenerators": {
+              "label": "アクティブ生成タイプ数",
+              "description": "現在読み込まれている生成タイプ（MOD含む）の数。",
+              "value": "{value} 種類"
+            },
+            "miniGameMods": {
+              "label": "ミニゲームMOD数",
+              "description": "MiniExpに登録されているMOD提供ミニゲームの数。",
+              "value": "{value} タイトル"
+            }
           }
         }
       },


### PR DESCRIPTION
## Summary
- expose addon and mini-game mod counts through global helpers and refresh achievements when new content registers
- extend the achievements statistics renderer to support dynamic values and show addon metrics
- localize the new statistics labels in Japanese and English

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ec67244084832b9552291951ab4a82