### PR TITLE
Implement draggable jigsaw puzzle pieces

### DIFF
--- a/games/jigsaw_puzzle.js
+++ b/games/jigsaw_puzzle.js
@@ -1,8 +1,5 @@
 (function(){
-  /** MiniExp MOD: Jigsaw Puzzle
-   *  - Load any image from file or URL and choose arbitrary rows/columns.
-   *  - Swap tiles to reconstruct the original picture.
-   */
+  /** MiniExp MOD: True Jigsaw Puzzle with draggable pieces */
   function create(root, awardXp, opts){
     const shortcuts = opts?.shortcuts;
     const localization = opts?.localization || (typeof window !== 'undefined' && typeof window.createMiniGameLocalization === 'function'
@@ -45,18 +42,18 @@
 
     const wrapper = document.createElement('div');
     wrapper.style.width = '100%';
-    wrapper.style.maxWidth = '520px';
+    wrapper.style.maxWidth = '620px';
     wrapper.style.margin = '0 auto';
-    wrapper.style.padding = '14px 14px 22px';
+    wrapper.style.padding = '16px 18px 26px';
     wrapper.style.boxSizing = 'border-box';
     wrapper.style.fontFamily = "'Segoe UI', system-ui, sans-serif";
     wrapper.style.color = '#e2e8f0';
     wrapper.style.background = '#020617';
     wrapper.style.borderRadius = '18px';
-    wrapper.style.boxShadow = '0 14px 32px rgba(15,23,42,0.65)';
+    wrapper.style.boxShadow = '0 16px 38px rgba(15,23,42,0.65)';
 
     const title = document.createElement('div');
-    title.style.fontSize = '21px';
+    title.style.fontSize = '22px';
     title.style.fontWeight = '600';
     title.style.marginBottom = '6px';
 
@@ -92,7 +89,7 @@
       input.min = '2';
       input.max = '12';
       input.value = initial;
-      input.style.width = '70px';
+      input.style.width = '72px';
       input.style.padding = '4px 6px';
       input.style.borderRadius = '6px';
       input.style.border = '1px solid rgba(148,163,184,0.4)';
@@ -106,7 +103,6 @@
 
     const rowsControl = createNumberInput(text('.controls.rowsLabel', '行数'), 3);
     const colsControl = createNumberInput(text('.controls.colsLabel', '列数'), 4);
-
     sizeRow.appendChild(rowsControl.container);
     sizeRow.appendChild(colsControl.container);
 
@@ -135,12 +131,13 @@
     fileLabel.style.alignItems = 'center';
     fileLabel.style.gap = '8px';
     fileLabel.style.padding = '6px 12px';
-    fileLabel.style.background = 'rgba(99,102,241,0.1)';
+    fileLabel.style.background = 'rgba(99,102,241,0.12)';
     fileLabel.style.border = '1px solid rgba(99,102,241,0.45)';
     fileLabel.style.borderRadius = '8px';
     fileLabel.style.cursor = 'pointer';
     fileLabel.style.fontSize = '13px';
     fileLabel.style.color = '#c7d2fe';
+
     const fileLabelText = document.createElement('span');
     fileLabelText.textContent = text('.controls.chooseFile', '画像を選択…');
 
@@ -177,7 +174,6 @@
 
     fileRow.appendChild(urlInput);
     fileRow.appendChild(loadUrlBtn);
-
     controls.appendChild(fileRow);
 
     const shuffleBtn = document.createElement('button');
@@ -218,7 +214,7 @@
 
     const movesInfo = createInfo('.info.moves', '手数');
     const timeInfo = createInfo('.info.time', 'タイム');
-    const correctInfo = createInfo('.info.correct', '正解ピース');
+    const correctInfo = createInfo('.info.correct', '正しい位置');
     const solveInfo = createInfo('.info.clears', 'クリア数');
 
     timeInfo.value.textContent = '0:00.0';
@@ -235,16 +231,27 @@
     boardFrame.style.width = '100%';
     boardFrame.style.background = '#020617';
     boardFrame.style.borderRadius = '16px';
-    boardFrame.style.boxShadow = '0 0 0 1px rgba(148,163,184,0.35) inset, 0 18px 40px rgba(15,23,42,0.45) inset';
-    boardFrame.style.overflow = 'hidden';
-    boardFrame.style.margin = '0 auto';
+    boardFrame.style.boxShadow = '0 0 0 1px rgba(148,163,184,0.28) inset, 0 18px 42px rgba(15,23,42,0.45) inset';
+    boardFrame.style.padding = '18px';
+    boardFrame.style.boxSizing = 'border-box';
+    boardFrame.style.overflow = 'visible';
 
-    const canvas = document.createElement('canvas');
-    canvas.style.display = 'block';
-    canvas.style.width = '100%';
-    canvas.style.height = '100%';
+    const boardArea = document.createElement('div');
+    boardArea.style.position = 'relative';
+    boardArea.style.margin = '0 auto';
+    boardArea.style.touchAction = 'none';
+    boardArea.style.userSelect = 'none';
 
-    boardFrame.appendChild(canvas);
+    const puzzleSurface = document.createElement('div');
+    puzzleSurface.style.position = 'absolute';
+    puzzleSurface.style.left = '0';
+    puzzleSurface.style.top = '0';
+    puzzleSurface.style.borderRadius = '12px';
+    puzzleSurface.style.background = 'linear-gradient(145deg, rgba(30,41,59,0.9), rgba(15,23,42,0.95))';
+    puzzleSurface.style.boxShadow = 'inset 0 0 0 2px rgba(15,23,42,0.7)';
+
+    boardArea.appendChild(puzzleSurface);
+    boardFrame.appendChild(boardArea);
 
     const statusBar = document.createElement('div');
     statusBar.style.marginTop = '14px';
@@ -264,24 +271,37 @@
     // --- Puzzle state ---
     let rows = 3;
     let cols = 4;
-    let board = [];
+    let pieces = [];
     let running = false;
-    let selectedIndex = null;
-    let correctPieces = 0;
     let solved = false;
     let solveCount = 0;
     let moves = 0;
     let elapsedMs = 0;
     let startedAt = null;
     let timerInterval = null;
+    let correctPieces = 0;
     let currentImage = null;
     let imageNaturalWidth = 0;
     let imageNaturalHeight = 0;
+    let sourceCanvas = null;
+    let boardWidth = 420;
+    let boardHeight = 320;
+    let pieceWidth = 0;
+    let pieceHeight = 0;
+    let piecePadding = 0;
+    let boardAreaWidth = 0;
+    let boardAreaHeight = 0;
     let hostRestartDisabled = false;
     let statusState = { mode: '', data: {} };
+    let activePiece = null;
+    let activePointerId = null;
+    let pointerOffsetX = 0;
+    let pointerOffsetY = 0;
+    let pointerMoved = false;
+    let zIndexCounter = 10;
 
     const pieceRewardXp = 0.6;
-    const solveRewardMultiplier = 0.9;
+    const solveRewardMultiplier = 1.2;
 
     function giveXp(amount, context){
       if (!awardXp || !amount) return;
@@ -321,7 +341,7 @@
       } else if (mode === 'clear'){
         const timeText = formatTime(payload?.timeMs ?? elapsedMs);
         const xpText = formatNumber(payload?.xp ?? 0, { maximumFractionDigits: 2 });
-        statusBar.textContent = text('.status.cleared', () => `完成！ ${moves} 手 / ${timeText} 取得EXP: ${xpText}`, {
+        statusBar.textContent = text('.status.cleared', () => `完成！ ${moves} 手 / ${timeText} EXP: ${xpText}`, {
           moves,
           time: timeText,
           xp: xpText,
@@ -330,11 +350,14 @@
         });
         statusBar.style.color = '#facc15';
       } else if (mode === 'ready'){
-        statusBar.textContent = text('.status.ready', () => `${formatBoardSize()} のピースをシャッフルしました。画像を完成させよう！`, {
+        statusBar.textContent = text('.status.ready', () => `${formatBoardSize()} のピースをシャッフルしました。ドラッグで組み立てよう！`, {
           rows,
           cols,
         });
         statusBar.style.color = '#cbd5f5';
+      } else if (mode === 'noImage'){
+        statusBar.textContent = text('.status.noImage', '画像を読み込んでください');
+        statusBar.style.color = '#94a3b8';
       } else {
         statusBar.textContent = '';
         statusBar.style.color = '#e2e8f0';
@@ -373,12 +396,12 @@
     }
 
     function calculateBoardSize(){
-      const containerWidth = wrapper.clientWidth ? Math.max(160, wrapper.clientWidth - 4) : 480;
-      const maxWidth = Math.min(520, containerWidth);
-      const aspect = imageNaturalWidth > 0 ? imageNaturalHeight / Math.max(1, imageNaturalWidth) : 1;
+      const containerWidth = wrapper.clientWidth ? Math.max(220, wrapper.clientWidth - 36) : 520;
+      const maxWidth = Math.min(560, containerWidth);
+      const aspect = imageNaturalWidth > 0 ? imageNaturalHeight / Math.max(1, imageNaturalWidth) : 0.75;
       let width = maxWidth;
       let height = width * aspect;
-      const maxHeight = 520;
+      const maxHeight = 500;
       if (height > maxHeight){
         const ratio = maxHeight / height;
         height = maxHeight;
@@ -389,208 +412,451 @@
         width *= ratio;
         height *= ratio;
       }
-      width = Math.max(160, width);
-      height = Math.max(160, height);
+      width = Math.max(220, width);
+      height = Math.max(220, height);
       return { width, height };
     }
 
-    function drawBoard(){
-      const ctx = canvas.getContext('2d');
-      if (!ctx){
-        return;
-      }
-      const dpr = window.devicePixelRatio || 1;
+    function prepareSourceCanvas(){
+      if (!currentImage) return;
       const { width, height } = calculateBoardSize();
-      const displayWidth = Math.max(50, width);
-      const displayHeight = Math.max(50, height);
-      boardFrame.style.width = `${displayWidth}px`;
-      boardFrame.style.height = `${displayHeight}px`;
-      canvas.style.width = '100%';
-      canvas.style.height = '100%';
-      canvas.width = Math.round(displayWidth * dpr);
-      canvas.height = Math.round(displayHeight * dpr);
-      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-      ctx.fillStyle = '#0f172a';
-      ctx.fillRect(0, 0, displayWidth, displayHeight);
-      if (!currentImage || !board.length){
-        ctx.fillStyle = '#475569';
-        ctx.font = '16px "Segoe UI", system-ui, sans-serif';
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'middle';
-        ctx.fillText(text('.status.noImage', '画像を読み込んでください'), displayWidth / 2, displayHeight / 2);
-        return;
-      }
-
-      const tileWidth = displayWidth / cols;
-      const tileHeight = displayHeight / rows;
-
+      boardWidth = width;
+      boardHeight = height;
+      const canvas = document.createElement('canvas');
+      canvas.width = Math.round(boardWidth);
+      canvas.height = Math.round(boardHeight);
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
       ctx.imageSmoothingEnabled = true;
       ctx.imageSmoothingQuality = 'high';
-
-      for (let index = 0; index < board.length; index++){
-        const pieceId = board[index];
-        const destRow = Math.floor(index / cols);
-        const destCol = index % cols;
-        const destX = destCol * tileWidth;
-        const destY = destRow * tileHeight;
-        const srcRow = Math.floor(pieceId / cols);
-        const srcCol = pieceId % cols;
-        const sx = (imageNaturalWidth / cols) * srcCol;
-        const sy = (imageNaturalHeight / rows) * srcRow;
-        const sw = imageNaturalWidth / cols;
-        const sh = imageNaturalHeight / rows;
-        ctx.drawImage(currentImage, sx, sy, sw, sh, destX, destY, tileWidth, tileHeight);
-        ctx.strokeStyle = 'rgba(15,23,42,0.55)';
-        ctx.lineWidth = 1;
-        ctx.strokeRect(destX, destY, tileWidth, tileHeight);
-      }
-
-      if (selectedIndex != null){
-        const selRow = Math.floor(selectedIndex / cols);
-        const selCol = selectedIndex % cols;
-        const sx = selCol * tileWidth;
-        const sy = selRow * tileHeight;
-        ctx.fillStyle = 'rgba(250,204,21,0.25)';
-        ctx.fillRect(sx, sy, tileWidth, tileHeight);
-        ctx.strokeStyle = 'rgba(250,204,21,0.8)';
-        ctx.lineWidth = 2;
-        ctx.strokeRect(sx + 1, sy + 1, tileWidth - 2, tileHeight - 2);
-      }
-
-      if (solved){
-        ctx.fillStyle = 'rgba(2,6,23,0.35)';
-        ctx.fillRect(0, 0, displayWidth, displayHeight);
-        ctx.fillStyle = '#facc15';
-        ctx.font = 'bold 24px "Segoe UI", system-ui, sans-serif';
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'middle';
-        ctx.fillText(text('.status.overlayCleared', '完成！'), displayWidth / 2, displayHeight / 2);
-      }
+      ctx.fillStyle = '#0f172a';
+      ctx.fillRect(0, 0, boardWidth, boardHeight);
+      ctx.drawImage(currentImage, 0, 0, boardWidth, boardHeight);
+      sourceCanvas = canvas;
     }
 
-    function countCorrectPieces(){
-      let count = 0;
-      for (let i = 0; i < board.length; i++){
-        if (board[i] === i) count++;
+    function createPiecePath(ctx, piece){
+      const tab = Math.min(pieceWidth, pieceHeight) * 0.35;
+      const tabDepth = tab * 0.55;
+      const halfTab = tab / 2;
+
+      ctx.moveTo(0, 0);
+      if (piece.top === 0){
+        ctx.lineTo(pieceWidth, 0);
+      } else {
+        const dir = piece.top;
+        ctx.lineTo(pieceWidth / 2 - halfTab, 0);
+        ctx.bezierCurveTo(
+          pieceWidth / 2 - halfTab * 0.25,
+          -tabDepth * dir * 0.3,
+          pieceWidth / 2 - halfTab * 0.15,
+          -tabDepth * dir,
+          pieceWidth / 2,
+          -tabDepth * dir
+        );
+        ctx.bezierCurveTo(
+          pieceWidth / 2 + halfTab * 0.15,
+          -tabDepth * dir,
+          pieceWidth / 2 + halfTab * 0.25,
+          -tabDepth * dir * 0.3,
+          pieceWidth / 2 + halfTab,
+          0
+        );
+        ctx.lineTo(pieceWidth, 0);
       }
-      return count;
+      if (piece.right === 0){
+        ctx.lineTo(pieceWidth, pieceHeight);
+      } else {
+        const dir = piece.right;
+        ctx.lineTo(pieceWidth, pieceHeight / 2 - halfTab);
+        ctx.bezierCurveTo(
+          pieceWidth + tabDepth * dir * 0.3,
+          pieceHeight / 2 - halfTab * 0.25,
+          pieceWidth + tabDepth * dir,
+          pieceHeight / 2 - halfTab * 0.15,
+          pieceWidth + tabDepth * dir,
+          pieceHeight / 2
+        );
+        ctx.bezierCurveTo(
+          pieceWidth + tabDepth * dir,
+          pieceHeight / 2 + halfTab * 0.15,
+          pieceWidth + tabDepth * dir * 0.3,
+          pieceHeight / 2 + halfTab * 0.25,
+          pieceWidth,
+          pieceHeight / 2 + halfTab
+        );
+        ctx.lineTo(pieceWidth, pieceHeight);
+      }
+      if (piece.bottom === 0){
+        ctx.lineTo(0, pieceHeight);
+      } else {
+        const dir = piece.bottom;
+        ctx.lineTo(pieceWidth / 2 + halfTab, pieceHeight);
+        ctx.bezierCurveTo(
+          pieceWidth / 2 + halfTab * 0.25,
+          pieceHeight + tabDepth * dir * 0.3,
+          pieceWidth / 2 + halfTab * 0.15,
+          pieceHeight + tabDepth * dir,
+          pieceWidth / 2,
+          pieceHeight + tabDepth * dir
+        );
+        ctx.bezierCurveTo(
+          pieceWidth / 2 - halfTab * 0.15,
+          pieceHeight + tabDepth * dir,
+          pieceWidth / 2 - halfTab * 0.25,
+          pieceHeight + tabDepth * dir * 0.3,
+          pieceWidth / 2 - halfTab,
+          pieceHeight
+        );
+        ctx.lineTo(0, pieceHeight);
+      }
+      if (piece.left === 0){
+        ctx.lineTo(0, 0);
+      } else {
+        const dir = piece.left;
+        ctx.lineTo(0, pieceHeight / 2 + halfTab);
+        ctx.bezierCurveTo(
+          -tabDepth * dir * 0.3,
+          pieceHeight / 2 + halfTab * 0.25,
+          -tabDepth * dir,
+          pieceHeight / 2 + halfTab * 0.15,
+          -tabDepth * dir,
+          pieceHeight / 2
+        );
+        ctx.bezierCurveTo(
+          -tabDepth * dir,
+          pieceHeight / 2 - halfTab * 0.15,
+          -tabDepth * dir * 0.3,
+          pieceHeight / 2 - halfTab * 0.25,
+          0,
+          pieceHeight / 2 - halfTab
+        );
+        ctx.lineTo(0, 0);
+      }
+      ctx.closePath();
     }
 
-    function checkSolved(){
-      for (let i = 0; i < board.length; i++){
-        if (board[i] !== i) return false;
-      }
-      return true;
+    function drawPiece(piece){
+      const canvas = piece.element;
+      const ctx = canvas.getContext('2d');
+      if (!ctx || !sourceCanvas) return;
+      const dpr = window.devicePixelRatio || 1;
+      const cssWidth = pieceWidth + piecePadding * 2;
+      const cssHeight = pieceHeight + piecePadding * 2;
+      canvas.width = Math.round(cssWidth * dpr);
+      canvas.height = Math.round(cssHeight * dpr);
+      canvas.style.width = `${cssWidth}px`;
+      canvas.style.height = `${cssHeight}px`;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx.clearRect(0, 0, cssWidth, cssHeight);
+      ctx.save();
+      ctx.translate(piecePadding, piecePadding);
+      ctx.beginPath();
+      createPiecePath(ctx, piece);
+      ctx.save();
+      ctx.clip();
+      ctx.drawImage(sourceCanvas, -piece.col * pieceWidth, -piece.row * pieceHeight);
+      ctx.restore();
+      ctx.strokeStyle = 'rgba(15,23,42,0.65)';
+      ctx.lineWidth = 1.6;
+      ctx.lineJoin = 'round';
+      ctx.stroke();
+      ctx.restore();
+      ctx.save();
+      ctx.translate(piecePadding, piecePadding);
+      ctx.beginPath();
+      createPiecePath(ctx, piece);
+      const grad = ctx.createLinearGradient(0, 0, pieceWidth, pieceHeight);
+      grad.addColorStop(0, 'rgba(15,23,42,0.18)');
+      grad.addColorStop(1, 'rgba(2,6,23,0)');
+      ctx.fillStyle = grad;
+      ctx.fill();
+      ctx.restore();
+    }
+    function updatePiecePosition(piece){
+      piece.element.style.left = `${piece.x}px`;
+      piece.element.style.top = `${piece.y}px`;
     }
 
-    function shuffleBoard(){
-      for (let i = board.length - 1; i > 0; i--){
-        const j = Math.floor(Math.random() * (i + 1));
-        const tmp = board[i];
-        board[i] = board[j];
-        board[j] = tmp;
-      }
-      if (checkSolved()){
-        // Force at least one swap to avoid solved board
-        if (board.length >= 2){
-          const tmp = board[0];
-          board[0] = board[1];
-          board[1] = tmp;
+    function setPieceLocked(piece, locked){
+      piece.locked = locked;
+      piece.element.style.cursor = locked ? 'default' : 'grab';
+      piece.element.style.filter = locked ? 'drop-shadow(0 0 0 rgba(0,0,0,0))' : 'drop-shadow(0 6px 18px rgba(15,23,42,0.45))';
+      piece.element.style.pointerEvents = locked ? 'none' : 'auto';
+    }
+
+    function createPieceElement(piece){
+      const canvas = document.createElement('canvas');
+      canvas.style.position = 'absolute';
+      canvas.style.left = '0';
+      canvas.style.top = '0';
+      canvas.style.cursor = 'grab';
+      canvas.style.touchAction = 'none';
+      canvas.style.transition = 'box-shadow 0.2s ease';
+      canvas.__piece = piece;
+      piece.element = canvas;
+      drawPiece(piece);
+      return canvas;
+    }
+
+    function updateBoardMetrics(){
+      pieceWidth = boardWidth / cols;
+      pieceHeight = boardHeight / rows;
+      piecePadding = Math.min(pieceWidth, pieceHeight) * 0.35;
+      boardAreaWidth = boardWidth + piecePadding * 2;
+      boardAreaHeight = boardHeight + piecePadding * 2;
+      boardArea.style.width = `${boardAreaWidth}px`;
+      boardArea.style.height = `${boardAreaHeight}px`;
+      puzzleSurface.style.left = `${piecePadding}px`;
+      puzzleSurface.style.top = `${piecePadding}px`;
+      puzzleSurface.style.width = `${boardWidth}px`;
+      puzzleSurface.style.height = `${boardHeight}px`;
+    }
+
+    function generatePieces(){
+      pieces = [];
+      const connectors = [];
+      for (let row = 0; row < rows; row++){
+        for (let col = 0; col < cols; col++){
+          const index = row * cols + col;
+          const top = row === 0 ? 0 : -connectors[(row - 1) * cols + col].bottom;
+          const left = col === 0 ? 0 : -connectors[index - 1].right;
+          const bottom = row === rows - 1 ? 0 : (Math.random() < 0.5 ? 1 : -1);
+          const right = col === cols - 1 ? 0 : (Math.random() < 0.5 ? 1 : -1);
+          const piece = {
+            row,
+            col,
+            top,
+            right,
+            bottom,
+            left,
+            element: null,
+            locked: false,
+            x: 0,
+            y: 0,
+            targetX: 0,
+            targetY: 0,
+          };
+          connectors[index] = piece;
+          pieces.push(piece);
         }
       }
     }
 
-    function buildBoard(){
-      const total = rows * cols;
-      board = new Array(total);
-      for (let i = 0; i < total; i++){
-        board[i] = i;
+    function clearPieces(){
+      while (boardArea.children.length > 1){
+        const child = boardArea.lastChild;
+        if (child !== puzzleSurface){
+          child.remove();
+        } else {
+          break;
+        }
       }
-      shuffleBoard();
-      correctPieces = countCorrectPieces();
-      moves = 0;
-      selectedIndex = null;
-      solved = false;
-      elapsedMs = 0;
+    }
+
+    function scatterPieces(){
+      const threshold = Math.min(pieceWidth, pieceHeight) * 0.3;
+      correctPieces = 0;
+      pieces.forEach((piece) => {
+        const element = piece.element;
+        const canvasWidth = pieceWidth + piecePadding * 2;
+        const canvasHeight = pieceHeight + piecePadding * 2;
+        piece.targetX = piece.col * pieceWidth;
+        piece.targetY = piece.row * pieceHeight;
+        const maxX = boardAreaWidth - canvasWidth;
+        const maxY = boardAreaHeight - canvasHeight;
+        piece.x = Math.random() * maxX;
+        piece.y = Math.random() * maxY;
+        setPieceLocked(piece, false);
+        element.dataset.snapDistance = String(threshold);
+        updatePiecePosition(piece);
+      });
+      updateInfo();
+    }
+
+    function buildPieces(){
+      if (!sourceCanvas) return;
+      detachPointerEvents();
+      clearPieces();
+      updateBoardMetrics();
+      generatePieces();
+      pieces.forEach((piece) => {
+        createPieceElement(piece);
+        boardArea.appendChild(piece.element);
+      });
+      scatterPieces();
+      attachPointerEvents();
+    }
+
+    function rebuildPuzzle(){
+      if (!currentImage){
+        setStatus('noImage');
+        clearPieces();
+        return;
+      }
+      prepareSourceCanvas();
+      buildPieces();
+      setStatus('ready');
       if (running){
-        startedAt = performance.now();
+        resetStats();
         startTimer();
       } else {
-        startedAt = null;
         stopTimer();
       }
-      setStatus('ready');
-      updateInfo();
-      drawBoard();
+    }
+
+    function clampPosition(piece, x, y){
+      const canvasWidth = pieceWidth + piecePadding * 2;
+      const canvasHeight = pieceHeight + piecePadding * 2;
+      const minX = 0;
+      const minY = 0;
+      const maxX = boardAreaWidth - canvasWidth;
+      const maxY = boardAreaHeight - canvasHeight;
+      return {
+        x: Math.min(maxX, Math.max(minX, x)),
+        y: Math.min(maxY, Math.max(minY, y)),
+      };
+    }
+
+    function trySnap(piece){
+      const snapDistance = Number(piece.element.dataset.snapDistance || 0) || Math.min(pieceWidth, pieceHeight) * 0.3;
+      const dx = piece.x - piece.targetX;
+      const dy = piece.y - piece.targetY;
+      const dist = Math.hypot(dx, dy);
+      if (dist <= snapDistance){
+        piece.x = piece.targetX;
+        piece.y = piece.targetY;
+        updatePiecePosition(piece);
+        if (!piece.locked){
+          setPieceLocked(piece, true);
+          correctPieces++;
+          giveXp(pieceRewardXp, { type: 'pieceLocked', rows, cols });
+          updateInfo();
+        }
+        checkSolved();
+        return true;
+      }
+      return false;
+    }
+
+    function checkSolved(){
+      if (pieces.every((p) => p.locked)){
+        if (!solved){
+          solved = true;
+          stopTimer();
+          solveCount++;
+          const bonus = rows * cols * solveRewardMultiplier;
+          giveXp(bonus, { type: 'completed', rows, cols, moves, timeMs: elapsedMs });
+          setStatus('clear', { timeMs: elapsedMs, xp: bonus });
+          correctPieces = pieces.length;
+          updateInfo();
+        }
+      }
+    }
+    function onPointerDown(event){
+      const piece = event.currentTarget.__piece;
+      if (!piece || piece.locked) return;
+      const rect = boardArea.getBoundingClientRect();
+      activePiece = piece;
+      activePointerId = event.pointerId;
+      pointerOffsetX = event.clientX - rect.left - piece.x;
+      pointerOffsetY = event.clientY - rect.top - piece.y;
+      pointerMoved = false;
+      piece.element.setPointerCapture(event.pointerId);
+      piece.element.style.cursor = 'grabbing';
+      piece.element.style.zIndex = String(zIndexCounter++);
+    }
+
+    function onPointerMove(event){
+      if (!activePiece || event.pointerId !== activePointerId) return;
+      const rect = boardArea.getBoundingClientRect();
+      const newX = event.clientX - rect.left - pointerOffsetX;
+      const newY = event.clientY - rect.top - pointerOffsetY;
+      const clamped = clampPosition(activePiece, newX, newY);
+      activePiece.x = clamped.x;
+      activePiece.y = clamped.y;
+      updatePiecePosition(activePiece);
+      pointerMoved = true;
+    }
+
+    function onPointerUp(event){
+      if (!activePiece || event.pointerId !== activePointerId) return;
+      try {
+        activePiece.element.releasePointerCapture(event.pointerId);
+      } catch {}
+      const piece = activePiece;
+      activePiece.element.style.cursor = piece.locked ? 'default' : 'grab';
+      activePiece = null;
+      activePointerId = null;
+      if (pointerMoved){
+        moves++;
+        updateInfo();
+      }
+      pointerMoved = false;
+      if (!piece.locked){
+        trySnap(piece);
+      }
+    }
+
+    function attachPointerEvents(){
+      pieces.forEach((piece) => {
+        const el = piece.element;
+        el.addEventListener('pointerdown', onPointerDown);
+        el.addEventListener('pointermove', onPointerMove);
+        el.addEventListener('pointerup', onPointerUp);
+        el.addEventListener('pointercancel', onPointerUp);
+      });
+    }
+
+    function detachPointerEvents(){
+      pieces.forEach((piece) => {
+        const el = piece.element;
+        if (!el) return;
+        el.removeEventListener('pointerdown', onPointerDown);
+        el.removeEventListener('pointermove', onPointerMove);
+        el.removeEventListener('pointerup', onPointerUp);
+        el.removeEventListener('pointercancel', onPointerUp);
+      });
     }
 
     function applySizeChanges(){
-      const newRows = clampSize(rowsControl.input.value);
-      const newCols = clampSize(colsControl.input.value);
-      rows = newRows;
-      cols = newCols;
-      rowsControl.input.value = rows;
-      colsControl.input.value = cols;
-      if (currentImage){
-        buildBoard();
-      } else {
-        drawBoard();
+      const nextRows = clampSize(rowsControl.input.value);
+      const nextCols = clampSize(colsControl.input.value);
+      rowsControl.input.value = String(nextRows);
+      colsControl.input.value = String(nextCols);
+      const changed = nextRows !== rows || nextCols !== cols;
+      rows = nextRows;
+      cols = nextCols;
+      if (changed && currentImage){
+        resetStats();
+        rebuildPuzzle();
       }
     }
 
-    function onCanvasClick(event){
-      if (!running || solved || !board.length) return;
-      const rect = canvas.getBoundingClientRect();
-      const x = event.clientX - rect.left;
-      const y = event.clientY - rect.top;
-      const { width, height } = calculateBoardSize();
-      const scaleX = width / rect.width;
-      const scaleY = height / rect.height;
-      const tileWidth = width / cols;
-      const tileHeight = height / rows;
-      const col = Math.max(0, Math.min(cols - 1, Math.floor((x * scaleX) / tileWidth)));
-      const row = Math.max(0, Math.min(rows - 1, Math.floor((y * scaleY) / tileHeight)));
-      const index = row * cols + col;
-      if (selectedIndex == null){
-        selectedIndex = index;
-        drawBoard();
-        return;
-      }
-      if (selectedIndex === index){
-        selectedIndex = null;
-        drawBoard();
-        return;
-      }
-      const prevCorrectA = board[selectedIndex] === selectedIndex;
-      const prevCorrectB = board[index] === index;
-      const tmp = board[selectedIndex];
-      board[selectedIndex] = board[index];
-      board[index] = tmp;
-      const nowCorrectA = board[selectedIndex] === selectedIndex;
-      const nowCorrectB = board[index] === index;
-      let gained = 0;
-      if (!prevCorrectA && nowCorrectA) gained++;
-      if (!prevCorrectB && nowCorrectB) gained++;
-      correctPieces = countCorrectPieces();
-      moves += 1;
-      selectedIndex = null;
-      drawBoard();
-      updateInfo();
-      if (gained > 0){
-        const xp = pieceRewardXp * gained;
-        giveXp(xp, { reason: 'piece', pieces: gained, rows, cols });
-      }
-      if (checkSolved()){
-        solved = true;
-        stopTimer();
-        elapsedMs = performance.now() - (startedAt ?? performance.now());
-        updateInfo();
-        solveCount += 1;
-        updateInfo();
-        const solveXp = Math.max(5, rows * cols * solveRewardMultiplier);
-        giveXp(solveXp, { reason: 'solve', moves, timeMs: elapsedMs, rows, cols });
-        setStatus('clear', { timeMs: elapsedMs, xp: solveXp });
-        drawBoard();
+    function loadImageFromFile(file){
+      if (!file) return;
+      const reader = new FileReader();
+      setStatus('loading');
+      reader.onload = () => {
+        const img = new Image();
+        img.onload = () => {
+          currentImage = img;
+          imageNaturalWidth = img.naturalWidth;
+          imageNaturalHeight = img.naturalHeight;
+          rebuildPuzzle();
+        };
+        img.onerror = () => {
+          setStatus('error', { message: text('.status.errorFile', 'ファイルの読み込みに失敗しました') });
+        };
+        img.src = reader.result;
+      };
+      reader.onerror = () => {
+        setStatus('error', { message: text('.status.errorFile', 'ファイルの読み込みに失敗しました') });
+      };
+      try {
+        reader.readAsDataURL(file);
+      } catch {
+        setStatus('error', { message: text('.status.errorFile', 'ファイルの読み込みに失敗しました') });
       }
     }
 
@@ -601,129 +867,56 @@
       img.crossOrigin = 'anonymous';
       img.onload = () => {
         currentImage = img;
-        imageNaturalWidth = img.naturalWidth || img.width;
-        imageNaturalHeight = img.naturalHeight || img.height;
-        resetStats();
-        buildBoard();
+        imageNaturalWidth = img.naturalWidth;
+        imageNaturalHeight = img.naturalHeight;
+        rebuildPuzzle();
       };
       img.onerror = () => {
-        setStatus('error', { message: text('.status.errorLoadUrl', '画像の取得に失敗しました') });
-        drawBoard();
+        setStatus('error', { message: text('.status.errorUrl', '画像の読み込みに失敗しました') });
       };
       img.src = url;
     }
 
-    function loadImageFromFile(file){
-      if (!file) return;
-      setStatus('loading');
-      const reader = new FileReader();
-      reader.onload = () => {
-        const img = new Image();
-        img.onload = () => {
-          currentImage = img;
-          imageNaturalWidth = img.naturalWidth || img.width;
-          imageNaturalHeight = img.naturalHeight || img.height;
-          resetStats();
-          buildBoard();
-        };
-        img.onerror = () => {
-          setStatus('error', { message: text('.status.errorLoadFile', 'ファイルを読み込めませんでした') });
-          drawBoard();
-        };
-        img.src = reader.result;
-      };
-      reader.onerror = () => {
-        setStatus('error', { message: text('.status.errorLoadFile', 'ファイルを読み込めませんでした') });
-      };
-      reader.readAsDataURL(file);
-    }
-
     function createDefaultImage(){
-      const size = 512;
+      const size = 480;
       const canvasEl = document.createElement('canvas');
       canvasEl.width = size;
-      canvasEl.height = size;
+      canvasEl.height = Math.floor(size * 0.65);
       const ctx = canvasEl.getContext('2d');
-      const gradient = ctx.createLinearGradient(0, 0, size, size);
-      gradient.addColorStop(0, '#0ea5e9');
-      gradient.addColorStop(1, '#6366f1');
-      ctx.fillStyle = gradient;
-      ctx.fillRect(0, 0, size, size);
-      ctx.fillStyle = 'rgba(15,23,42,0.15)';
-      for (let i = 0; i < 12; i++){
-        const radius = 60 + i * 18;
+      if (!ctx) return null;
+      const grd = ctx.createLinearGradient(0, 0, size, canvasEl.height);
+      grd.addColorStop(0, '#1d4ed8');
+      grd.addColorStop(1, '#9333ea');
+      ctx.fillStyle = grd;
+      ctx.fillRect(0, 0, size, canvasEl.height);
+      ctx.fillStyle = 'rgba(255,255,255,0.15)';
+      for (let i = 0; i < 18; i++){
         ctx.beginPath();
-        ctx.arc(size / 2, size / 2, radius, 0, Math.PI * 2);
-        ctx.strokeStyle = `rgba(15,23,42,${0.05 + i * 0.015})`;
-        ctx.lineWidth = 3;
-        ctx.stroke();
+        ctx.arc(Math.random() * size, Math.random() * canvasEl.height, 30 + Math.random() * 120, 0, Math.PI * 2);
+        ctx.fill();
       }
-      ctx.fillStyle = 'rgba(15,23,42,0.12)';
-      for (let i = 0; i < 120; i++){
-        const x = Math.random() * size;
-        const y = Math.random() * size;
-        const w = 18 + Math.random() * 32;
-        const h = 18 + Math.random() * 32;
-        ctx.save();
-        ctx.translate(x, y);
-        ctx.rotate(Math.random() * Math.PI);
-        ctx.fillRect(-w / 2, -h / 2, w, h);
-        ctx.restore();
-      }
-      ctx.fillStyle = 'rgba(241,245,249,0.9)';
-      ctx.font = 'bold 64px "Segoe UI", system-ui, sans-serif';
+      ctx.fillStyle = '#f8fafc';
+      ctx.font = 'bold 52px "Segoe UI", system-ui, sans-serif';
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
-      ctx.fillText(text('.defaultImage.title', 'Jigsaw'), size / 2, size / 2 - 24);
-      ctx.font = '24px "Segoe UI", system-ui, sans-serif';
-      ctx.fillText(text('.defaultImage.subtitle', 'Puzzle'), size / 2, size / 2 + 32);
+      ctx.fillText(text('.defaultImage.title', 'Jigsaw'), size / 2, canvasEl.height / 2 - 30);
+      ctx.font = '28px "Segoe UI", system-ui, sans-serif';
+      ctx.fillText(text('.defaultImage.subtitle', 'Puzzle'), size / 2, canvasEl.height / 2 + 26);
       return canvasEl.toDataURL('image/png');
     }
 
     function loadDefaultImage(){
-      const dataUrl = createDefaultImage();
-      loadImageFromUrl(dataUrl);
-    }
-
-    const onResize = () => { drawBoard(); };
-
-    canvas.addEventListener('click', onCanvasClick);
-    window.addEventListener('resize', onResize);
-    applySizeBtn.addEventListener('click', () => {
-      applySizeChanges();
-    });
-    shuffleBtn.addEventListener('click', () => {
-      if (!currentImage){
-        loadDefaultImage();
-        return;
-      }
-      resetStats();
-      buildBoard();
-    });
-    fileInput.addEventListener('change', (event) => {
-      const file = event.target.files && event.target.files[0];
-      if (file){
-        loadImageFromFile(file);
-        try { event.target.value = ''; } catch {}
-      }
-    });
-    loadUrlBtn.addEventListener('click', () => {
-      const url = urlInput.value.trim();
-      if (!url) return;
-      loadImageFromUrl(url);
-    });
-    urlInput.addEventListener('keydown', (event) => {
-      if (event.key === 'Enter'){
-        event.preventDefault();
-        const url = urlInput.value.trim();
-        if (!url) return;
+      const url = createDefaultImage();
+      if (url){
         loadImageFromUrl(url);
+      } else {
+        setStatus('error', { message: text('.status.error', '画像の生成に失敗しました') });
       }
-    });
+    }
 
     function refreshLocalizedTexts(){
       title.textContent = text('.title', 'ジグソーパズル');
-      description.textContent = text('.description', '任意の画像を読み込み、ピース数を自由に設定してジグソーパズルを楽しもう。ピースをクリックして入れ替え、元の画像を完成させよう。');
+      description.textContent = text('.description', 'ジグソーピースの形をしたパーツをドラッグし、元の画像を完成させよう。行数と列数、画像を自由に選べます。');
       rowsControl.container.querySelector('span').textContent = text('.controls.rowsLabel', '行数');
       colsControl.container.querySelector('span').textContent = text('.controls.colsLabel', '列数');
       applySizeBtn.textContent = text('.controls.applySize', 'サイズを更新');
@@ -736,20 +929,86 @@
       correctInfo.updateLabel();
       solveInfo.updateLabel();
       renderStatus();
-      drawBoard();
     }
 
     refreshLocalizedTexts();
 
+    function onResize(){
+      if (!currentImage) return;
+      prepareSourceCanvas();
+      updateBoardMetrics();
+      const threshold = Math.min(pieceWidth, pieceHeight) * 0.3;
+      pieces.forEach((piece) => {
+        drawPiece(piece);
+        piece.targetX = piece.col * pieceWidth;
+        piece.targetY = piece.row * pieceHeight;
+        piece.element.dataset.snapDistance = String(threshold);
+        if (piece.locked){
+          piece.x = piece.targetX;
+          piece.y = piece.targetY;
+        } else {
+          const { x, y } = clampPosition(piece, piece.x, piece.y);
+          piece.x = x;
+          piece.y = y;
+        }
+        updatePiecePosition(piece);
+      });
+    }
+
+    applySizeBtn.addEventListener('click', () => {
+      applySizeChanges();
+    });
+
+    shuffleBtn.addEventListener('click', () => {
+      if (!currentImage){
+        loadDefaultImage();
+        return;
+      }
+      resetStats();
+      pieces.forEach((piece) => setPieceLocked(piece, false));
+      scatterPieces();
+      if (running){
+        startTimer();
+      }
+      setStatus('ready');
+    });
+
+    fileInput.addEventListener('change', (event) => {
+      const file = event.target.files && event.target.files[0];
+      if (file){
+        loadImageFromFile(file);
+        try { event.target.value = ''; } catch {}
+      }
+    });
+
+    loadUrlBtn.addEventListener('click', () => {
+      const url = urlInput.value.trim();
+      if (!url) return;
+      loadImageFromUrl(url);
+    });
+
+    urlInput.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter'){
+        event.preventDefault();
+        const url = urlInput.value.trim();
+        if (!url) return;
+        loadImageFromUrl(url);
+      }
+    });
+
+    window.addEventListener('resize', onResize);
+
     function start(){
       if (running) return;
       running = true;
-      setStatus('');
+      solved = false;
+      moves = 0;
+      correctPieces = 0;
       if (!currentImage){
         loadDefaultImage();
       } else {
         resetStats();
-        buildBoard();
+        rebuildPuzzle();
       }
       if (disableHostRestart && !hostRestartDisabled){
         disableHostRestart();
@@ -761,6 +1020,7 @@
       if (!running) return;
       running = false;
       stopTimer();
+      detachPointerEvents();
       if (hostRestartDisabled && enableHostRestart){
         enableHostRestart();
         hostRestartDisabled = false;
@@ -769,12 +1029,12 @@
 
     function destroy(){
       stopTimer();
-      canvas.removeEventListener('click', onCanvasClick);
+      detachPointerEvents();
+      window.removeEventListener('resize', onResize);
       if (hostRestartDisabled && enableHostRestart){
         enableHostRestart();
         hostRestartDisabled = false;
       }
-      window.removeEventListener('resize', onResize);
       wrapper.remove();
     }
 
@@ -788,7 +1048,7 @@
   window.registerMiniGame({
     id: 'jigsaw_puzzle',
     name: 'ジグソーパズル', nameKey: 'selection.miniexp.games.jigsaw_puzzle.name',
-    description: '任意の画像を行列指定で遊べるジグソーパズル', descriptionKey: 'selection.miniexp.games.jigsaw_puzzle.description',
+    description: '任意の画像をピースで組み立てるジグソーパズル', descriptionKey: 'selection.miniexp.games.jigsaw_puzzle.description',
     categoryIds: ['puzzle'],
     create
   });


### PR DESCRIPTION
## Summary
- replace the previous tile-swapping board with true jigsaw-shaped pieces and per-piece canvases
- allow players to drag, snap, and solve puzzles with updated status, XP, and localization-aware UI
- keep size and image selection controls while rebuilding the board with responsive scaling and resize handling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69020af7c564832baff5384f786e9736