### PR TITLE
Fix exothello localization text formatting

### DIFF
--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -14572,6 +14572,8 @@
         }
       },
       "exothello": {
+        "name": "拡張オセロ",
+        "description": "盤面サイズや壁、勝利条件を自由に切り替えられる拡張オセロ",
         "title": "拡張オセロ",
         "subtitle": "好みのルールを組み合わせて戦略的なオセロ勝負に挑戦しよう。",
         "controls": {
@@ -14643,14 +14645,10 @@
           "most": "石が多い方が勝ち",
           "least": "石が少ない方が勝ち"
         },
-        "counts": {
-          "black": "黒: ${0}",
-          "white": "白: ${0}"
-        },
         "info": {
-          "player": "あなた (${color}): ${count}",
-          "ai": "AI (${color}): ${count}",
-          "totals": "合計 — 黒: ${black}、白: ${white}"
+          "player": "あなた ({color}): {count}",
+          "ai": "AI ({color}): {count}",
+          "totals": "合計 — 黒: {black}、白: {white}"
         },
         "result": {
           "win": "勝利！",


### PR DESCRIPTION
## Summary
- align the Ex-Othello text helper with the shared localization system so placeholders render correctly
- update fallback strings and Japanese translations to use the {key} placeholder style and cover missing keys

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f60df17d2c832b8e69a8cc22113aa8