### PR TITLE
Fix Ex-Othello initial no-move handling

### DIFF
--- a/games/exothello.js
+++ b/games/exothello.js
@@ -697,6 +697,7 @@
       if (moves.length === 0){
         state.turn = BLACK;
         updateLegalMoves();
+        checkEnd();
         draw();
         checkEnd();
         return;
@@ -789,6 +790,7 @@
         state.legal = [];
         resizeCanvas();
         updateLegalMoves();
+        checkEnd();
         draw();
         resetButton.disabled = false;
         if (state.sandboxEditing){
@@ -833,6 +835,7 @@
       state.turn = BLACK;
       setStatus('miniexp.games.exothello.status.continue', 'Game in progress');
       updateLegalMoves();
+      checkEnd();
       draw();
     }
 


### PR DESCRIPTION
## Summary
- ensure newly started games and sandbox starts invoke end-of-turn checks after legal move calculation so automatic passes trigger immediately

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f49c30adec832bba422ef1e7c7a030