### PR TITLE
Initialize Sanpo localization fallback

### DIFF
--- a/games/sanpo.js
+++ b/games/sanpo.js
@@ -7,16 +7,27 @@
   function create(root, awardXp, opts){
     const shortcuts = opts?.shortcuts;
     const dungeonApi = opts?.dungeon;
-    const localization = opts?.localization;
+    const localization = opts?.localization
+      || (typeof window !== 'undefined' && typeof window.createMiniGameLocalization === 'function'
+        ? window.createMiniGameLocalization({ id: 'sanpo' })
+        : null);
 
     const text = (key, fallback, params) => {
       if (key && localization && typeof localization.t === 'function'){
-        return localization.t(key, fallback, params);
+        try {
+          const localized = localization.t(key, fallback, params);
+          if (localized != null) {
+            return localized;
+          }
+        } catch (error) {
+          console.warn('[MiniExp][Sanpo] Failed to translate key:', key, error);
+        }
       }
       if (typeof fallback === 'function'){
         try {
           return fallback(params);
-        } catch {
+        } catch (error) {
+          console.warn('[MiniExp][Sanpo] Failed to compute fallback text for key:', key, error);
           return '';
         }
       }


### PR DESCRIPTION
## Summary
- create a Sanpo-specific localization instance when one is not provided
- harden the text helper so it falls back cleanly if localization lookups fail

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6903612c885c832ba41bde7b81798f20