### PR TITLE
Fix missing To-Do list localization entries

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -17681,94 +17681,6 @@
       }
     },
     "games": {
-      "todoList": {
-        "defaults": {
-          "untitled": "Untitled"
-        },
-        "header": {
-          "title": "To-Do List",
-          "today": "Today · {date}",
-          "stats": "Pending: {pending} / Completed: {completed} / Achievements: {achievements}"
-        },
-        "form": {
-          "titleCreate": "Add New To-Do",
-          "titleEdit": "Edit To-Do",
-          "name": "Name",
-          "namePlaceholder": "e.g., Send daily report",
-          "type": "Type",
-          "typeSingle": "Single",
-          "typeRepeatable": "Repeatable",
-          "xp": "EXP Reward",
-          "rewards": {
-            "title": "Additional Rewards",
-            "passiveOrb": {
-              "label": "Passive Orb",
-              "placeholder": "e.g., attackBoost",
-              "selectPlaceholder": "Select a passive orb",
-              "customOption": "{value} (saved)",
-              "amount": "Quantity"
-            },
-            "item": {
-              "label": "Item",
-              "placeholder": "e.g., potion30",
-              "selectPlaceholder": "Select an item",
-              "customOption": "{value} (saved)",
-              "amount": "Quantity",
-              "defaults": {
-                "potion30": "Potion (30%)",
-                "hpBoost": "HP Boost",
-                "atkBoost": "ATK Boost",
-                "defBoost": "DEF Boost",
-                "hpBoostMajor": "Grand HP Boost",
-                "atkBoostMajor": "Grand ATK Boost",
-                "defBoostMajor": "Grand DEF Boost",
-                "spElixir": "SP Elixir"
-              }
-            },
-            "sp": {
-              "label": "SP",
-              "amount": "Amount"
-            }
-          },
-          "color": "Color",
-          "memo": "Notes",
-          "memoPlaceholder": "Add notes or checkpoints",
-          "submitCreate": "Add",
-          "submitUpdate": "Update",
-          "cancel": "Cancel"
-        },
-        "sections": {
-          "pending": "Pending Tasks",
-          "completed": "Completed Tasks",
-          "emptyPending": "No pending to-dos.",
-          "emptyCompleted": "No completed to-dos yet."
-        },
-        "task": {
-          "xpChip": "{xp} EXP",
-          "rewards": {
-            "passiveOrb": "Orb: {orb} ×{amount}",
-            "item": "{item} ×{amount}",
-            "sp": "+{amount} SP"
-          },
-          "memoEmpty": "No notes",
-          "createdAt": "Created: {date}",
-          "completedAt": "Completed: {date}",
-          "repeatableCount": "Achieved: {count} times",
-          "statusCompleted": "Success",
-          "statusFailed": "Failed",
-          "actions": {
-            "achieve": "Achieve",
-            "complete": "Complete",
-            "fail": "Fail",
-            "edit": "Edit",
-            "delete": "Delete"
-          }
-        },
-        "dialogs": {
-          "confirmDelete": "Delete this to-do?",
-          "requireName": "Enter a name."
-        }
-      },
       "notepad": {
         "defaultFileName": "Untitled.txt",
         "confirm": {
@@ -18545,14 +18457,48 @@
         "header": {
           "title": "To-Do List",
           "today": "Today · {date}",
-          "stats": "Pending: {pending} / Completed: {completed}"
+          "stats": "Pending: {pending} / Completed: {completed} / Achievements: {achievements}"
         },
         "form": {
           "titleCreate": "Add New To-Do",
           "titleEdit": "Edit To-Do",
           "name": "Name",
           "namePlaceholder": "e.g., Send daily report",
+          "type": "Type",
+          "typeSingle": "Single",
+          "typeRepeatable": "Repeatable",
           "xp": "EXP Reward",
+          "rewards": {
+            "title": "Additional Rewards",
+            "passiveOrb": {
+              "label": "Passive Orb",
+              "placeholder": "e.g., attackBoost",
+              "selectPlaceholder": "Select a passive orb",
+              "customOption": "{value} (saved)",
+              "amount": "Quantity"
+            },
+            "item": {
+              "label": "Item",
+              "placeholder": "e.g., potion30",
+              "selectPlaceholder": "Select an item",
+              "customOption": "{value} (saved)",
+              "amount": "Quantity",
+              "defaults": {
+                "potion30": "Potion (30%)",
+                "hpBoost": "HP Boost",
+                "atkBoost": "ATK Boost",
+                "defBoost": "DEF Boost",
+                "hpBoostMajor": "Grand HP Boost",
+                "atkBoostMajor": "Grand ATK Boost",
+                "defBoostMajor": "Grand DEF Boost",
+                "spElixir": "SP Elixir"
+              }
+            },
+            "sp": {
+              "label": "SP",
+              "amount": "Amount"
+            }
+          },
           "color": "Color",
           "memo": "Notes",
           "memoPlaceholder": "Add notes or checkpoints",
@@ -18568,12 +18514,19 @@
         },
         "task": {
           "xpChip": "{xp} EXP",
+          "rewards": {
+            "passiveOrb": "Orb: {orb} ×{amount}",
+            "item": "{item} ×{amount}",
+            "sp": "+{amount} SP"
+          },
           "memoEmpty": "No notes",
           "createdAt": "Created: {date}",
           "completedAt": "Completed: {date}",
+          "repeatableCount": "Achieved: {count} times",
           "statusCompleted": "Success",
           "statusFailed": "Failed",
           "actions": {
+            "achieve": "Achieve",
             "complete": "Complete",
             "fail": "Fail",
             "edit": "Edit",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -18609,53 +18609,6 @@
           "found": "宝を発見！次のラウンドを生成中…"
         }
       },
-      "todoList": {
-        "defaults": {
-          "untitled": "名称未設定"
-        },
-        "header": {
-          "title": "ToDoリスト",
-          "today": "{date}",
-          "stats": "未完了: {pending}件 / 完了: {completed}件"
-        },
-        "form": {
-          "titleCreate": "新規ToDoを登録",
-          "titleEdit": "ToDoを編集",
-          "name": "名前",
-          "namePlaceholder": "例: 日次レポートを送信",
-          "xp": "獲得EXP",
-          "color": "カラー",
-          "memo": "メモ",
-          "memoPlaceholder": "補足情報やチェックポイントなどを入力",
-          "submitCreate": "追加",
-          "submitUpdate": "更新",
-          "cancel": "キャンセル"
-        },
-        "sections": {
-          "pending": "未完了タスク",
-          "completed": "完了済みタスク",
-          "emptyPending": "未完了のToDoはありません。",
-          "emptyCompleted": "完了したToDoはまだありません。"
-        },
-        "task": {
-          "xpChip": "{xp} EXP",
-          "memoEmpty": "メモなし",
-          "createdAt": "登録: {date}",
-          "completedAt": "完了: {date}",
-          "statusCompleted": "成功",
-          "statusFailed": "失敗",
-          "actions": {
-            "complete": "完了",
-            "fail": "失敗",
-            "edit": "編集",
-            "delete": "削除"
-          }
-        },
-        "dialogs": {
-          "confirmDelete": "このToDoを削除しますか？",
-          "requireName": "名前を入力してください。"
-        }
-      },
       "notepad": {
         "defaultFileName": "タイトルなし.txt",
         "confirm": {


### PR DESCRIPTION
## Summary
- remove the outdated fallback To-Do list locale block so the full translation set is used
- extend the remaining English strings with the task type, rewards, and achievement text so no fallback is needed
- rely on the existing comprehensive Japanese strings without allowing them to be overridden by the truncated copy

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ec6757e9b4832bac3db2a7fce20af3