### PR TITLE
Fix board game localization fallbacks

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -603,49 +603,146 @@
             }
           },
           "xiangqi": {
-        "header": {
-          "title": "Xiangqi",
-          "subtitle": "{color} moves first"
-        },
-        "controls": {
-          "reset": "Reset position"
-        },
-        "board": {
-          "riverLabel": "Chu River  Han Border"
-        },
-        "color": {
-          "red": "Red",
-          "black": "Black",
-          "redPlayer": "Red (Bottom)",
-          "blackPlayer": "Black (Top)"
-        },
-        "pieces": {
-          "general": "General",
-          "advisor": "Advisor",
-          "elephant": "Elephant",
-          "horse": "Horse",
-          "chariot": "Chariot",
-          "cannon": "Cannon",
-          "soldier": "Soldier"
-        },
-        "expLabel": "EXP",
-        "piece": {
-          "description": "{color} {piece}"
-        },
-        "status": {
-          "turnLine": "Turn: {turn}",
-          "turn": {
-            "red": "It is {color}'s move.",
-            "black": "It is {color}'s move."
+            "name": "Xiangqi",
+            "description": "Chinese chess. Capture pieces, deliver checks, and mate to earn EXP.",
+            "header": {
+              "title": "Xiangqi",
+              "subtitle": "{color} moves first"
+            },
+            "controls": {
+              "reset": "Reset position"
+            },
+            "board": {
+              "riverLabel": "Chu River  Han Border"
+            },
+            "color": {
+              "red": "Red",
+              "black": "Black",
+              "redPlayer": "Red (Bottom)",
+              "blackPlayer": "Black (Top)"
+            },
+            "pieces": {
+              "general": "General",
+              "advisor": "Advisor",
+              "elephant": "Elephant",
+              "horse": "Horse",
+              "chariot": "Chariot",
+              "cannon": "Cannon",
+              "soldier": "Soldier"
+            },
+            "expLabel": "EXP",
+            "piece": {
+              "description": "{color} {piece}"
+            },
+            "status": {
+              "turnLine": "Turn: {turn}",
+              "turn": {
+                "red": "It is {color}'s move.",
+                "black": "It is {color}'s move."
+              },
+              "scoreLine": "Total score: {score}",
+              "capture": "{actor} captured {target} (+{exp}{expLabel})",
+              "move": "{piece} moved.",
+              "win": "{loser} is checkmated. {winner} wins!",
+              "stalemate": "Stalemate (no legal moves).",
+              "check": "{defender} is in check (+{exp}{expLabel})"
+            }
           },
-          "scoreLine": "Total score: {score}",
-          "capture": "{actor} captured {target} (+{exp}{expLabel})",
-          "move": "{piece} moved.",
-          "win": "{loser} is checkmated. {winner} wins!",
-          "stalemate": "Stalemate (no legal moves).",
-          "check": "{defender} is in check (+{exp}{expLabel})"
-        }
-      },
+          "shogi": {
+            "name": "Shogi",
+            "description": "Authentic shogi. Use drops and promotions to aim for mate and earn EXP from moves, captures, and checks.",
+            "ui": {
+              "title": "Shogi",
+              "subtitle": "MiniExp Edition",
+              "legend": "Moves: +{moveExpFormatted} EXP / Drops: +{dropExpFormatted} EXP / Capture bonus / Promotion: +{promoteExpFormatted} EXP / Check: +{checkExpFormatted} EXP / Victory bonus",
+              "hands": {
+                "aiLabel": "Sente (CPU)",
+                "playerLabel": "Gote (You)",
+                "empty": "None",
+                "chip": "{piece}×{countFormatted}",
+                "total": "{countFormatted} pieces",
+                "totalNone": "None"
+              },
+              "actions": {
+                "restart": "Restart"
+              },
+              "confirm": {
+                "promote": "Promote this piece?"
+              }
+            },
+            "status": {
+              "playerTurn": "Your turn. Select a piece on the board or from your hand.",
+              "aiThinking": "CPU is considering its move…",
+              "playerInCheck": "You're in check! Respond carefully.",
+              "aiInCheck": "Check! Look for the finishing blow."
+            },
+            "result": {
+              "playerWin": "Checkmate! You win.",
+              "playerLose": "Checkmated… Defeat.",
+              "draw": "Impasse / repetition draw"
+            },
+            "pieces": {
+              "glyph": {
+                "pawn": "歩",
+                "lance": "香",
+                "knight": "桂",
+                "silver": "銀",
+                "gold": "金",
+                "bishop": "角",
+                "rook": "飛",
+                "king": "玉",
+                "promotedPawn": "と",
+                "promotedLance": "成香",
+                "promotedKnight": "成桂",
+                "promotedSilver": "成銀",
+                "promotedBishop": "馬",
+                "promotedRook": "龍"
+              },
+              "label": {
+                "pawn": "歩",
+                "lance": "香",
+                "knight": "桂",
+                "silver": "銀",
+                "gold": "金",
+                "bishop": "角",
+                "rook": "飛",
+                "king": "玉"
+              }
+            }
+          },
+          "go": {
+            "name": "Go",
+            "description": "Place stones, capture groups, and claim victory EXP.",
+            "info": {
+              "intro": "Go 9×9 — You play first (Black)"
+            },
+            "hud": {
+              "turn": {
+                "player": "Your turn (Black)",
+                "ai": "AI's turn (White)"
+              },
+              "status": "{turn} ｜ Black Captures:{blackCaptures} ｜ White Captures:{whiteCaptures} (Komi +{komi})",
+              "passNotice": "{actor} passed ({count} in a row)",
+              "aiThinking": "AI is thinking…"
+            },
+            "buttons": {
+              "pass": "Pass",
+              "resign": "Resign"
+            },
+            "messages": {
+              "koViolation": "That move is illegal due to ko."
+            },
+            "actors": {
+              "player": "You",
+              "ai": "AI"
+            },
+            "result": {
+              "win": "You win!",
+              "loss": "AI wins…",
+              "draw": "Jigo (Draw)",
+              "summary": "{result} ｜ Black {blackScore} - White {whiteScore}"
+            }
+          },
       "mancala": {
             "name": "Mancala",
             "description": "Sow seeds and capture pits in the Kalah rule set to outscore the AI for EXP."

--- a/js/i18n/locales/ko.json.js
+++ b/js/i18n/locales/ko.json.js
@@ -505,47 +505,144 @@
             }
           },
           "xiangqi": {
+            "name": "샹치",
+            "description": "중국 장기. 기물을 포획하고 장군·체크메이트로 경험치를 얻으세요.",
             "header": {
               "title": "샹치",
-              "subtitle": "{color}이 먼저 이동합니다."
+              "subtitle": "{color}이 선공"
             },
             "controls": {
-              "reset": "위치 재설정"
+              "reset": "초기 배치로 리셋"
             },
             "board": {
-              "riverLabel": "추강 한 국경"
+              "riverLabel": "楚河　漢界"
             },
             "color": {
-              "red": "빨간색",
-              "black": "검은색",
-              "redPlayer": "빨간색(하단)",
-              "blackPlayer": "블랙(상의)"
+              "red": "홍",
+              "black": "흑",
+              "redPlayer": "홍 (아래)",
+              "blackPlayer": "흑 (위)"
             },
             "pieces": {
-              "general": "일반적인",
-              "advisor": "고문",
-              "elephant": "코끼리",
-              "horse": "말",
-              "chariot": "이륜 전차",
-              "cannon": "대포",
-              "soldier": "군인"
+              "general": "장군",
+              "advisor": "사",
+              "elephant": "상",
+              "horse": "마",
+              "chariot": "차",
+              "cannon": "포",
+              "soldier": "졸"
             },
-            "expLabel": "경험치",
+            "expLabel": "EXP",
             "piece": {
               "description": "{color} {piece}"
             },
             "status": {
-              "turnLine": "차례: {turn}",
+              "turnLine": "턴: {turn}",
               "turn": {
-                "red": "{color}의 움직임입니다.",
-                "black": "{color}의 움직임입니다."
+                "red": "{color} 차례입니다.",
+                "black": "{color} 차례입니다."
               },
-              "scoreLine": "총점: {score}",
-              "capture": "{actor} 캡처됨 {target} (+{exp}{expLabel})",
-              "move": "{piece} 이사했습니다.",
-              "win": "{loser}이(가) 체크메이트되었습니다. {winner} 승리!",
-              "stalemate": "교착상태(적법한 움직임 없음).",
-              "check": "{defender}이(가) 확인 중입니다(+{exp}{expLabel})."
+              "scoreLine": "총 점수: {score}",
+              "capture": "{actor}이(가) {target}을(를) 잡았습니다 (+{exp}{expLabel})",
+              "move": "{piece}이(가) 이동했습니다.",
+              "win": "{loser}이(가) 체크메이트당했습니다. {winner} 승리!",
+              "stalemate": "스테일메이트 (합법 수 없음).",
+              "check": "{defender}이(가) 장군을 당했습니다 (+{exp}{expLabel})"
+            }
+          },
+          "shogi": {
+            "name": "쇼기",
+            "description": "정통 쇼기. 손패와 승급을 활용해 체크메이트를 노리고, 착수·포획·장군으로 경험치를 얻으세요.",
+            "ui": {
+              "title": "쇼기",
+              "subtitle": "MiniExp 버전",
+              "legend": "수:+{moveExpFormatted} EXP / 손패 투입:+{dropExpFormatted} EXP / 포획 보너스 / 승급:+{promoteExpFormatted} EXP / 장군:+{checkExpFormatted} EXP / 승리 보너스",
+              "hands": {
+                "aiLabel": "선수 (CPU)",
+                "playerLabel": "후수 (당신)",
+                "empty": "없음",
+                "chip": "{piece}×{countFormatted}",
+                "total": "{countFormatted}개",
+                "totalNone": "없음"
+              },
+              "actions": {
+                "restart": "재시작"
+              },
+              "confirm": {
+                "promote": "승급하시겠습니까?"
+              }
+            },
+            "status": {
+              "playerTurn": "당신의 차례입니다. 기물 또는 손패를 선택하세요.",
+              "aiThinking": "CPU가 수를 계산 중…",
+              "playerInCheck": "장군을 당했습니다! 대응하세요.",
+              "aiInCheck": "장군! 마무리를 노려 보세요."
+            },
+            "result": {
+              "playerWin": "체크메이트! 당신의 승리",
+              "playerLose": "체크메이트 당했습니다… 패배",
+              "draw": "지장 / 천일수 무승부"
+            },
+            "pieces": {
+              "glyph": {
+                "pawn": "歩",
+                "lance": "香",
+                "knight": "桂",
+                "silver": "銀",
+                "gold": "金",
+                "bishop": "角",
+                "rook": "飛",
+                "king": "玉",
+                "promotedPawn": "と",
+                "promotedLance": "成香",
+                "promotedKnight": "成桂",
+                "promotedSilver": "成銀",
+                "promotedBishop": "馬",
+                "promotedRook": "龍"
+              },
+              "label": {
+                "pawn": "歩",
+                "lance": "香",
+                "knight": "桂",
+                "silver": "銀",
+                "gold": "金",
+                "bishop": "角",
+                "rook": "飛",
+                "king": "玉"
+              }
+            }
+          },
+          "go": {
+            "name": "바둑",
+            "description": "돌을 두면 +1 / 포획 보너스 / 승리 EXP",
+            "info": {
+              "intro": "바둑 9×9 — 당신이 선공 (흑)"
+            },
+            "hud": {
+              "turn": {
+                "player": "당신의 차례 (흑)",
+                "ai": "AI 차례 (백)"
+              },
+              "status": "{turn} ｜ 흑 포획:{blackCaptures} ｜ 백 포획:{whiteCaptures} (덤+{komi})",
+              "passNotice": "{actor}이(가) 패스했습니다 (연속 {count})",
+              "aiThinking": "AI가 수를 생각 중…"
+            },
+            "buttons": {
+              "pass": "패스",
+              "resign": "기권"
+            },
+            "messages": {
+              "koViolation": "그 수는 패 상황이라 둘 수 없습니다"
+            },
+            "actors": {
+              "player": "당신",
+              "ai": "AI"
+            },
+            "result": {
+              "win": "당신의 승리!",
+              "loss": "AI의 승리…",
+              "draw": "빅 (무승부)",
+              "summary": "{result} ｜ 흑 {blackScore} - 백 {whiteScore}"
             }
           },
           "mancala": {

--- a/js/i18n/locales/zh.json.js
+++ b/js/i18n/locales/zh.json.js
@@ -608,47 +608,144 @@
             }
           },
           "xiangqi": {
+            "name": "象棋",
+            "description": "中国象棋。通过吃子、将军和将死获取经验值。",
             "header": {
               "title": "象棋",
-              "subtitle": "{color}移动"
+              "subtitle": "{color}先手"
             },
             "controls": {
-              "reset": "重置位置"
+              "reset": "恢复初始布局"
             },
             "board": {
-              "riverLabel": "楚河汉疆"
+              "riverLabel": "楚河　汉界"
             },
             "color": {
-              "red": "红色",
-              "black": "黑色",
-              "redPlayer": "红色（下）",
-              "blackPlayer": "黑色(上)"
+              "red": "红方",
+              "black": "黑方",
+              "redPlayer": "红方（下）",
+              "blackPlayer": "黑方（上）"
             },
             "pieces": {
-              "general": "一般",
-              "advisor": "顾问",
-              "elephant": "大象",
+              "general": "帅",
+              "advisor": "仕",
+              "elephant": "相",
               "horse": "马",
-              "chariot": "战车",
-              "cannon": "大炮",
-              "soldier": "士兵"
+              "chariot": "车",
+              "cannon": "炮",
+              "soldier": "兵"
             },
             "expLabel": "EXP",
             "piece": {
-              "description": "{color} {piece}"
+              "description": "{color}{piece}"
             },
             "status": {
-              "turnLine": "转动：{turn}",
+              "turnLine": "回合：{turn}",
               "turn": {
-                "red": "这是{color}的动作。",
-                "black": "这是{color}的动作。"
+                "red": "{color}行动",
+                "black": "{color}行动"
               },
               "scoreLine": "总分：{score}",
-              "capture": "{actor}捕获{target} (+{exp}{expLabel})",
-              "move": "{piece}移动。",
-              "win": "{loser}被将死。 {winner}获胜！",
-              "stalemate": "僵局（无合法动作）。",
-              "check": "{defender}处于检查状态"
+              "capture": "{actor}吃掉了{target}(+{exp}{expLabel})",
+              "move": "{piece}移动了。",
+              "win": "{loser}被将死，{winner}获胜！",
+              "stalemate": "僵局（无合法着法）。",
+              "check": "{defender}被将军 (+{exp}{expLabel})"
+            }
+          },
+          "shogi": {
+            "name": "将棋",
+            "description": "正统将棋。善用持驹和升变，通过着手、吃子与将军获得经验值。",
+            "ui": {
+              "title": "将棋",
+              "subtitle": "MiniExp 版",
+              "legend": "着手:+{moveExpFormatted} EXP / 打入:+{dropExpFormatted} EXP / 吃子奖励 / 升变:+{promoteExpFormatted} EXP / 将军:+{checkExpFormatted} EXP / 胜利奖励",
+              "hands": {
+                "aiLabel": "先手 (CPU)",
+                "playerLabel": "后手 (你)",
+                "empty": "无",
+                "chip": "{piece}×{countFormatted}",
+                "total": "{countFormatted}枚",
+                "totalNone": "无"
+              },
+              "actions": {
+                "restart": "重新开始"
+              },
+              "confirm": {
+                "promote": "要升变吗？"
+              }
+            },
+            "status": {
+              "playerTurn": "轮到你。请选择棋子或手持棋。",
+              "aiThinking": "CPU正在思考…",
+              "playerInCheck": "你被将军了！请应对。",
+              "aiInCheck": "将军！寻找制胜一手。"
+            },
+            "result": {
+              "playerWin": "将死！你赢了",
+              "playerLose": "被将死…失败",
+              "draw": "持将棋 / 千日手，平局"
+            },
+            "pieces": {
+              "glyph": {
+                "pawn": "歩",
+                "lance": "香",
+                "knight": "桂",
+                "silver": "銀",
+                "gold": "金",
+                "bishop": "角",
+                "rook": "飛",
+                "king": "玉",
+                "promotedPawn": "と",
+                "promotedLance": "成香",
+                "promotedKnight": "成桂",
+                "promotedSilver": "成銀",
+                "promotedBishop": "馬",
+                "promotedRook": "龍"
+              },
+              "label": {
+                "pawn": "歩",
+                "lance": "香",
+                "knight": "桂",
+                "silver": "銀",
+                "gold": "金",
+                "bishop": "角",
+                "rook": "飛",
+                "king": "玉"
+              }
+            }
+          },
+          "go": {
+            "name": "围棋",
+            "description": "落子+1 / 吃子奖励 / 胜利经验值",
+            "info": {
+              "intro": "围棋 9×9 — 你执黑先行"
+            },
+            "hud": {
+              "turn": {
+                "player": "你的回合（黑）",
+                "ai": "AI 的回合（白）"
+              },
+              "status": "{turn} ｜ 黑 提子:{blackCaptures} ｜ 白 提子:{whiteCaptures} (贴目+{komi})",
+              "passNotice": "{actor}选择了停着（连续{count}次）",
+              "aiThinking": "AI 正在思考…"
+            },
+            "buttons": {
+              "pass": "停着",
+              "resign": "认输"
+            },
+            "messages": {
+              "koViolation": "该手因劫争禁止。"
+            },
+            "actors": {
+              "player": "你",
+              "ai": "AI"
+            },
+            "result": {
+              "win": "你赢了！",
+              "loss": "AI 获胜…",
+              "draw": "持棋（平局）",
+              "summary": "{result} ｜ 黑 {blackScore} - 白 {whiteScore}"
             }
           },
           "mancala": {


### PR DESCRIPTION
## Summary
- add full English localization entries for MiniExp Xiangqi, Shogi, and Go so they no longer fall back to Japanese
- provide Simplified Chinese translations for the same MiniExp board games, covering UI and status strings
- provide Korean translations for the Xiangqi, Shogi, and Go MiniExp entries to restore localized titles and descriptions

## Testing
- npm test -- --runTestsByPath tests/tosochu-localization.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ecbbe66174832bbd7798352295e2df