### PR TITLE
feat: allow multiple ToDo list reward entries

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -18615,7 +18615,7 @@
           "type": "Type",
           "typeSingle": "Single",
           "typeRepeatable": "Repeatable",
-          "xp": "EXP Reward",
+          "xp": "EXP Change (use minus to revoke)",
           "rewards": {
             "title": "Additional Rewards",
             "passiveOrb": {
@@ -18623,14 +18623,16 @@
               "placeholder": "e.g., attackBoost",
               "selectPlaceholder": "Select a passive orb",
               "customOption": "{value} (saved)",
-              "amount": "Quantity"
+              "amount": "Quantity (negative to remove)",
+              "addEntry": "Add"
             },
             "item": {
               "label": "Item",
               "placeholder": "e.g., potion30",
               "selectPlaceholder": "Select an item",
               "customOption": "{value} (saved)",
-              "amount": "Quantity",
+              "amount": "Quantity (negative to remove)",
+              "addEntry": "Add",
               "defaults": {
                 "potion30": "Potion (30%)",
                 "hpBoost": "HP Boost",
@@ -18644,7 +18646,7 @@
             },
             "sp": {
               "label": "SP",
-              "amount": "Amount"
+              "amount": "Change (negative to deduct)"
             }
           },
           "color": "Color",
@@ -18665,7 +18667,7 @@
           "rewards": {
             "passiveOrb": "Orb: {orb} ×{amount}",
             "item": "{item} ×{amount}",
-            "sp": "+{amount} SP"
+            "sp": "SP {amount}"
           },
           "memoEmpty": "No notes",
           "createdAt": "Created: {date}",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -17792,7 +17792,7 @@
           "type": "タイプ",
           "typeSingle": "単発",
           "typeRepeatable": "繰り返し",
-          "xp": "獲得EXP",
+          "xp": "EXP変化量（マイナスで没収）",
           "rewards": {
             "title": "追加報酬",
             "passiveOrb": {
@@ -17800,14 +17800,16 @@
               "placeholder": "例: attackBoost",
               "selectPlaceholder": "パッシブオーブを選択",
               "customOption": "{value} (保存済み)",
-              "amount": "個数"
+              "amount": "個数（マイナスで没収）",
+              "addEntry": "追加"
             },
             "item": {
               "label": "アイテム",
               "placeholder": "例: potion30",
               "selectPlaceholder": "アイテムを選択",
               "customOption": "{value} (保存済み)",
-              "amount": "個数",
+              "amount": "個数（マイナスで没収）",
+              "addEntry": "追加",
               "defaults": {
                 "potion30": "ポーション（30%）",
                 "hpBoost": "HPブースト",
@@ -17821,7 +17823,7 @@
             },
             "sp": {
               "label": "SP",
-              "amount": "回復量"
+              "amount": "変化量（マイナスで没収）"
             }
           },
           "color": "カラー",
@@ -17842,7 +17844,7 @@
           "rewards": {
             "passiveOrb": "オーブ: {orb} ×{amount}",
             "item": "{item} ×{amount}",
-            "sp": "SP +{amount}"
+            "sp": "SP {amount}"
           },
           "memoEmpty": "メモなし",
           "createdAt": "登録: {date}",

--- a/js/i18n/locales/zh.json.js
+++ b/js/i18n/locales/zh.json.js
@@ -8759,7 +8759,7 @@
           "type": "类型",
           "typeSingle": "单张",
           "typeRepeatable": "可重复",
-          "xp": "经验奖励",
+          "xp": "经验变化（负数为扣除）",
           "rewards": {
             "title": "额外奖励",
             "passiveOrb": {
@@ -8767,14 +8767,16 @@
               "placeholder": "例如，攻击Boost",
               "selectPlaceholder": "选择一个被动球体",
               "customOption": "{value}（已保存）",
-              "amount": "数量"
+              "amount": "数量（负数为扣除）",
+              "addEntry": "添加"
             },
             "item": {
               "label": "项目",
               "placeholder": "药水30",
               "selectPlaceholder": "选择项目",
               "customOption": "{value}（已保存）",
-              "amount": "数量",
+              "amount": "数量（负数为扣除）",
+              "addEntry": "添加",
               "defaults": {
                 "potion30": "药水(30%)",
                 "hpBoost": "生命值提升",
@@ -8788,7 +8790,7 @@
             },
             "sp": {
               "label": "SP",
-              "amount": "数量"
+              "amount": "变化量（负数为扣除）"
             }
           },
           "color": "颜色",
@@ -8809,7 +8811,7 @@
           "rewards": {
             "passiveOrb": "宝珠：{orb} ×{amount}",
             "item": "{item} ×{amount}",
-            "sp": "+{amount} SP"
+            "sp": "SP {amount}"
           },
           "memoEmpty": "无注释",
           "createdAt": "创建：{date}",

--- a/main.js
+++ b/main.js
@@ -6600,12 +6600,17 @@ function grantPassiveOrb(source = 'unknown') {
 function awardPassiveOrbFromMini(orbId, amount = 1, opts = {}) {
     if (!PASSIVE_ORB_DEFS[orbId]) return null;
     const numericAmount = Number(amount);
-    if (!Number.isFinite(numericAmount) || numericAmount <= 0) return null;
+    if (!Number.isFinite(numericAmount) || Math.abs(numericAmount) < 1e-6) return null;
     const delta = numericAmount > 0 ? Math.floor(numericAmount) : Math.ceil(numericAmount);
-    if (delta <= 0) return null;
+    if (delta === 0) return null;
     const nextCount = incrementPassiveOrb(orbId, delta);
     const options = opts && typeof opts === 'object' ? opts : {};
-    handlePassiveOrbAcquisition(orbId, nextCount, delta, options.source || 'mini', options);
+    if (delta > 0) {
+        handlePassiveOrbAcquisition(orbId, nextCount, delta, options.source || 'mini', options);
+    } else {
+        markUiDirty();
+        saveAll();
+    }
     return { orbId, count: nextCount, delta };
 }
 


### PR DESCRIPTION
## Summary
- allow configuring multiple passive orbs/items for ToDo list rewards and support negative SP/orb deductions
- update ToDo list localization strings for new reward controls and negative amounts
- enable the passive orb mini-game API to process negative deltas

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ef7bab4b9c832bb89fe203f61b4ebb