### PR TITLE
Update README manual links to GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Yuローグライク（dungeon-game-html）
 
-Yuローグライクは、ブラウザだけで遊べるダンジョン探索ゲームです。難易度や世界、ダンジョンを選んで冒険しつつ、豊富なミニゲームや開発者向けツールで遊び方を拡張できます。HTML/CSS/JavaScript のみで構築されているため、カスタマイズや教材利用にも最適です。詳細は同梱の [マニュアル](manual/index.html) を参照してください。
+Yuローグライクは、ブラウザだけで遊べるダンジョン探索ゲームです。難易度や世界、ダンジョンを選んで冒険しつつ、豊富なミニゲームや開発者向けツールで遊び方を拡張できます。HTML/CSS/JavaScript のみで構築されているため、カスタマイズや教材利用にも最適です。詳細は同梱の [マニュアル](https://yutokure.github.io/yu-roguelike/manual/index.html) を参照してください。
 
 ## 主な特徴
 - シンプルな構成でダンジョンやデータを自由に追加・編集可能。
@@ -10,14 +10,14 @@ Yuローグライクは、ブラウザだけで遊べるダンジョン探索ゲ
 - レベル100以降に解放される SP、推奨レベル300以上で有効になる満腹度システムなど、ハイレベル向けの仕掛けが多数。
 - サンドボックス用のインタラクティブパネルや創造神コンソールで検証・チートが可能。
 
-各機能の背景や詳細は「[ゲーム全体の概要](manual/overview.html)」「[画面と操作の解説](manual/ui.html)」「[このゲームの遊び方](manual/how-to-play.html)」を参照してください。
+各機能の背景や詳細は「[ゲーム全体の概要](https://yutokure.github.io/yu-roguelike/manual/overview.html)」「[画面と操作の解説](https://yutokure.github.io/yu-roguelike/manual/ui.html)」「[このゲームの遊び方](https://yutokure.github.io/yu-roguelike/manual/how-to-play.html)」を参照してください。
 
 ## 必要な環境
 - モダンブラウザ（Chrome / Edge / Firefox / Safari など）
 - テキストエディター（VS Code など）
 - プロジェクト一式（`git clone` または ZIP ダウンロード）
 
-推奨ツールやディレクトリ準備のポイントは「[必要な環境と準備](manual/environment.html)」にまとまっています。
+推奨ツールやディレクトリ準備のポイントは「[必要な環境と準備](https://yutokure.github.io/yu-roguelike/manual/environment.html)」にまとまっています。
 
 ## フォルダー構成
 | 主要パス | 役割 |
@@ -31,17 +31,17 @@ Yuローグライクは、ブラウザだけで遊べるダンジョン探索ゲ
 | `tools/` | 制作者向けツールとテンプレート |
 | `blockdata.js` / `blockdata.json` | ブロック次元モード向けのデータ |
 
-より詳細な整理方法や命名規則は「[フォルダーとファイル構成](manual/structure.html)」で確認できます。
+より詳細な整理方法や命名規則は「[フォルダーとファイル構成](https://yutokure.github.io/yu-roguelike/manual/structure.html)」で確認できます。
 
 ## はじめての起動
 1. プロジェクトをダウンロードまたはクローンします。
 2. `index.html` をブラウザで開きます。
 3. タイトル画面が表示されたら準備完了です。
 
-VS Code の Live Server 拡張を使うと、保存と同時にブラウザへ反映できます。手順やトラブルシューティングは「[はじめての起動](manual/start.html)」を参照してください。
+VS Code の Live Server 拡張を使うと、保存と同時にブラウザへ反映できます。手順やトラブルシューティングは「[はじめての起動](https://yutokure.github.io/yu-roguelike/manual/start.html)」を参照してください。
 
 ## 開発・テスト
-- JavaScript の構成や主要関数は「[JavaScript の仕組み](manual/development.html)」にまとめています。
+- JavaScript の構成や主要関数は「[JavaScript の仕組み](https://yutokure.github.io/yu-roguelike/manual/development.html)」にまとめています。
 - 単体テストは Node.js で実行できます。
 
 ```bash
@@ -54,18 +54,18 @@ npm test
 - 難易度調整：各ダンジョンデータのダメージ倍率や敵設定を編集。
 - 見た目変更：`style.css` を中心に背景・配色・ボタンスタイルを編集。
 
-具体的な手順やヒントは「[コンテンツの追加・変更](manual/customize.html)」を参照してください。
+具体的な手順やヒントは「[コンテンツの追加・変更](https://yutokure.github.io/yu-roguelike/manual/customize.html)」を参照してください。
 
 ## プレイチップス
 - 選択画面のタブから通常探索・ブロック次元・ミニゲー経験・実績/統計・ツールズへ移動できます。
 - 推奨レベル300以上のダンジョンでは満腹度管理が重要。推奨レベルとの差で床ギミックや宝箱イベントの挙動が変化します。
 - サンドボックスモードやアノス級解放後はインタラクティブ/創造神コンソールでゴッドモードやスクリプト操作が可能です。
 
-探索の流れや操作一覧、リザルト画面の見方などは「[このゲームの遊び方](manual/how-to-play.html)」「[画面と操作の解説](manual/ui.html)」に詳細があります。
+探索の流れや操作一覧、リザルト画面の見方などは「[このゲームの遊び方](https://yutokure.github.io/yu-roguelike/manual/how-to-play.html)」「[画面と操作の解説](https://yutokure.github.io/yu-roguelike/manual/ui.html)」に詳細があります。
 
 ## 追加ドキュメント
-- 日本語マニュアル: [`manual/`](manual/index.html)
-- 英語マニュアル: [`manual/en/`](manual/en/index.html)
+- 日本語マニュアル: [`manual/`](https://yutokure.github.io/yu-roguelike/manual/index.html)
+- 英語マニュアル: [`manual/en/`](https://yutokure.github.io/yu-roguelike/manual/en/index.html)
 - 仕様・設計資料: リポジトリ直下の各種 `.md` / `.txt` ドキュメント
 
 不明点があればマニュアルの FAQ やリファレンス章を参照し、必要に応じて Issue や PR で報告してください。
@@ -74,7 +74,7 @@ npm test
 
 # Yu Roguelike (dungeon-game-html)
 
-Yu Roguelike is a dungeon crawler that runs entirely in the browser. Pick a world, dungeon, and difficulty, then expand your adventure with optional mini-games and creator tools. Because it is built only with HTML, CSS, and JavaScript, it is easy to customize or repurpose for learning. See the bundled [manual](manual/en/index.html) for complete documentation.
+Yu Roguelike is a dungeon crawler that runs entirely in the browser. Pick a world, dungeon, and difficulty, then expand your adventure with optional mini-games and creator tools. Because it is built only with HTML, CSS, and JavaScript, it is easy to customize or repurpose for learning. See the bundled [manual](https://yutokure.github.io/yu-roguelike/manual/en/index.html) for complete documentation.
 
 ## Highlights
 - Simple project structure that makes it easy to add or edit dungeons and data.
@@ -84,14 +84,14 @@ Yu Roguelike is a dungeon crawler that runs entirely in the browser. Pick a worl
 - Late-game mechanics such as SP (unlocked after level 100) and the fullness system (recommended level 300+) keep high-level play engaging.
 - Interactive Sandbox panel and Creator God console for debugging, experiments, or cheats.
 
-Background and feature explanations live in "[Game Overview](manual/en/overview.html)", "[Screens & Controls](manual/en/ui.html)", and "[How to Play](manual/en/how-to-play.html)".
+Background and feature explanations live in "[Game Overview](https://yutokure.github.io/yu-roguelike/manual/en/overview.html)", "[Screens & Controls](https://yutokure.github.io/yu-roguelike/manual/en/ui.html)", and "[How to Play](https://yutokure.github.io/yu-roguelike/manual/en/how-to-play.html)".
 
 ## Requirements
 - Modern browser (Chrome / Edge / Firefox / Safari, etc.)
 - Text editor (VS Code, etc.)
 - Project files (`git clone` or ZIP download)
 
-Recommended tooling tips and workspace setup are covered in "[Environment & Preparation](manual/en/environment.html)".
+Recommended tooling tips and workspace setup are covered in "[Environment & Preparation](https://yutokure.github.io/yu-roguelike/manual/en/environment.html)".
 
 ## Folder Structure
 | Path | Description |
@@ -105,17 +105,17 @@ Recommended tooling tips and workspace setup are covered in "[Environment & Prep
 | `tools/` | Creator tools and templates |
 | `blockdata.js` / `blockdata.json` | Assets used by the Block Dimension mode |
 
-Additional naming conventions and organization tips are in "[Folders & Files](manual/en/structure.html)".
+Additional naming conventions and organization tips are in "[Folders & Files](https://yutokure.github.io/yu-roguelike/manual/en/structure.html)".
 
 ## Getting Started
 1. Download or clone the repository.
 2. Open `index.html` in your browser.
 3. Once the title screen appears, you are ready to play.
 
-Using VS Code with Live Server lets you reload the browser automatically when saving. Refer to "[First Launch](manual/en/start.html)" for troubleshooting steps.
+Using VS Code with Live Server lets you reload the browser automatically when saving. Refer to "[First Launch](https://yutokure.github.io/yu-roguelike/manual/en/start.html)" for troubleshooting steps.
 
 ## Development & Testing
-- Core JavaScript architecture is summarized in "[JavaScript Internals](manual/en/development.html)".
+- Core JavaScript architecture is summarized in "[JavaScript Internals](https://yutokure.github.io/yu-roguelike/manual/en/development.html)".
 - Unit tests can be executed with Node.js.
 
 ```bash
@@ -128,18 +128,18 @@ npm test
 - Adjust difficulty: tweak damage multipliers and enemy configurations in each dungeon file.
 - Change visuals: update backgrounds, colors, and button styles primarily in `style.css`.
 
-Detailed walkthroughs and tips are available in "[Add & Modify Content](manual/en/customize.html)".
+Detailed walkthroughs and tips are available in "[Add & Modify Content](https://yutokure.github.io/yu-roguelike/manual/en/customize.html)".
 
 ## Gameplay Tips
 - Use the tabbed menu to switch between the main exploration, Block Dimension, mini-game experience, achievements/statistics, and tools.
 - Manage fullness carefully in dungeons recommended for level 300 or higher—the gap between your level and the recommendation influences traps and treasure behavior.
 - After unlocking Sandbox mode or the Anos tier, use the interactive console or Creator God console for god-mode controls and scripting.
 
-Gameplay flow, controls, and result screen explanations are documented in "[How to Play](manual/en/how-to-play.html)" and "[Screens & Controls](manual/en/ui.html)".
+Gameplay flow, controls, and result screen explanations are documented in "[How to Play](https://yutokure.github.io/yu-roguelike/manual/en/how-to-play.html)" and "[Screens & Controls](https://yutokure.github.io/yu-roguelike/manual/en/ui.html)".
 
 ## Additional Documentation
-- Japanese manual: [`manual/`](manual/index.html)
-- English manual: [`manual/en/`](manual/en/index.html)
+- Japanese manual: [`manual/`](https://yutokure.github.io/yu-roguelike/manual/index.html)
+- English manual: [`manual/en/`](https://yutokure.github.io/yu-roguelike/manual/en/index.html)
 - Specs and design docs: Assorted `.md` / `.txt` files at the repository root
 
 Check the manual's FAQ and reference chapters, and report open questions via Issues or PRs when necessary.


### PR DESCRIPTION
## Summary
- update README manual links to point to the GitHub Pages site

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f49f92c440832b948592ca1c667bc7