### PR TITLE
Add manual shortcuts to top screen header

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,10 @@
 <body>
     <header class="site-header">
         <h1 data-i18n="header.title"></h1>
-        <div class="language-switcher">
+        <div class="header-actions">
+            <a class="header-link-button" href="manual/index.html" target="_blank" rel="noopener" data-i18n="header.manual"></a>
+            <a class="header-link-button" href="manual/minigame-guide.html" target="_blank" rel="noopener" data-i18n="header.minigameManual"></a>
+            <div class="language-switcher">
             <label for="language-select" data-i18n="ui.language.label"></label>
             <select id="language-select" aria-label="" data-i18n-attr="aria-label:ui.language.ariaLabel">
                 <option value="ja" data-i18n="ui.language.option.ja"></option>
@@ -17,6 +20,7 @@
                 <option value="zh" data-i18n="ui.language.option.zh"></option>
                 <option value="ko" data-i18n="ui.language.option.ko"></option>
             </select>
+            </div>
         </div>
     </header>
     <div id="selection-screen">

--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -7,7 +7,9 @@
     },
 
     "header": {
-      "title": "Yu Roguelike"
+      "title": "Yu Roguelike",
+      "manual": "Read Manual",
+      "minigameManual": "Read Mini-Game Manual"
     },
 
     "ui": {

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -7,7 +7,9 @@
     },
 
     "header": {
-      "title": "Yuローグライク"
+      "title": "Yuローグライク",
+      "manual": "マニュアルを読む",
+      "minigameManual": "ミニゲームのマニュアルを読む"
     },
 
     "ui": {

--- a/js/i18n/locales/ko.json.js
+++ b/js/i18n/locales/ko.json.js
@@ -6,7 +6,9 @@
       "title": "유 로그라이크"
     },
     "header": {
-      "title": "유 로그라이크"
+      "title": "유 로그라이크",
+      "manual": "매뉴얼 읽기",
+      "minigameManual": "미니게임 매뉴얼 읽기"
     },
     "ui": {
       "language": {

--- a/js/i18n/locales/zh.json.js
+++ b/js/i18n/locales/zh.json.js
@@ -7,7 +7,9 @@
       "title": "Yu Roguelike"
     },
     "header": {
-      "title": "Yu Roguelike"
+      "title": "Yu Roguelike",
+      "manual": "阅读手册",
+      "minigameManual": "阅读迷你游戏手册"
     },
     "ui": {
       "language": {

--- a/style.css
+++ b/style.css
@@ -18,6 +18,7 @@ body {
     justify-content: space-between;
     align-items: center;
     gap: 16px;
+    flex-wrap: wrap;
     padding: 18px 24px;
     margin-bottom: 20px;
     background: rgba(255, 255, 255, 0.88);
@@ -30,6 +31,41 @@ body {
     margin: 0;
     font-size: 28px;
     letter-spacing: 0.04em;
+}
+
+.header-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+
+.header-link-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px 14px;
+    border-radius: 12px;
+    background: linear-gradient(135deg, rgba(59,130,246,0.18), rgba(37,99,235,0.28));
+    color: #1e3a8a;
+    font-weight: 600;
+    font-size: 0.9rem;
+    text-decoration: none;
+    border: 1px solid rgba(59, 130, 246, 0.25);
+    box-shadow: 0 6px 18px rgba(37, 99, 235, 0.22);
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.header-link-button:hover,
+.header-link-button:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 10px 24px rgba(37, 99, 235, 0.28);
+}
+
+.header-link-button:focus-visible {
+    outline: 2px solid rgba(59, 130, 246, 0.5);
+    outline-offset: 2px;
 }
 
 .language-switcher {


### PR DESCRIPTION
## Summary
- add header buttons that link to the main manual and mini-game guide next to the language selector
- style the new buttons and adjust the header layout for better wrapping on small screens
- localize the new button labels across Japanese, English, Chinese, and Korean locales

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ecae303e60832ba5980f185f336bab