### PR TITLE
Fix least-disc victories and enhance Ex-Othello AI

### DIFF
--- a/games/exothello.js
+++ b/games/exothello.js
@@ -778,15 +778,14 @@
     const next = cloneBoard(board);
     applyMove(next, move, color);
     const ruleSign = victoryCondition === 'least' ? -1 : 1;
-    const orientation = color === WHITE ? 1 : -1;
     const cellWeight = weights?.[move.y]?.[move.x] ?? 0;
     const flips = move.flips.length;
     const wallInfluence = countWallNeighbors(board, move.x, move.y);
     const mobilityAfter = legalMoves(next, color).length - legalMoves(next, -color).length;
-    const positionalScore = cellWeight * ruleSign * orientation;
-    const flipWeight = (victoryCondition === 'least' ? -4 : 4) * orientation;
+    const positionalScore = cellWeight * ruleSign;
+    const flipWeight = victoryCondition === 'least' ? -4 : 4;
     const mobilityScore = mobilityAfter * 2;
-    const wallScore = wallInfluence * orientation;
+    const wallScore = wallInfluence;
     return positionalScore + flips * flipWeight + mobilityScore + wallScore;
   }
 


### PR DESCRIPTION
## Summary
- correct the least-disc victory check so results align with the selected rule and XP awards
- enrich board evaluation with wall-aware weights, stability, and mobility heuristics and reuse them in the AI
- adjust AI move selection by difficulty using the new heuristics and ensure sandbox setups rebuild weights

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f4d33e7eec832bb60553a6b99d6fdd