### PR TITLE
Add sandbox sokoban localization

### DIFF
--- a/games/sandbox_sokoban.js
+++ b/games/sandbox_sokoban.js
@@ -96,11 +96,11 @@
     panels.appendChild(playPanel);
 
     const TOOL_TYPES = [
-      { id: 'floor', label: text('.tool.floor', '床'), hint: text('.tool.floor.hint', '基本の床マス') },
-      { id: 'wall', label: text('.tool.wall', '壁'), hint: text('.tool.wall.hint', '移動できない壁') },
-      { id: 'goal', label: text('.tool.goal', 'ゴール'), hint: text('.tool.goal.hint', '木箱をはめる目標地点') },
-      { id: 'crate', label: text('.tool.crate', '木箱'), hint: text('.tool.crate.hint', '押して動かす木箱 (クリックで配置/削除)') },
-      { id: 'player', label: text('.tool.player', '作業員'), hint: text('.tool.player.hint', '開始位置 (1つのみ)') },
+      { id: 'floor', label: text('.tool.floor.label', '床'), hint: text('.tool.floor.hint', '基本の床マス') },
+      { id: 'wall', label: text('.tool.wall.label', '壁'), hint: text('.tool.wall.hint', '移動できない壁') },
+      { id: 'goal', label: text('.tool.goal.label', 'ゴール'), hint: text('.tool.goal.hint', '木箱をはめる目標地点') },
+      { id: 'crate', label: text('.tool.crate.label', '木箱'), hint: text('.tool.crate.hint', '押して動かす木箱 (クリックで配置/削除)') },
+      { id: 'player', label: text('.tool.player.label', '作業員'), hint: text('.tool.player.hint', '開始位置 (1つのみ)') },
     ];
 
     const MIN_SIZE = 4;
@@ -265,11 +265,11 @@
     function updateStatusExtra(){
       const crateCount = stage.crates.length;
       const goalCount = stage.goals.size;
-      const hasPlayer = !!stage.player;
-      statusExtra.textContent = text('.status.summary', () => `木箱 ${crateCount} / ゴール ${goalCount} / 作業員 ${hasPlayer ? '1' : '0'}`, {
+      const workers = stage.player ? 1 : 0;
+      statusExtra.textContent = text('.status.summary', () => `木箱 ${crateCount} / ゴール ${goalCount} / 作業員 ${workers}`, {
         crates: crateCount,
         goals: goalCount,
-        hasPlayer,
+        workers,
       });
     }
 
@@ -770,10 +770,12 @@
 
     function updatePlayInfo(){
       const cratesOnGoal = playState ? countCratesOnGoals() : 0;
-      playInfo.textContent = text('.play.info', () => `手数 ${playState?.moves ?? 0} / 木箱 ${cratesOnGoal} / ${playState?.crates.length ?? 0}`, {
-        moves: playState?.moves ?? 0,
+      const moves = playState?.moves ?? 0;
+      const cratesTotal = playState?.crates.length ?? 0;
+      playInfo.textContent = text('.play.info', () => `手数 ${moves} / 木箱 ${cratesOnGoal}/${cratesTotal}`, {
+        moves,
         cratesOnGoal,
-        cratesTotal: playState?.crates.length ?? 0,
+        cratesTotal,
       });
     }
 

--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -834,6 +834,10 @@
             "name": "Number Place",
             "description": "Fill the grid with correct digits to gain EXP and a completion bonus."
           },
+          "sandbox_sokoban": {
+            "name": "Sandbox Sokoban",
+            "description": "Edit and test Sokoban layouts seamlessly. Slot crates for +25 EXP and clear stages for +100 EXP."
+          },
           "ultimate_ttt": {
             "name": "Ultimate Tic-Tac-Toe",
             "description": "Control mini-boards and claim the macro victory for layered EXP rewards."
@@ -15443,6 +15447,61 @@
     },
     "miniexp": {
       "games": {
+        "sandbox_sokoban": {
+          "title": "Sandbox Sokoban",
+          "description": "Create custom Sokoban stages and swap between edit and play. Slot crates for +25 EXP and clear the stage for +100 EXP.",
+          "status": {
+            "ready": "Edit mode: pick a tool on the left to start painting.",
+            "updated": "Cell updated.",
+            "summary": "Crates {crates} / Goals {goals} / Worker {workers}",
+            "exported": "Stage data exported. Copy and save it anywhere.",
+            "import": {
+              "empty": "Paste JSON to import a stage.",
+              "success": "Stage imported.",
+              "error": "Failed to parse JSON. Check the format."
+            },
+            "reset": "Restored the initial stage.",
+            "resetPlay": "Stage reset.",
+            "play": "Play mode: push crates onto every goal!",
+            "crateFit": "Crate slotted! +25 EXP",
+            "cleared": "Stage clear! +100 EXP",
+            "editMode": "Back in edit mode."
+          },
+          "tool": {
+            "floor": { "label": "Floor", "hint": "Basic walkable tile" },
+            "wall": { "label": "Wall", "hint": "Impassable wall" },
+            "goal": { "label": "Goal", "hint": "Target tile for crates" },
+            "crate": { "label": "Crate", "hint": "Pushable crate (click to place/remove)" },
+            "player": { "label": "Worker", "hint": "Starting position (only one)" }
+          },
+          "editor": {
+            "title": "Stage Editor",
+            "width": "Width",
+            "height": "Height",
+            "export": "Export",
+            "import": "Import",
+            "clear": "Reset",
+            "io": "Import / Export (JSON)"
+          },
+          "play": {
+            "title": "Playtest",
+            "hint": "Use arrow keys or WASD. Reset to try again.",
+            "reset": "Reset",
+            "info": "Moves {moves} / Crates {cratesOnGoal}/{cratesTotal}"
+          },
+          "validate": {
+            "player": "Set the worker's starting position.",
+            "crate": "Place at least one crate.",
+            "goal": "Place at least one goal.",
+            "balance": "Goals must be at least equal to crates.",
+            "crateWall": "Crates cannot sit on walls.",
+            "playerWall": "The worker cannot start on a wall."
+          },
+          "mode": {
+            "editor": "Edit",
+            "play": "Play"
+          }
+        },
         "exothello": {
           "name": "Ex-Othello",
           "description": "Experiment with variable board sizes, walls, and alternate win conditions.",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -836,6 +836,10 @@
             "name": "ナンプレ",
             "description": "正解入力でEXP / クリアボーナス"
           },
+          "sandbox_sokoban": {
+            "name": "サンドボックス倉庫番",
+            "description": "ステージ編集＆プレイを行き来できる倉庫番。木箱で+25EXP、クリアで+100EXP。"
+          },
           "ultimate_ttt": {
             "name": "スーパー三目並べ",
             "description": "小盤制覇+25/配置+1/リーチ+10/勝利ボーナス"
@@ -15404,6 +15408,61 @@
     },
     "miniexp": {
       "games": {
+        "sandbox_sokoban": {
+          "title": "サンドボックス倉庫番",
+          "description": "編集とプレイを行き来しながら、自分だけの倉庫番ステージを作成できます。木箱をはめると25EXP、完全クリアで100EXP獲得。",
+          "status": {
+            "ready": "編集中: 左のツールから配置してみましょう。",
+            "updated": "マスを更新しました。",
+            "summary": "木箱 {crates} / ゴール {goals} / 作業員 {workers}",
+            "exported": "ステージデータを出力しました。コピーして保存できます。",
+            "import": {
+              "empty": "インポートするJSONを入力してください。",
+              "success": "ステージを読み込みました。",
+              "error": "JSONの解析に失敗しました。形式を確認してください。"
+            },
+            "reset": "初期ステージに戻しました。",
+            "resetPlay": "ステージをリセットしました。",
+            "play": "プレイモード: 箱をゴールに押し込みましょう！",
+            "crateFit": "木箱をはめました！ +25EXP",
+            "cleared": "ステージクリア！ +100EXP",
+            "editMode": "編集モードに戻りました。"
+          },
+          "tool": {
+            "floor": { "label": "床", "hint": "基本の床マス" },
+            "wall": { "label": "壁", "hint": "移動できない壁" },
+            "goal": { "label": "ゴール", "hint": "木箱をはめる目標地点" },
+            "crate": { "label": "木箱", "hint": "押して動かす木箱 (クリックで配置/削除)" },
+            "player": { "label": "作業員", "hint": "開始位置 (1つのみ)" }
+          },
+          "editor": {
+            "title": "ステージエディタ",
+            "width": "幅",
+            "height": "高さ",
+            "export": "エクスポート",
+            "import": "インポート",
+            "clear": "初期化",
+            "io": "インポート / エクスポート (JSON)"
+          },
+          "play": {
+            "title": "プレイテスト",
+            "hint": "矢印キーまたはWASDで操作。リセットで再挑戦。",
+            "reset": "リセット",
+            "info": "手数 {moves} / 木箱 {cratesOnGoal}/{cratesTotal}"
+          },
+          "validate": {
+            "player": "作業員の開始位置が必要です。",
+            "crate": "最低1つの木箱を配置してください。",
+            "goal": "最低1つのゴールを配置してください。",
+            "balance": "ゴール数は木箱以上にしましょう。",
+            "crateWall": "壁の上に木箱は置けません。",
+            "playerWall": "作業員の位置が壁になっています。"
+          },
+          "mode": {
+            "editor": "編集",
+            "play": "プレイ"
+          }
+        },
         "tosochu": {
           "ui": {
             "timer": "残り {seconds}s",


### PR DESCRIPTION
## Summary
- switch the sandbox Sokoban tool definitions to dedicated localization keys and clean up runtime status formatting
- add Japanese and English locale entries so Sandbox Sokoban appears with localized UI text and selection metadata

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_690356902c4c832b94d6b99bd7ca1ff8