### PR TITLE
Fix Ex-Othello Japanese localization fallback

### DIFF
--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -14572,18 +14572,41 @@
         }
       },
       "exothello": {
+        "title": "拡張オセロ",
+        "subtitle": "好みのルールを組み合わせて戦略的なオセロ勝負に挑戦しよう。",
         "controls": {
+          "sectionTitle": "対局設定",
+          "sectionDescription": "モードと盤面、勝利条件を整えてから開始してください。",
           "mode": "モード",
           "size": "盤面サイズ",
           "victoryLabel": "勝利条件",
           "victoryMost": "石が多い方が勝ち",
           "victoryLeast": "石が少ない方が勝ち",
+          "playerColor": "手番",
+          "playerBlack": "先手 (黒) を担当",
+          "playerWhite": "後手 (白) を担当",
           "difficultyLabel": "難易度",
           "difficultyEasy": "かんたん",
           "difficultyNormal": "ふつう",
           "difficultyHard": "むずかしい",
           "start": "ゲーム開始",
           "reset": "リセット"
+        },
+        "sandbox": {
+          "modeLabel": "サンドボックスモード",
+          "edit": "盤面を編集",
+          "play": "テスト対局",
+          "paletteLabel": "ペイントツール",
+          "tool": {
+            "empty": "消しゴム",
+            "black": "黒石",
+            "white": "白石",
+            "wall": "壁"
+          }
+        },
+        "color": {
+          "black": "黒",
+          "white": "白"
         },
         "modes": {
           "normal": "壁なしの基本オセロ。盤面サイズを自由に設定できます。",
@@ -14613,6 +14636,7 @@
         "turn": {
           "player": "あなたの番",
           "ai": "AI思考中",
+          "waiting": "待機中",
           "ended": "対局終了"
         },
         "victoryCondition": {
@@ -14622,6 +14646,11 @@
         "counts": {
           "black": "黒: ${0}",
           "white": "白: ${0}"
+        },
+        "info": {
+          "player": "あなた (${color}): ${count}",
+          "ai": "AI (${color}): ${count}",
+          "totals": "合計 — 黒: ${black}、白: ${white}"
         },
         "result": {
           "win": "勝利！",
@@ -18886,6 +18915,17 @@
   locale.mathLab = mathLabLocale;
   if (locale.games) {
     locale.games.mathLab = mathLabLocale;
+  }
+  if (locale.minigame && locale.minigame.exothello) {
+    if (!locale.miniexp) {
+      locale.miniexp = {};
+    }
+    if (!locale.miniexp.games) {
+      locale.miniexp.games = {};
+    }
+    if (!locale.miniexp.games.exothello) {
+      locale.miniexp.games.exothello = locale.minigame.exothello;
+    }
   }
   store['ja'] = locale;
   if (!store['ja']) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "main.js",
   "scripts": {
-    "test": "node tests/bowling-localization.test.js && node tests/tosochu-localization.test.js && node tests/minigame-metadata-localization.test.js && node tests/todo-list-rewards.test.js"
+    "test": "node tests/bowling-localization.test.js && node tests/tosochu-localization.test.js && node tests/minigame-metadata-localization.test.js && node tests/exothello-localization.test.js && node tests/todo-list-rewards.test.js"
   },
   "keywords": [],
   "author": "",

--- a/tests/exothello-localization.test.js
+++ b/tests/exothello-localization.test.js
@@ -1,0 +1,23 @@
+const assert = require('node:assert/strict');
+
+require('../js/i18n/locales/ja.json.js');
+
+const locales = global.__i18nLocales || {};
+const ja = locales.ja || {};
+
+assert.ok(ja, 'Japanese locale should load');
+assert.ok(ja.selection?.miniexp?.games?.exothello, 'Selection metadata for Ex-Othello should exist');
+assert.ok(ja.minigame?.exothello, 'Minigame translations for Ex-Othello should exist');
+assert.ok(ja.miniexp?.games?.exothello, 'MiniExp translations for Ex-Othello should exist');
+
+const exothello = ja.miniexp.games.exothello;
+
+assert.equal(exothello.title, '拡張オセロ');
+assert.equal(exothello.controls.start, 'ゲーム開始');
+assert.equal(exothello.status.preparing, '盤面を準備中...');
+assert.equal(exothello.result.win, '勝利！');
+assert.equal(exothello.color.black, '黒');
+assert.equal(exothello.turn.player, 'あなたの番');
+assert.equal(exothello.sandbox.tool.wall, '壁');
+
+console.log('Ex-Othello Japanese localization is configured for MiniExp.');


### PR DESCRIPTION
## Summary
- map the Ex-Othello Japanese strings into the MiniExp namespace so they resolve without English fallbacks
- add a regression test that asserts the Ex-Othello Japanese locale entries exist for selection, minigame, and MiniExp consumers
- wire the new localization check into the default npm test script

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f4cfde02e4832b8f6dc52efc9e2f20