### PR TITLE
Fix Ex-Othello MiniExp localization mapping for English

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -18914,6 +18914,17 @@
   if (locale.games) {
     locale.games.mathLab = mathLabLocale;
   }
+  if (locale.minigame && locale.minigame.exothello) {
+    if (!locale.miniexp) {
+      locale.miniexp = {};
+    }
+    if (!locale.miniexp.games) {
+      locale.miniexp.games = {};
+    }
+    if (!locale.miniexp.games.exothello) {
+      locale.miniexp.games.exothello = locale.minigame.exothello;
+    }
+  }
   store['en'] = locale;
   if (!store['en']) {
     store['en'] = {};

--- a/tests/exothello-localization.test.js
+++ b/tests/exothello-localization.test.js
@@ -1,16 +1,23 @@
 const assert = require('node:assert/strict');
 
 require('../js/i18n/locales/ja.json.js');
+require('../js/i18n/locales/en.json.js');
 
 const locales = global.__i18nLocales || {};
 const ja = locales.ja || {};
+const en = locales.en || {};
 
 assert.ok(ja, 'Japanese locale should load');
 assert.ok(ja.selection?.miniexp?.games?.exothello, 'Selection metadata for Ex-Othello should exist');
 assert.ok(ja.minigame?.exothello, 'Minigame translations for Ex-Othello should exist');
 assert.ok(ja.miniexp?.games?.exothello, 'MiniExp translations for Ex-Othello should exist');
 
+assert.ok(en, 'English locale should load');
+assert.ok(en.minigame?.exothello, 'English minigame translations for Ex-Othello should exist');
+assert.ok(en.miniexp?.games?.exothello, 'English MiniExp translations for Ex-Othello should be linked');
+
 const exothello = ja.miniexp.games.exothello;
+const exothelloEn = en.miniexp.games.exothello;
 
 assert.equal(exothello.title, '拡張オセロ');
 assert.equal(exothello.controls.start, 'ゲーム開始');
@@ -20,4 +27,10 @@ assert.equal(exothello.color.black, '黒');
 assert.equal(exothello.turn.player, 'あなたの番');
 assert.equal(exothello.sandbox.tool.wall, '壁');
 
+assert.equal(exothelloEn.controls.start, 'Start Game');
+assert.equal(exothelloEn.status.preparing, 'Preparing board...');
+assert.equal(exothelloEn.result.win, 'You win!');
+assert.equal(exothelloEn.turn.player, 'Your turn');
+
 console.log('Ex-Othello Japanese localization is configured for MiniExp.');
+console.log('Ex-Othello English localization is linked to MiniExp.');


### PR DESCRIPTION
## Summary
- ensure the English locale exposes the Ex-Othello translations under the MiniExp namespace so the UI no longer falls back to Japanese
- extend the localization test to cover the English MiniExp mapping for Ex-Othello

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f4def2f6fc832b8af5456bce58d1af