### PR TITLE
fix: add sandbox breakout locales

### DIFF
--- a/js/i18n/locales/en.json.js
+++ b/js/i18n/locales/en.json.js
@@ -17605,6 +17605,64 @@
       }
     },
     "games": {
+      "sandboxBreakout": {
+        "title": "Sandbox Breakout",
+        "modeInfo": "Arrange blocks in the editor and jump straight into play. Supports stage import/export.",
+        "mode": {
+          "label": {
+            "edit": "Mode: Edit",
+            "play": "Mode: Play"
+          }
+        },
+        "buttons": {
+          "play": "▶ Start Play",
+          "returnToEdit": "⏹ Return to Edit",
+          "clearAll": "Clear All",
+          "export": "Export",
+          "import": "Import",
+          "copy": "Copy"
+        },
+        "grid": {
+          "columns": "Columns",
+          "rows": "Rows"
+        },
+        "palette": {
+          "label": "Block to place:"
+        },
+        "hardness": {
+          "label": "Custom hardness:"
+        },
+        "io": {
+          "placeholder": "Import/export JSON will appear here."
+        },
+        "blocks": {
+          "empty": "Empty",
+          "normal": "Normal block",
+          "hard": "Hard block (2)",
+          "unbreakable": "Unbreakable block",
+          "bonus": "Bonus block",
+          "custom": "Custom hardness"
+        },
+        "hud": {
+          "editHint": "Edit mode: click to place, right-click to remove / Blocks: {blockCount}",
+          "score": "SCORE {score}",
+          "lives": "LIVES {lives}",
+          "hits": "HITS {hits}",
+          "returnHint": "Returning to edit resets progress"
+        },
+        "messages": {
+          "placeBlocks": "Place some blocks first.",
+          "exported": "Stage data exported.",
+          "imported": "Stage imported.",
+          "importFailed": "Import failed: {error}",
+          "copyUnsupported": "Copy not supported in this browser.",
+          "copySuccess": "Copied to clipboard.",
+          "copyFailed": "Copy failed: {error}"
+        },
+        "errors": {
+          "invalidCells": "The \"cells\" field is invalid."
+        }
+      },
       "timer": {
         "header": {
           "title": "Timer Utility",

--- a/js/i18n/locales/ja.json.js
+++ b/js/i18n/locales/ja.json.js
@@ -17477,6 +17477,64 @@
       }
     },
     "games": {
+      "sandboxBreakout": {
+        "title": "サンドボックスブロック崩し",
+        "modeInfo": "エディタで配置 → そのままプレイ / ステージのインポート・エクスポートに対応",
+        "mode": {
+          "label": {
+            "edit": "モード: 編集",
+            "play": "モード: プレイ"
+          }
+        },
+        "buttons": {
+          "play": "▶ プレイ開始",
+          "returnToEdit": "⏹ 編集に戻る",
+          "clearAll": "全消去",
+          "export": "エクスポート",
+          "import": "インポート",
+          "copy": "コピー"
+        },
+        "grid": {
+          "columns": "列",
+          "rows": "行"
+        },
+        "palette": {
+          "label": "配置するブロック:"
+        },
+        "hardness": {
+          "label": "カスタム硬さ:"
+        },
+        "io": {
+          "placeholder": "インポート/エクスポート用JSONがここに表示されます"
+        },
+        "blocks": {
+          "empty": "空",
+          "normal": "通常ブロック",
+          "hard": "硬いブロック(2)",
+          "unbreakable": "壊れないブロック",
+          "bonus": "高得点ブロック",
+          "custom": "カスタム硬さ"
+        },
+        "hud": {
+          "editHint": "編集モード: クリックで配置、右クリックで削除 / ブロック数: {blockCount}",
+          "score": "スコア {score}",
+          "lives": "残機 {lives}",
+          "hits": "ヒット {hits}",
+          "returnHint": "編集中に戻るとリセット"
+        },
+        "messages": {
+          "placeBlocks": "ブロックを配置してください",
+          "exported": "ステージデータをエクスポートしました。",
+          "imported": "ステージをインポートしました。",
+          "importFailed": "インポートに失敗しました: {error}",
+          "copyUnsupported": "クリップボード非対応のためコピーできません",
+          "copySuccess": "コピーしました",
+          "copyFailed": "コピーに失敗: {error}"
+        },
+        "errors": {
+          "invalidCells": "cellsが不正です"
+        }
+      },
       "timer": {
         "header": {
           "title": "タイマー",


### PR DESCRIPTION
## Summary
- add sandbox breakout UI strings to the Japanese locale bundle
- add sandbox breakout UI strings to the English locale bundle for parity

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690356a82c40832bb625341e42304461