### PR TITLE
Add Japanese and English locales for jigsaw puzzle

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -19101,6 +19101,64 @@
       }
     };
   }
+  if (!store['en'].miniexp) {
+    store['en'].miniexp = {};
+  }
+  if (!store['en'].miniexp.games) {
+    store['en'].miniexp.games = {};
+  }
+  var enMiniExpGames = store['en'].miniexp.games;
+  if (!enMiniExpGames.jigsaw_puzzle) {
+    enMiniExpGames.jigsaw_puzzle = {
+      "title": "Jigsaw Puzzle",
+      "description": "Assemble any image by dragging jigsaw pieces. Choose the rows, columns, and picture freely.",
+      "controls": {
+        "rowsLabel": "Rows",
+        "colsLabel": "Columns",
+        "applySize": "Update size",
+        "chooseFile": "Choose image…",
+        "urlPlaceholder": "Enter image URL",
+        "loadUrl": "Load URL",
+        "shuffle": "Shuffle and start"
+      },
+      "info": {
+        "moves": "Moves",
+        "time": "Time",
+        "correct": "Correct pieces",
+        "clears": "Clears"
+      },
+      "status": {
+        "loading": "Loading image…",
+        "error": "Failed to load the image",
+        "cleared": "Completed! {moves} moves / {time} EXP: {xp}",
+        "ready": "{size} puzzle shuffled. Drag the pieces to solve!",
+        "noImage": "Please load an image",
+        "errorFile": "Failed to read the file",
+        "errorUrl": "Failed to load the image",
+        "errorGenerate": "Failed to generate an image"
+      },
+      "defaultImage": {
+        "title": "Jigsaw",
+        "subtitle": "Puzzle"
+      }
+    };
+  }
+  if (!store['en'].selection) {
+    store['en'].selection = {};
+  }
+  if (!store['en'].selection.miniexp) {
+    store['en'].selection.miniexp = {};
+  }
+  if (!store['en'].selection.miniexp.games) {
+    store['en'].selection.miniexp.games = {};
+  }
+  if (!store['en'].selection.miniexp.games.jigsaw_puzzle) {
+    store['en'].selection.miniexp.games.jigsaw_puzzle = {
+      "name": "Jigsaw Puzzle",
+      "description": "Assemble any image by dragging jigsaw pieces. Choose the rows, columns, and picture freely."
+    };
+  }
+
   if (!enGames.wording) {
     enGames.wording = {
         "name": "Wording",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -18988,6 +18988,64 @@
         }
       };
   }
+  if (!store['ja'].miniexp) {
+    store['ja'].miniexp = {};
+  }
+  if (!store['ja'].miniexp.games) {
+    store['ja'].miniexp.games = {};
+  }
+  var jaMiniExpGames = store['ja'].miniexp.games;
+  if (!jaMiniExpGames.jigsaw_puzzle) {
+    jaMiniExpGames.jigsaw_puzzle = {
+      "title": "ジグソーパズル",
+      "description": "任意の画像をピースで組み立てるジグソーパズル",
+      "controls": {
+        "rowsLabel": "行数",
+        "colsLabel": "列数",
+        "applySize": "サイズを更新",
+        "chooseFile": "画像を選択…",
+        "urlPlaceholder": "画像URLを入力",
+        "loadUrl": "URLを読み込み",
+        "shuffle": "シャッフルして開始"
+      },
+      "info": {
+        "moves": "手数",
+        "time": "タイム",
+        "correct": "正しい位置",
+        "clears": "クリア数"
+      },
+      "status": {
+        "loading": "画像を読み込み中…",
+        "error": "画像の読み込みに失敗しました",
+        "cleared": "完成！ {moves} 手 / {time} EXP: {xp}",
+        "ready": "{size} のピースをシャッフルしました。ドラッグで組み立てよう！",
+        "noImage": "画像を読み込んでください",
+        "errorFile": "ファイルの読み込みに失敗しました",
+        "errorUrl": "画像の読み込みに失敗しました",
+        "errorGenerate": "画像の生成に失敗しました"
+      },
+      "defaultImage": {
+        "title": "Jigsaw",
+        "subtitle": "Puzzle"
+      }
+    };
+  }
+  if (!store['ja'].selection) {
+    store['ja'].selection = {};
+  }
+  if (!store['ja'].selection.miniexp) {
+    store['ja'].selection.miniexp = {};
+  }
+  if (!store['ja'].selection.miniexp.games) {
+    store['ja'].selection.miniexp.games = {};
+  }
+  if (!store['ja'].selection.miniexp.games.jigsaw_puzzle) {
+    store['ja'].selection.miniexp.games.jigsaw_puzzle = {
+      "name": "ジグソーパズル",
+      "description": "任意の画像をピースで組み立てるジグソーパズル"
+    };
+  }
+
   if (!jaGames.wording) {
     jaGames.wording = {
         "name": "Wording",


### PR DESCRIPTION
## Summary
- add Japanese localization strings for the jigsaw puzzle mini-game, covering controls, status messages, and selection metadata
- add English localization strings for the jigsaw puzzle mini-game so UI text and selection labels translate correctly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690356470fc4832b8f41f57a471ff735