### PR TITLE
Fix localization for MiniExp mod metadata

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -710,6 +710,30 @@
               }
             }
           },
+          "riichi_mahjong": {
+            "name": "Riichi Mahjong Lite",
+            "description": "Play a streamlined single-hand riichi mahjong round against three AI opponents with riichi/tsumo/ron scoring."
+          },
+          "connect6": {
+            "name": "Connect Six",
+            "description": "Place two stones per turn to chase six-in-a-row. Gain +1 EXP per placement, +10 for threats, and big victory rewards."
+          },
+          "gomoku": {
+            "name": "Gomoku",
+            "description": "Earn +1 EXP per placement, +10 for threats, and bonus EXP for victories in five-in-a-row duels."
+          },
+          "renju": {
+            "name": "Renju",
+            "description": "Five-in-a-row with forbidden move rules. Gain +1 EXP per placement, +10 for threats, and victory bonuses."
+          },
+          "connect4": {
+            "name": "Connect Four",
+            "description": "Falling four-in-a-row battles. Earn +1 EXP per drop, +10 for threats, and difficulty-scaled victory EXP."
+          },
+          "tic_tac_toe": {
+            "name": "Tic-Tac-Toe",
+            "description": "Classic three-in-a-row. Gain +1 EXP per move, +10 for threats, and modest victory bonuses."
+          },
           "go": {
             "name": "Go",
             "description": "Place stones, capture groups, and claim victory EXP.",

--- a/js/i18n/locales/ko.json.js
+++ b/js/i18n/locales/ko.json.js
@@ -1450,6 +1450,30 @@
               }
             }
           },
+          "riichi_mahjong": {
+            "name": "리치 마작 라이트",
+            "description": "3명의 AI와 동풍 1국을 치르는 간단한 리치 마작. 리치/쯔모/론과 점봉 정산을 지원합니다."
+          },
+          "connect6": {
+            "name": "커넥트 식스",
+            "description": "차례마다 돌 두 개를 놓아 여섯 줄을 노리는 대결. 착수 +1EXP, 위협 +10EXP, 승리 시 높은 보상."
+          },
+          "gomoku": {
+            "name": "오목",
+            "description": "돌을 놓을 때마다 +1EXP, 위협을 만들면 +10EXP, 승리 보너스가 지급됩니다."
+          },
+          "renju": {
+            "name": "렌주",
+            "description": "금수 규칙이 적용된 오목. 착수 +1EXP, 위협 +10EXP, 승리 보너스."
+          },
+          "connect4": {
+            "name": "커넥트 포",
+            "description": "말이 떨어지는 사목 게임. 착수 +1EXP, 위협 +10EXP, 난이도에 따라 승리 EXP가 주어집니다."
+          },
+          "tic_tac_toe": {
+            "name": "틱택토",
+            "description": "고전 삼목 게임. 착수 +1EXP, 위협 +10EXP, 승리는 소폭 보너스입니다."
+          },
           "go": {
             "name": "바둑",
             "description": "돌을 두면 +1 / 포획 보너스 / 승리 EXP",

--- a/js/i18n/locales/zh.json.js
+++ b/js/i18n/locales/zh.json.js
@@ -715,6 +715,30 @@
               }
             }
           },
+          "riichi_mahjong": {
+            "name": "立直麻将精简版",
+            "description": "与3名AI进行一局东风战立直麻将，支持立直/自摸/荣和与点棒结算。"
+          },
+          "connect6": {
+            "name": "连六棋",
+            "description": "每回合落两子争夺六连。落子+1EXP、形成威胁+10EXP、胜利奖励丰厚。"
+          },
+          "gomoku": {
+            "name": "五子棋",
+            "description": "每次落子+1EXP、形成冲四等威胁+10EXP、胜利可获额外奖励。"
+          },
+          "renju": {
+            "name": "连珠",
+            "description": "带禁手规则的五子棋。落子+1EXP、形成威胁+10EXP、胜利奖励。"
+          },
+          "connect4": {
+            "name": "四子连线",
+            "description": "棋子会下落的四子连线。落子+1EXP、形成威胁+10EXP、胜利按难度提供EXP。"
+          },
+          "tic_tac_toe": {
+            "name": "井字棋",
+            "description": "经典三子棋。落子+1EXP、形成威胁+10EXP、胜利奖励较为克制。"
+          },
           "go": {
             "name": "围棋",
             "description": "落子+1 / 吃子奖励 / 胜利经验值",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "main.js",
   "scripts": {
-    "test": "node tests/bowling-localization.test.js && node tests/tosochu-localization.test.js"
+    "test": "node tests/bowling-localization.test.js && node tests/tosochu-localization.test.js && node tests/minigame-metadata-localization.test.js"
   },
   "keywords": [],
   "author": "",

--- a/tests/minigame-metadata-localization.test.js
+++ b/tests/minigame-metadata-localization.test.js
@@ -1,0 +1,41 @@
+const assert = require('node:assert/strict');
+
+require('../js/i18n/locales/ja.json.js');
+require('../js/i18n/locales/en.json.js');
+require('../js/i18n/locales/zh.json.js');
+require('../js/i18n/locales/ko.json.js');
+
+const store = globalThis.__i18nLocales || {};
+
+const TARGET_GAMES = [
+  'riichi_mahjong',
+  'connect6',
+  'gomoku',
+  'renju',
+  'connect4',
+  'tic_tac_toe'
+];
+
+const LOCALES = ['ja', 'en', 'zh', 'ko'];
+
+function getMetadata(locale) {
+  const localeData = store[locale] || {};
+  return (
+    localeData.selection &&
+    localeData.selection.miniexp &&
+    localeData.selection.miniexp.games
+  ) || {};
+}
+
+for (const locale of LOCALES) {
+  const games = getMetadata(locale);
+  assert.ok(Object.keys(games).length > 0, `Locale ${locale} should provide mini-game metadata.`);
+  for (const id of TARGET_GAMES) {
+    const entry = games[id];
+    assert.ok(entry, `Locale ${locale} should define metadata for ${id}.`);
+    assert.equal(typeof entry.name, 'string', `Locale ${locale} metadata for ${id} must include a name string.`);
+    assert.ok(entry.name.trim().length > 0, `Locale ${locale} metadata for ${id} should have a non-empty name.`);
+    assert.equal(typeof entry.description, 'string', `Locale ${locale} metadata for ${id} must include a description string.`);
+    assert.ok(entry.description.trim().length > 0, `Locale ${locale} metadata for ${id} should have a non-empty description.`);
+  }
+}


### PR DESCRIPTION
## Summary
- add localized names and descriptions for Riichi Mahjong Lite and stone board game mods across supported locales
- add a regression test to ensure required mini-game metadata translations exist and update the test script to run it

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ecd9d18a54832b9d1aa2e5bcc92d77