### PR TITLE
Fix ToDo result overlay dismissal and random drop handling

### DIFF
--- a/tests/todo-list-rewards.test.js
+++ b/tests/todo-list-rewards.test.js
@@ -79,7 +79,10 @@ function setupEnvironment(){
     }
   };
 
-  const runtime = create(root, awardXp, { player: playerApi });
+  const runtime = create(root, awardXp, {
+    player: playerApi,
+    random: () => Math.random()
+  });
 
   const cleanup = () => {
     try {


### PR DESCRIPTION
## Summary
- keep the ToDo result dialog visible until an explicit OK button is pressed and ensure it stays centered while scrolling
- route reward and loot calculations through a crypto-backed random helper with an injectable override so drop chances behave correctly
- update the ToDo rewards test harness to provide the new random hook

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f4ca07e43c832ba04994b55f285672