### PR TITLE
Fix Ex-Othello registration with registerMiniGame object signature

### DIFF
--- a/games/exothello.js
+++ b/games/exothello.js
@@ -891,11 +891,16 @@
   }
 
   if (typeof window !== 'undefined' && typeof window.registerMiniGame === 'function'){
-    window.registerMiniGame('exothello', create, {
-      category: 'board',
+    window.registerMiniGame({
+      id: 'exothello',
       name: 'Ex-Othello',
+      nameKey: 'selection.miniexp.games.exothello.name',
+      description: '可変サイズ・壁・特殊勝利条件を選べる拡張オセロ',
+      descriptionKey: 'selection.miniexp.games.exothello.description',
+      categoryIds: ['board'],
       author: 'AI Generated',
-      icon: '🀄'
+      icon: '🀄',
+      create
     });
   }
 


### PR DESCRIPTION
## Summary
- register the Ex-Othello mini-game with the object-based `registerMiniGame` signature so it is discoverable
- include localization metadata and board category information in the registration payload

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f4a1ecfb40832b92ac18fa4bb179a4