### PR TITLE
Adjust random text XP gain

### DIFF
--- a/games/random_tool.js
+++ b/games/random_tool.js
@@ -1103,7 +1103,7 @@
       }
       const value = characters.join('');
       updateResult('text', value);
-      const xpGain = Math.max(1, pool.length * length);
+      const xpGain = Math.max(1, Math.floor((pool.length * length) / 7));
       awardXp(xpGain);
     }
 


### PR DESCRIPTION
## Summary
- reduce the random text generator's experience formula by dividing the existing calculation by seven to better balance rewards

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f4cbd12124832b927828e000f1e96e