### PR TITLE
Fix language selector to include Chinese option

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
             <select id="language-select" aria-label="" data-i18n-attr="aria-label:ui.language.ariaLabel">
                 <option value="ja" data-i18n="ui.language.option.ja"></option>
                 <option value="en" data-i18n="ui.language.option.en"></option>
+                <option value="zh" data-i18n="ui.language.option.zh"></option>
             </select>
         </div>
     </header>


### PR DESCRIPTION
## Summary
- add the Simplified Chinese entry to the top-level language selector

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ec9bbda8ec832bacc0c524b8735d65