### PR TITLE
Add localization for Sanpo mini game UI

### DIFF
--- a/games/sanpo.js
+++ b/games/sanpo.js
@@ -84,7 +84,7 @@
     zoomLabel.style.gap = '4px';
     zoomLabel.style.alignItems = 'center';
     zoomLabel.style.color = '#cbd5f5';
-    zoomLabel.textContent = text('games.sanpo.ui.zoom', 'ズーム');
+    zoomLabel.textContent = text('games.sanpo.ui.zoomLabel', 'ズーム');
 
     const zoomSlider = document.createElement('input');
     zoomSlider.type = 'range';
@@ -125,7 +125,7 @@
     miniMapContainer.style.gap = '6px';
 
     const miniMapTitle = document.createElement('div');
-    miniMapTitle.textContent = text('games.sanpo.ui.minimap', 'ミニマップ');
+    miniMapTitle.textContent = text('games.sanpo.ui.minimapTitle', 'ミニマップ');
     miniMapTitle.style.color = '#cbd5f5';
     miniMapTitle.style.fontSize = '0.9rem';
 
@@ -215,15 +215,39 @@
         const typeName = stage.type || stage.requestedType || 'unknown';
         const sizeText = `${stage.width}×${stage.height}`;
         const tileSizeText = `${stage.tileSize}px`;
-        stageInfo.textContent = text('games.sanpo.ui.stage', () => `タイプ: ${typeName} / サイズ: ${sizeText} / タイル: ${tileSizeText}`);
-        seedInfo.textContent = text('games.sanpo.ui.seed', () => `シード: ${formatSeed(stageSeed)}`);
-        stepsInfo.textContent = text('games.sanpo.ui.steps', () => `歩数: ${stepsTaken}`);
+        const stageParams = { type: typeName, size: sizeText, tileSize: tileSizeText };
+        stageInfo.textContent = text(
+          'games.sanpo.ui.stageInfo',
+          (params = {}) => {
+            const type = params.type ?? typeName;
+            const size = params.size ?? sizeText;
+            const tile = params.tileSize ?? tileSizeText;
+            return `タイプ: ${type} / サイズ: ${size} / タイル: ${tile}`;
+          },
+          stageParams
+        );
+        const seedText = formatSeed(stageSeed);
+        seedInfo.textContent = text(
+          'games.sanpo.ui.seedInfo',
+          (params = {}) => `シード: ${params.seed ?? seedText}`,
+          { seed: seedText }
+        );
+        stepsInfo.textContent = text(
+          'games.sanpo.ui.stepsInfo',
+          (params = {}) => `歩数: ${params.steps ?? stepsTaken}`,
+          { steps: stepsTaken }
+        );
       } else {
-        stageInfo.textContent = text('games.sanpo.ui.stage.none', 'タイプ: -');
-        seedInfo.textContent = text('games.sanpo.ui.seed.none', 'シード: -');
-        stepsInfo.textContent = text('games.sanpo.ui.steps.none', '歩数: 0');
+        stageInfo.textContent = text('games.sanpo.ui.stageInfoEmpty', 'タイプ: -');
+        seedInfo.textContent = text('games.sanpo.ui.seedInfoEmpty', 'シード: -');
+        stepsInfo.textContent = text('games.sanpo.ui.stepsInfoEmpty', '歩数: 0');
       }
-      zoomInfo.textContent = text('games.sanpo.ui.zoomValue', () => `ズーム: ${currentZoom.toFixed(2)}x`);
+      const zoomText = currentZoom.toFixed(2);
+      zoomInfo.textContent = text(
+        'games.sanpo.ui.zoomInfo',
+        (params = {}) => `ズーム: ${(params.value ?? zoomText)}x`,
+        { value: zoomText }
+      );
     }
 
     function updateStatus(message){
@@ -296,8 +320,17 @@
       const ctx = canvas.getContext('2d');
       ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-      zoomValue.textContent = `${currentZoom.toFixed(2)}x`;
-      zoomInfo.textContent = text('games.sanpo.ui.zoomValue', () => `ズーム: ${currentZoom.toFixed(2)}x`);
+      const zoomText = currentZoom.toFixed(2);
+      zoomValue.textContent = text(
+        'games.sanpo.ui.zoomDisplay',
+        (params = {}) => `${params.value ?? zoomText}x`,
+        { value: zoomText }
+      );
+      zoomInfo.textContent = text(
+        'games.sanpo.ui.zoomInfo',
+        (params = {}) => `ズーム: ${(params.value ?? zoomText)}x`,
+        { value: zoomText }
+      );
 
       const maxWidth = stage.pixelWidth || (stage.width * stage.tileSize);
       const maxHeight = stage.pixelHeight || (stage.height * stage.tileSize);
@@ -357,7 +390,11 @@
           if (lastTile !== null){
             stepsTaken += 1;
             awardXp(1, { reason: 'step', gameId: 'sanpo' });
-            stepsInfo.textContent = text('games.sanpo.ui.steps', () => `歩数: ${stepsTaken}`);
+            stepsInfo.textContent = text(
+              'games.sanpo.ui.stepsInfo',
+              (params = {}) => `歩数: ${params.steps ?? stepsTaken}`,
+              { steps: stepsTaken }
+            );
           }
           lastTile = tile;
         }
@@ -378,7 +415,7 @@
       cancelAnimationFrame(raf);
       shortcuts?.enableKey?.('r');
       shortcuts?.enableKey?.('p');
-      updateStatus(text('games.sanpo.ui.status.paused', '一時停止中')); 
+      updateStatus(text('games.sanpo.ui.status.paused', '一時停止中'));
     }
 
     function startLoop(){
@@ -400,7 +437,7 @@
       player.speed = Math.max(60, stage.tileSize * 5.2);
       lastTile = stage.toTile(player.x, player.y);
       stepsTaken = 0;
-      stepsInfo.textContent = text('games.sanpo.ui.steps', () => '歩数: 0');
+      stepsInfo.textContent = text('games.sanpo.ui.stepsInfoEmpty', '歩数: 0');
     }
 
     function configureCanvas(){
@@ -416,14 +453,14 @@
       currentZoom = 1;
       targetZoom = 1;
       zoomSlider.value = '1';
-      zoomValue.textContent = '1.00x';
+      zoomValue.textContent = text('games.sanpo.ui.zoomDisplay', (params = {}) => `${params.value ?? '1.00'}x`, { value: '1.00' });
       miniMapCanvas.width = clamp(Math.floor(stage.width * 4), 120, 260);
       miniMapCanvas.height = clamp(Math.floor(stage.height * 4), 120, 220);
     }
 
     async function prepareStage(){
       if (!dungeonApi || typeof dungeonApi.generateStage !== 'function'){
-        updateStatus(text('games.sanpo.ui.status.noApi', 'ダンジョンAPIが利用できません')); 
+        updateStatus(text('games.sanpo.ui.status.noApi', 'ダンジョンAPIが利用できません'));
         stageReady = false;
         return;
       }
@@ -456,7 +493,7 @@
       resetPlayer();
       updateStageInfo();
       stageReady = true;
-      updateStatus(text('games.sanpo.ui.status.ready', '準備完了！開始ボタンで散歩を始めよう')); 
+      updateStatus(text('games.sanpo.ui.status.ready', '準備完了！開始ボタンで散歩を始めよう'));
       if (pendingStart) startLoop();
       draw();
     }

--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -1866,6 +1866,34 @@
               "vault": { "label": "Crack the high-risk vault" }
             }
           },
+          "sanpo": {
+            "name": "Stroll",
+            "description": "Stroll through a randomly generated dungeon and earn steps ×1 EXP.",
+            "ui": {
+              "regenerate": "Regenerate Stage",
+              "zoomLabel": "Zoom",
+              "minimapTitle": "Minimap",
+              "stageInfo": "Type: {type} / Size: {size} / Tile: {tileSize}",
+              "seedInfo": "Seed: {seed}",
+              "stepsInfo": "Steps: {steps}",
+              "stageInfoEmpty": "Type: -",
+              "seedInfoEmpty": "Seed: -",
+              "stepsInfoEmpty": "Steps: 0",
+              "zoomInfo": "Zoom: {value}x",
+              "zoomDisplay": "{value}x",
+              "hideMap": "Minimap OFF",
+              "showMap": "Minimap ON",
+              "status": {
+                "paused": "Paused",
+                "walk": "Strolling… Move with WASD/arrow keys. Toggle the minimap with M, zoom with [ / ].",
+                "noApi": "Dungeon API unavailable",
+                "generating": "Generating stage…",
+                "failed": "Failed to generate the stage",
+                "ready": "Ready! Press Start to begin strolling.",
+                "initializing": "Loading…"
+              }
+            }
+          },
           "ten_ten": {
             "name": "1010 Puzzle",
             "description": "Place blocks to clear lines, with cross clears doubling your EXP.",
@@ -17681,6 +17709,34 @@
           "subtitle": "Most recent first",
           "empty": "Your laps will appear here once recorded.",
           "label": "Lap {index}"
+        }
+      },
+      "sanpo": {
+        "name": "Stroll",
+        "description": "Stroll through a randomly generated dungeon and earn steps ×1 EXP.",
+        "ui": {
+          "regenerate": "Regenerate Stage",
+          "zoomLabel": "Zoom",
+          "minimapTitle": "Minimap",
+          "stageInfo": "Type: {type} / Size: {size} / Tile: {tileSize}",
+          "seedInfo": "Seed: {seed}",
+          "stepsInfo": "Steps: {steps}",
+          "stageInfoEmpty": "Type: -",
+          "seedInfoEmpty": "Seed: -",
+          "stepsInfoEmpty": "Steps: 0",
+          "zoomInfo": "Zoom: {value}x",
+          "zoomDisplay": "{value}x",
+          "hideMap": "Minimap OFF",
+          "showMap": "Minimap ON",
+          "status": {
+            "paused": "Paused",
+            "walk": "Strolling… Move with WASD/arrow keys. Toggle the minimap with M, zoom with [ / ].",
+            "noApi": "Dungeon API unavailable",
+            "generating": "Generating stage…",
+            "failed": "Failed to generate the stage",
+            "ready": "Ready! Press Start to begin strolling.",
+            "initializing": "Loading…"
+          }
         }
       },
       "diagramMaker": {

--- a/js/i18n/locales/fr.json.js
+++ b/js/i18n/locales/fr.json.js
@@ -885,6 +885,42 @@
     if (!locale.games && enLocale.games) {
       locale.games = clone(enLocale.games);
     }
+    if (locale.games) {
+      locale.games.sanpo = {
+        "name": "Balade",
+        "description": "Parcourez un donjon généré aléatoirement et gagnez des EXP à raison de 1 par pas.",
+        "ui": {
+          "regenerate": "Régénérer la zone",
+          "zoomLabel": "Zoom",
+          "minimapTitle": "Mini-carte",
+          "stageInfo": "Type : {type} / Taille : {size} / Tuile : {tileSize}",
+          "seedInfo": "Graine : {seed}",
+          "stepsInfo": "Pas : {steps}",
+          "stageInfoEmpty": "Type : -",
+          "seedInfoEmpty": "Graine : -",
+          "stepsInfoEmpty": "Pas : 0",
+          "zoomInfo": "Zoom : {value}x",
+          "zoomDisplay": "{value}x",
+          "hideMap": "Mini-carte OFF",
+          "showMap": "Mini-carte ON",
+          "status": {
+            "paused": "En pause",
+            "walk": "En balade… Déplacez-vous avec WASD/flèches. M pour la mini-carte, [ / ] pour le zoom.",
+            "noApi": "API de donjon indisponible",
+            "generating": "Génération de la zone…",
+            "failed": "Échec de la génération de la zone",
+            "ready": "Prêt ! Appuyez sur Démarrer pour lancer la balade.",
+            "initializing": "Chargement…"
+          }
+        }
+      };
+    }
+    if (locale.selection && locale.selection.miniexp && locale.selection.miniexp.games) {
+      locale.selection.miniexp.games.sanpo = {
+        "name": "Balade",
+        "description": "Parcourez un donjon généré aléatoirement et gagnez 1 EXP par pas."
+      };
+    }
     if (!locale.statusModal && enLocale.statusModal) {
       locale.statusModal = clone(enLocale.statusModal);
     }

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -1868,6 +1868,34 @@
               "vault": { "label": "ハイリスク金庫を解錠" }
             }
           },
+          "sanpo": {
+            "name": "散歩",
+            "description": "完全ランダムのダンジョンを散歩して歩数×1EXPを獲得する自由行動モード",
+            "ui": {
+              "regenerate": "ステージ再生成",
+              "zoomLabel": "ズーム",
+              "minimapTitle": "ミニマップ",
+              "stageInfo": "タイプ: {type} / サイズ: {size} / タイル: {tileSize}",
+              "seedInfo": "シード: {seed}",
+              "stepsInfo": "歩数: {steps}",
+              "stageInfoEmpty": "タイプ: -",
+              "seedInfoEmpty": "シード: -",
+              "stepsInfoEmpty": "歩数: 0",
+              "zoomInfo": "ズーム: {value}x",
+              "zoomDisplay": "{value}x",
+              "hideMap": "ミニマップOFF",
+              "showMap": "ミニマップON",
+              "status": {
+                "paused": "一時停止中",
+                "walk": "散歩中… WASD/矢印キーで移動。Mでミニマップ切替、[ / ] でズーム。",
+                "noApi": "ダンジョンAPIが利用できません",
+                "generating": "ステージ生成中…",
+                "failed": "ステージ生成に失敗しました",
+                "ready": "準備完了！開始ボタンで散歩を始めよう",
+                "initializing": "ロード中…"
+              }
+            }
+          },
           "ten_ten": {
             "name": "1010パズル",
             "description": "ラインでEXP／クロス消しは倍増",
@@ -17553,6 +17581,34 @@
           "subtitle": "最新順に表示",
           "empty": "ラップを記録するとここに表示されます",
           "label": "ラップ {index}"
+        }
+      },
+      "sanpo": {
+        "name": "散歩",
+        "description": "完全ランダムのダンジョンを散歩して歩数×1EXPを獲得する自由行動モード",
+        "ui": {
+          "regenerate": "ステージ再生成",
+          "zoomLabel": "ズーム",
+          "minimapTitle": "ミニマップ",
+          "stageInfo": "タイプ: {type} / サイズ: {size} / タイル: {tileSize}",
+          "seedInfo": "シード: {seed}",
+          "stepsInfo": "歩数: {steps}",
+          "stageInfoEmpty": "タイプ: -",
+          "seedInfoEmpty": "シード: -",
+          "stepsInfoEmpty": "歩数: 0",
+          "zoomInfo": "ズーム: {value}x",
+          "zoomDisplay": "{value}x",
+          "hideMap": "ミニマップOFF",
+          "showMap": "ミニマップON",
+          "status": {
+            "paused": "一時停止中",
+            "walk": "散歩中… WASD/矢印キーで移動。Mでミニマップ切替、[ / ] でズーム。",
+            "noApi": "ダンジョンAPIが利用できません",
+            "generating": "ステージ生成中…",
+            "failed": "ステージ生成に失敗しました",
+            "ready": "準備完了！開始ボタンで散歩を始めよう",
+            "initializing": "ロード中…"
+          }
         }
       },
       "diagramMaker": {

--- a/js/i18n/locales/ko.json.js
+++ b/js/i18n/locales/ko.json.js
@@ -2627,6 +2627,34 @@
               }
             }
           },
+          "sanpo": {
+            "name": "산책",
+            "description": "무작위로 생성된 던전을 산책하며 걸음 수 ×1 EXP를 획득하세요.",
+            "ui": {
+              "regenerate": "스테이지 재생성",
+              "zoomLabel": "줌",
+              "minimapTitle": "미니맵",
+              "stageInfo": "타입: {type} / 크기: {size} / 타일: {tileSize}",
+              "seedInfo": "시드: {seed}",
+              "stepsInfo": "걸음 수: {steps}",
+              "stageInfoEmpty": "타입: -",
+              "seedInfoEmpty": "시드: -",
+              "stepsInfoEmpty": "걸음 수: 0",
+              "zoomInfo": "줌: {value}x",
+              "zoomDisplay": "{value}x",
+              "hideMap": "미니맵 끄기",
+              "showMap": "미니맵 켜기",
+              "status": {
+                "paused": "일시 정지",
+                "walk": "산책 중… WASD/화살표 키로 이동하세요. M으로 미니맵, [ / ]로 줌을 조절하세요.",
+                "noApi": "던전 API를 사용할 수 없습니다",
+                "generating": "스테이지 생성 중…",
+                "failed": "스테이지 생성에 실패했습니다",
+                "ready": "준비 완료! 시작을 눌러 산책을 시작하세요.",
+                "initializing": "불러오는 중…"
+              }
+            }
+          },
           "ten_ten": {
             "name": "1010 퍼즐",
             "description": "라인을 클리어하기 위해 블록을 배치하고 크로스 클리어를 통해 EXP를 두 배로 늘리세요.",
@@ -3854,6 +3882,34 @@
   if (!store["ko"]) { store["ko"] = {}; }
   if (!store["ko"].games) { store["ko"].games = {}; }
   var koGames = store["ko"].games;
+  koGames.sanpo = {
+    "name": "산책",
+    "description": "무작위로 생성된 던전을 산책하며 걸음 수 ×1 EXP를 획득하세요.",
+    "ui": {
+      "regenerate": "스테이지 재생성",
+      "zoomLabel": "줌",
+      "minimapTitle": "미니맵",
+      "stageInfo": "타입: {type} / 크기: {size} / 타일: {tileSize}",
+      "seedInfo": "시드: {seed}",
+      "stepsInfo": "걸음 수: {steps}",
+      "stageInfoEmpty": "타입: -",
+      "seedInfoEmpty": "시드: -",
+      "stepsInfoEmpty": "걸음 수: 0",
+      "zoomInfo": "줌: {value}x",
+      "zoomDisplay": "{value}x",
+      "hideMap": "미니맵 끄기",
+      "showMap": "미니맵 켜기",
+      "status": {
+        "paused": "일시 정지",
+        "walk": "산책 중… WASD/화살표 키로 이동하세요. M으로 미니맵, [ / ]로 줌을 조절하세요.",
+        "noApi": "던전 API를 사용할 수 없습니다",
+        "generating": "스테이지 생성 중…",
+        "failed": "스테이지 생성에 실패했습니다",
+        "ready": "준비 완료! 시작을 눌러 산책을 시작하세요.",
+        "initializing": "불러오는 중…"
+      }
+    }
+  };
   koGames.todoList = koGames.todoList || {};
   koGames.todoList.form = koGames.todoList.form || {};
   koGames.todoList.form.randomRange = koGames.todoList.form.randomRange || {

--- a/js/i18n/locales/zh.json.js
+++ b/js/i18n/locales/zh.json.js
@@ -1892,6 +1892,34 @@
               }
             }
           },
+          "sanpo": {
+            "name": "散步",
+            "description": "在随机生成的迷宫中散步，每一步获得 1 点经验。",
+            "ui": {
+              "regenerate": "重新生成关卡",
+              "zoomLabel": "缩放",
+              "minimapTitle": "小地图",
+              "stageInfo": "类型：{type} / 尺寸：{size} / 单元：{tileSize}",
+              "seedInfo": "种子：{seed}",
+              "stepsInfo": "步数：{steps}",
+              "stageInfoEmpty": "类型：-",
+              "seedInfoEmpty": "种子：-",
+              "stepsInfoEmpty": "步数：0",
+              "zoomInfo": "缩放：{value}x",
+              "zoomDisplay": "{value}x",
+              "hideMap": "小地图关闭",
+              "showMap": "小地图开启",
+              "status": {
+                "paused": "已暂停",
+                "walk": "散步中… 使用 WASD/方向键移动。按 M 切换小地图，[ / ] 缩放。",
+                "noApi": "迷宫 API 不可用",
+                "generating": "正在生成关卡…",
+                "failed": "关卡生成失败",
+                "ready": "准备就绪！按开始按钮开始散步。",
+                "initializing": "加载中…"
+              }
+            }
+          },
           "ten_ten": {
             "name": "1010谜题",
             "description": "放置方块来清除线，十字清除使你的经验加倍。",
@@ -9028,6 +9056,34 @@
           "subtitle": "最近的第一个",
           "empty": "记录后你的圈数将出现在此处。",
           "label": "圈{index}"
+        }
+      },
+      "sanpo": {
+        "name": "散步",
+        "description": "在随机生成的迷宫中散步，每一步获得 1 点经验。",
+        "ui": {
+          "regenerate": "重新生成关卡",
+          "zoomLabel": "缩放",
+          "minimapTitle": "小地图",
+          "stageInfo": "类型：{type} / 尺寸：{size} / 单元：{tileSize}",
+          "seedInfo": "种子：{seed}",
+          "stepsInfo": "步数：{steps}",
+          "stageInfoEmpty": "类型：-",
+          "seedInfoEmpty": "种子：-",
+          "stepsInfoEmpty": "步数：0",
+          "zoomInfo": "缩放：{value}x",
+          "zoomDisplay": "{value}x",
+          "hideMap": "小地图关闭",
+          "showMap": "小地图开启",
+          "status": {
+            "paused": "已暂停",
+            "walk": "散步中… 使用 WASD/方向键移动。按 M 切换小地图，[ / ] 缩放。",
+            "noApi": "迷宫 API 不可用",
+            "generating": "正在生成关卡…",
+            "failed": "关卡生成失败",
+            "ready": "准备就绪！按开始按钮开始散步。",
+            "initializing": "加载中…"
+          }
         }
       },
       "wording": {


### PR DESCRIPTION
## Summary
- localize the Sanpo mini-game UI to use parameterized translation keys
- add Sanpo entries across all supported locales for both in-game text and selection metadata

## Testing
- npm test -- --runTestsByPath tests/bowling-localization.test.js

------
https://chatgpt.com/codex/tasks/task_e_6903560f97b8832bbe14d5e8313d9b57