### PR TITLE
Add Ex-Othello mode description fallbacks

### DIFF
--- a/games/exothello.js
+++ b/games/exothello.js
@@ -382,6 +382,7 @@
       defaultSize: { width: 8, height: 8 },
       allowSizeChange: true,
       descriptionKey: 'miniexp.games.exothello.modes.normal',
+      descriptionDefault: 'Classic Othello rules on a flexible board size.',
       labelKey: 'miniexp.games.exothello.modes.normal.short',
       setup(state) {
         const width = clampSize(state.settings.width, 4, 32);
@@ -396,6 +397,7 @@
       defaultSize: { width: 8, height: 8 },
       allowSizeChange: true,
       descriptionKey: 'miniexp.games.exothello.modes.cornerWalls',
+      descriptionDefault: 'Corner squares are locked as walls, reshaping opening play.',
       labelKey: 'miniexp.games.exothello.modes.cornerWalls.short',
       setup(state) {
         const width = clampSize(state.settings.width, 6, 32);
@@ -414,6 +416,7 @@
       defaultSize: { width: 8, height: 8 },
       allowSizeChange: true,
       descriptionKey: 'miniexp.games.exothello.modes.least',
+      descriptionDefault: 'Aim for the fewest discs to win instead of the most.',
       labelKey: 'miniexp.games.exothello.modes.least.short',
       setup(state) {
         const width = clampSize(state.settings.width, 6, 32);
@@ -428,6 +431,7 @@
       defaultSize: { width: 64, height: 32 },
       allowSizeChange: false,
       descriptionKey: 'miniexp.games.exothello.modes.river',
+      descriptionDefault: 'Fight along a 64×32 river channel carved through solid walls.',
       labelKey: 'miniexp.games.exothello.modes.river.short',
       setup(){
         const width = 64;
@@ -449,6 +453,7 @@
       defaultSize: { width: 8, height: 8 },
       allowSizeChange: true,
       descriptionKey: 'miniexp.games.exothello.modes.sandbox',
+      descriptionDefault: 'Free-build board editor for crafting and testing layouts.',
       labelKey: 'miniexp.games.exothello.modes.sandbox.short',
       setup(state){
         const width = clampSize(state.settings.width, 4, 32);
@@ -462,6 +467,7 @@
       defaultSize: { width: 16, height: 16 },
       allowSizeChange: true,
       descriptionKey: 'miniexp.games.exothello.modes.dungeon',
+      descriptionDefault: 'Battle through a procedurally carved dungeon of rooms and corridors.',
       labelKey: 'miniexp.games.exothello.modes.dungeon.short',
       async setup(state){
         const dungeonApi = state.opts?.dungeon;
@@ -1260,7 +1266,7 @@
       if (mode.id === 'sandbox'){
         statusBox.textContent = text('miniexp.games.exothello.status.sandboxHint', 'Sandbox: paint walls and stones in Edit mode, then switch to Play to test.');
       } else {
-        statusBox.textContent = text(mode.descriptionKey, '');
+        statusBox.textContent = text(mode.descriptionKey, mode.descriptionDefault);
       }
     }
 
@@ -1580,7 +1586,7 @@
           draw();
         } else {
           state.running = true;
-          setStatus(mode.descriptionKey, '');
+          setStatus(mode.descriptionKey, mode.descriptionDefault);
           updateSandboxControls();
           updateLegalMoves();
           checkEnd();

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "main.js",
   "scripts": {
-    "test": "node tests/bowling-localization.test.js && node tests/tosochu-localization.test.js && node tests/minigame-metadata-localization.test.js && node tests/exothello-localization.test.js && node tests/todo-list-rewards.test.js"
+    "test": "node tests/bowling-localization.test.js && node tests/tosochu-localization.test.js && node tests/minigame-metadata-localization.test.js && node tests/exothello-localization.test.js && node tests/exothello-status-fallback.test.js && node tests/todo-list-rewards.test.js"
   },
   "keywords": [],
   "author": "",

--- a/tests/exothello-status-fallback.test.js
+++ b/tests/exothello-status-fallback.test.js
@@ -1,0 +1,63 @@
+const assert = require('node:assert/strict');
+const { JSDOM } = require('jsdom');
+
+const { create } = require('../games/exothello.js');
+
+const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', {
+  url: 'http://localhost/',
+  pretendToBeVisual: true
+});
+
+global.window = dom.window;
+global.document = dom.window.document;
+global.navigator = dom.window.navigator;
+global.Option = dom.window.Option;
+const originalGetContext = dom.window.HTMLCanvasElement.prototype.getContext;
+dom.window.HTMLCanvasElement.prototype.getContext = () => ({
+  clearRect() {},
+  fillRect() {},
+  beginPath() {},
+  moveTo() {},
+  lineTo() {},
+  stroke() {},
+  arc() {},
+  fill() {},
+  save() {},
+  restore() {}
+});
+
+try {
+  const root = document.getElementById('root');
+  const instance = create(root, () => {}, { localization: null });
+  const statusBox = root.querySelector('.exothello-status');
+  const selects = Array.from(root.querySelectorAll('select.exothello-input'));
+  const modeSelect = selects[0];
+
+  const expectStatus = (modeId, expected) => {
+    modeSelect.value = modeId;
+    modeSelect.dispatchEvent(new window.Event('change', { bubbles: true }));
+    assert.equal(statusBox.textContent, expected, `Status text should describe ${modeId}`);
+  };
+
+  expectStatus('normal', 'Classic Othello rules on a flexible board size.');
+  expectStatus('corner_walls', 'Corner squares are locked as walls, reshaping opening play.');
+  expectStatus('least', 'Aim for the fewest discs to win instead of the most.');
+  expectStatus('river64', 'Fight along a 64×32 river channel carved through solid walls.');
+  expectStatus('dungeon', 'Battle through a procedurally carved dungeon of rooms and corridors.');
+
+  if (instance && typeof instance.destroy === 'function'){
+    instance.destroy();
+  }
+} finally {
+  delete global.window;
+  delete global.document;
+  delete global.navigator;
+  delete global.Option;
+  if (originalGetContext){
+    dom.window.HTMLCanvasElement.prototype.getContext = originalGetContext;
+  } else {
+    delete dom.window.HTMLCanvasElement.prototype.getContext;
+  }
+}
+
+console.log('Ex-Othello status fallback text is displayed without localization.');


### PR DESCRIPTION
## Summary
- add default description text to each Ex-Othello mode configuration
- use the new fallbacks when updating the status line without localization
- cover the status fallback behavior with a jsdom-based regression test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f4dbfdf414832b90a413a2808701c1